### PR TITLE
feat(tenancy): tenant isolation foundation (F1, F2, F4 record-level)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ Homestead.json
 /.vagrant
 .phpunit.result.cache
 /.opencode/
+.idea
+.idea/CRM.iml

--- a/app/Contracts/OwnsRecords.php
+++ b/app/Contracts/OwnsRecords.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Contracts;
+
+/**
+ * A model whose rows have an owner column for record-level scoping.
+ * Implemented by the RestrictsToOwner trait.
+ */
+interface OwnsRecords
+{
+    public function ownerColumn(): string;
+}

--- a/app/Http/Middleware/SetTenantContext.php
+++ b/app/Http/Middleware/SetTenantContext.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Support\TenantContext;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Establishes the tenant for API requests from the authenticated user's
+ * current team, so the IsTenantModel global scope filters every query —
+ * including route-model binding, which otherwise resolves any team's record
+ * by id (cross-tenant IDOR).
+ *
+ * Resolves via the sanctum guard directly so it does not depend on middleware
+ * ordering relative to auth:sanctum. Must run before SubstituteBindings.
+ */
+class SetTenantContext
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        TenantContext::set(auth('sanctum')->user()?->currentTeam?->id);
+
+        return $next($request);
+    }
+
+    public function terminate(Request $request, Response $response): void
+    {
+        // Octane/RoadRunner reuses workers across requests — never let a
+        // team leak into the next request.
+        TenantContext::clear();
+    }
+}

--- a/app/Models/Deal.php
+++ b/app/Models/Deal.php
@@ -2,16 +2,19 @@
 
 namespace App\Models;
 
+use App\Contracts\OwnsRecords;
 use App\Traits\IsTenantModel;
+use App\Traits\RestrictsToOwner;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 
-class Deal extends Model
+class Deal extends Model implements OwnsRecords
 {
     use HasFactory;
     use IsTenantModel;
+    use RestrictsToOwner;
 
     protected $fillable = [
         'team_id',

--- a/app/Models/Lead.php
+++ b/app/Models/Lead.php
@@ -2,7 +2,9 @@
 
 namespace App\Models;
 
+use App\Contracts\OwnsRecords;
 use App\Traits\IsTenantModel;
+use App\Traits\RestrictsToOwner;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -10,11 +12,12 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Notifications\Notifiable;
 use InvalidArgumentException;
 
-class Lead extends Model
+class Lead extends Model implements OwnsRecords
 {
     use HasFactory;
     use IsTenantModel;
     use Notifiable;
+    use RestrictsToOwner;
 
     protected $fillable = [
         'status',

--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -2,14 +2,20 @@
 
 namespace App\Models;
 
+use App\Contracts\OwnsRecords;
 use App\Traits\IsTenantModel;
+use App\Traits\RestrictsToOwner;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-class Task extends Model
+class Task extends Model implements OwnsRecords
 {
     use HasFactory;
     use IsTenantModel;
+    use RestrictsToOwner;
+
+    /** Record-level ownership keys off the assignee, not a creator. */
+    protected $ownerColumn = 'assigned_to';
 
     protected $primaryKey = 'id';
 

--- a/app/Support/AccessContext.php
+++ b/app/Support/AccessContext.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
+
+/**
+ * Record-level access resolver for RestrictsToOwner models.
+ *
+ * Returns the user id a query must be restricted to (owner-only visibility),
+ * or null for "see everything in scope". Only the named restricted roles are
+ * owner-scoped; every other role (manager/admin/super_admin), a roleless user,
+ * and non-auth contexts (console, queue) see all records in scope.
+ *
+ * Resolution: an explicit restrictTo()/clear() override (tests, "run as user"
+ * jobs) wins; otherwise the authenticated user is resolved lazily via the
+ * sanctum guard then the default guard, so it works on both API and web/panel
+ * requests at query-build time.
+ */
+class AccessContext
+{
+    /** Roles restricted to records they own; all other roles see everything in scope. */
+    private const RESTRICTED_ROLES = ['sales_rep', 'free'];
+
+    protected static ?int $ownerId = null;
+
+    protected static bool $overridden = false;
+
+    public static function restrictTo(?int $userId): void
+    {
+        static::$ownerId = $userId;
+        static::$overridden = true;
+    }
+
+    public static function clear(): void
+    {
+        static::$ownerId = null;
+        static::$overridden = false;
+    }
+
+    public static function restrictToOwnerId(): ?int
+    {
+        if (static::$overridden) {
+            return static::$ownerId;
+        }
+
+        $user = Auth::guard('sanctum')->user() ?? Auth::user();
+
+        if (! $user instanceof User) {
+            return null;
+        }
+
+        foreach (self::RESTRICTED_ROLES as $role) {
+            if ($user->hasRole($role)) {
+                return $user->getKey();
+            }
+        }
+
+        return null;
+    }
+}

--- a/app/Support/TenantContext.php
+++ b/app/Support/TenantContext.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Support;
+
+use Filament\Facades\Filament;
+use Throwable;
+
+/**
+ * Resolves the "current team" that tenant-scoped models filter by.
+ *
+ * Resolution order:
+ *  1. An explicit runtime override (set()/clear()) — used by jobs, console,
+ *     tests, and any context outside a Filament panel request.
+ *  2. The Filament panel tenant (app panel is team-scoped; admin panel has
+ *     none, so it resolves to null and queries stay un-scoped).
+ *
+ * Null result = no scoping (admin/global/console). This is what keeps the
+ * global scope inert until a tenant context genuinely exists.
+ */
+class TenantContext
+{
+    protected static ?int $teamId = null;
+
+    public static function set(?int $teamId): void
+    {
+        static::$teamId = $teamId;
+    }
+
+    public static function clear(): void
+    {
+        static::$teamId = null;
+    }
+
+    public static function currentId(): ?int
+    {
+        if (static::$teamId !== null) {
+            return static::$teamId;
+        }
+
+        // Filament::getTenant() throws when there is no current panel
+        // (console, queue, plain HTTP) — treat that as "un-scoped".
+        try {
+            $tenant = Filament::getTenant();
+        } catch (Throwable) {
+            return null;
+        }
+
+        return $tenant ? (int) $tenant->getKey() : null;
+    }
+}

--- a/app/Traits/IsTenantModel.php
+++ b/app/Traits/IsTenantModel.php
@@ -3,11 +3,35 @@
 namespace App\Traits;
 
 use App\Models\Team;
+use App\Support\TenantContext;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 trait IsTenantModel
 {
+    /**
+     * Auto-boots for every model using this trait: a removable global scope
+     * that filters reads to the current team, plus auto-stamping team_id on
+     * create. Both are inert when TenantContext::currentId() is null
+     * (admin panel, console, queue, un-scoped tests).
+     */
+    protected static function bootIsTenantModel(): void
+    {
+        static::addGlobalScope('tenant', function (Builder $builder): void {
+            if ($teamId = TenantContext::currentId()) {
+                $model = $builder->getModel();
+                $builder->where($model->qualifyColumn('team_id'), $teamId);
+            }
+        });
+
+        static::creating(function (Model $model): void {
+            if (empty($model->getAttribute('team_id')) && $teamId = TenantContext::currentId()) {
+                $model->setAttribute('team_id', $teamId);
+            }
+        });
+    }
+
     public function team(): BelongsTo
     {
         return $this->belongsTo(Team::class);

--- a/app/Traits/RestrictsToOwner.php
+++ b/app/Traits/RestrictsToOwner.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Traits;
+
+use App\Contracts\OwnsRecords;
+use App\Support\AccessContext;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Auth;
+
+/**
+ * Record-level ownership scope. Stacks on top of IsTenantModel's team scope:
+ * when AccessContext restricts to an owner, reads are filtered to rows the
+ * user owns, and the owner column is auto-stamped with the creator on insert.
+ *
+ * Owner column defaults to `user_id`; override with `protected $ownerColumn`.
+ */
+trait RestrictsToOwner
+{
+    public function ownerColumn(): string
+    {
+        return property_exists($this, 'ownerColumn') ? $this->ownerColumn : 'user_id';
+    }
+
+    protected static function bootRestrictsToOwner(): void
+    {
+        static::addGlobalScope('owner', function (Builder $builder): void {
+            $ownerId = AccessContext::restrictToOwnerId();
+            $model = $builder->getModel();
+
+            if ($ownerId !== null && $model instanceof OwnsRecords) {
+                $builder->where($model->qualifyColumn($model->ownerColumn()), $ownerId);
+            }
+        });
+
+        static::creating(function (Model $model): void {
+            if (! $model instanceof OwnsRecords) {
+                return;
+            }
+
+            $column = $model->ownerColumn();
+
+            if (empty($model->getAttribute($column))) {
+                $creator = Auth::guard('sanctum')->user() ?? Auth::user();
+
+                if ($creator !== null) {
+                    $model->setAttribute($column, $creator->getAuthIdentifier());
+                }
+            }
+        });
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -35,6 +35,12 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->web(append: [
             SecurityHeaders::class,
         ]);
+
+        // Establish the tenant from the Sanctum user before route-model
+        // binding runs, so the IsTenantModel global scope filters API queries.
+        $middleware->api(prepend: [
+            \App\Http\Middleware\SetTenantContext::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/database/migrations/2026_07_06_000001_add_team_id_to_tenant_scoped_tables.php
+++ b/database/migrations/2026_07_06_000001_add_team_id_to_tenant_scoped_tables.php
@@ -1,0 +1,69 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * F1: backfill the team_id column on every table whose model uses
+ * IsTenantModel but was missing it, so the tenant global scope can actually
+ * filter them (previously these leaked / fataled under an active context).
+ *
+ * team_id is nullable and auto-stamped on create by IsTenantModel.
+ * ponytail: nullable now; tighten to NOT NULL once historical rows are
+ * backfilled from their parent records — no prod data exists yet, so there is
+ * nothing to backfill today.
+ */
+return new class extends Migration
+{
+    /** @var list<string> */
+    private array $tables = [
+        'activities',
+        'audit_logs',
+        'campaign_recipients',
+        'chatbots',
+        'chatbot_interactions',
+        'connected_accounts',
+        'email_link_clicks',
+        'email_templates',
+        'email_trackings',
+        'knowledge_base_articles',
+        'live_chats',
+        'pipelines',
+        'quote_requests',
+        'report_builders',
+        'site_settings',
+        'stages',
+        'workflow_actions',
+        'workflow_conditions',
+        'workflow_executions',
+        'workflow_triggers',
+    ];
+
+    public function up(): void
+    {
+        foreach ($this->tables as $table) {
+            if (! Schema::hasTable($table) || Schema::hasColumn($table, 'team_id')) {
+                continue;
+            }
+
+            Schema::table($table, function (Blueprint $t) {
+                $t->foreignId('team_id')->nullable()->constrained()->cascadeOnDelete();
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        foreach ($this->tables as $table) {
+            if (! Schema::hasTable($table) || ! Schema::hasColumn($table, 'team_id')) {
+                continue;
+            }
+
+            Schema::table($table, function (Blueprint $t) {
+                $t->dropForeign(['team_id']);
+                $t->dropColumn('team_id');
+            });
+        }
+    }
+};

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - vendor/nunomaduro/larastan/extension.neon
+    - vendor/larastan/larastan/extension.neon
     - phpstan-baseline.neon
 
 parameters:

--- a/tests/Feature/Http/Api/ContactApiExtendedTest.php
+++ b/tests/Feature/Http/Api/ContactApiExtendedTest.php
@@ -96,6 +96,9 @@ class ContactApiExtendedTest extends TestCase
 
         $response = $this->getJson("/api/v1/contacts/{$contact->id}");
 
-        $response->assertForbidden();
+        // Tenant global scope makes the record invisible, so binding 404s
+        // before any policy runs. 404 (not 403) is intentional: it does not
+        // disclose that another team's record exists.
+        $response->assertNotFound();
     }
 }

--- a/tests/Feature/Tenancy/ApiTenantScopingTest.php
+++ b/tests/Feature/Tenancy/ApiTenantScopingTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Feature\Tenancy;
+
+use App\Models\Contact;
+use App\Models\Team;
+use App\Models\User;
+use App\Support\TenantContext;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+/**
+ * The REST API authenticates with Sanctum and has no team in the path, so a
+ * request's tenant must come from the authenticated user's current team.
+ * Without that, route-model binding (show/update/destroy) resolves any team's
+ * record by id — a cross-tenant IDOR.
+ */
+class ApiTenantScopingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function tearDown(): void
+    {
+        TenantContext::clear();
+        parent::tearDown();
+    }
+
+    private function actingUserOnTeam(): array
+    {
+        $user = User::factory()->create();
+        $team = Team::factory()->create(['user_id' => $user->id]);
+        $user->forceFill(['current_team_id' => $team->id])->save();
+        Sanctum::actingAs($user);
+
+        return [$user, $team];
+    }
+
+    public function test_index_only_returns_current_teams_contacts(): void
+    {
+        [, $teamA] = $this->actingUserOnTeam();
+        $mine = Contact::factory()->create(['team_id' => $teamA->id]);
+        $other = Contact::factory()->create(['team_id' => Team::factory()->create()->id]);
+
+        $this->getJson('/api/v1/contacts')
+            ->assertOk()
+            ->assertJsonFragment(['id' => $mine->id])
+            ->assertJsonMissing(['id' => $other->id]);
+    }
+
+    public function test_show_does_not_leak_another_teams_contact(): void
+    {
+        $this->actingUserOnTeam();
+        $foreign = Contact::factory()->create(['team_id' => Team::factory()->create()->id]);
+
+        $this->getJson("/api/v1/contacts/{$foreign->id}")->assertNotFound();
+    }
+
+    public function test_show_returns_own_teams_contact(): void
+    {
+        [, $teamA] = $this->actingUserOnTeam();
+        $mine = Contact::factory()->create(['team_id' => $teamA->id]);
+
+        $this->getJson("/api/v1/contacts/{$mine->id}")
+            ->assertOk()
+            ->assertJsonFragment(['id' => $mine->id]);
+    }
+}

--- a/tests/Feature/Tenancy/CrossTenantLeakageTest.php
+++ b/tests/Feature/Tenancy/CrossTenantLeakageTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Tests\Feature\Tenancy;
+
+use App\Models\Team;
+use App\Support\TenantContext;
+use App\Traits\IsTenantModel;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\DataProvider;
+use ReflectionClass;
+use Tests\TestCase;
+
+/**
+ * F2: every model tagged tenant-scoped must actually filter by team_id.
+ *
+ * Layer A (dataprovider, one case per model): the table carries team_id AND a
+ * query built under an active tenant context includes the team_id predicate —
+ * proves no model silently escapes the global scope.
+ *
+ * Layer B: real rows in two teams; a tenant must never read the other's rows.
+ * Runs for every model with a usable factory (skips the rest, but reports what
+ * it actually exercised so coverage is never silently zero).
+ */
+class CrossTenantLeakageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function tearDown(): void
+    {
+        TenantContext::clear();
+        parent::tearDown();
+    }
+
+    /** @return array<string, array{class-string}> */
+    public static function tenantModels(): array
+    {
+        // Filesystem walk — no container helpers: data providers run at
+        // collection time, before the app is booted.
+        $modelDir = dirname(__DIR__, 3).'/app/Models';
+        $models = [];
+
+        foreach (glob($modelDir.'/*.php') as $file) {
+            $class = 'App\\Models\\'.basename($file, '.php');
+
+            if (! class_exists($class)) {
+                continue;
+            }
+            if (! in_array(IsTenantModel::class, class_uses_recursive($class), true)) {
+                continue;
+            }
+            if (! (new ReflectionClass($class))->isInstantiable()) {
+                continue;
+            }
+
+            $models[class_basename($class)] = [$class];
+        }
+
+        ksort($models);
+
+        return $models;
+    }
+
+    #[DataProvider('tenantModels')]
+    public function test_model_is_team_scoped(string $class): void
+    {
+        $table = (new $class)->getTable();
+
+        if (! Schema::hasTable($table)) {
+            // Tenant-scoped model with no table = dead/pending code; it holds
+            // no rows so it cannot leak. Flag as skipped so the drift stays
+            // visible instead of passing green.
+            $this->markTestSkipped("{$class}: no `{$table}` table (schema drift — model tagged tenant-scoped but never migrated)");
+        }
+
+        $this->assertTrue(
+            Schema::hasColumn($table, 'team_id'),
+            "{$class}: table `{$table}` has no team_id column — global scope would fatal or leak",
+        );
+
+        TenantContext::set(1);
+        $sql = $class::query()->toSql();
+        TenantContext::clear();
+
+        $this->assertStringContainsString(
+            "\"{$table}\".\"team_id\"",
+            $sql,
+            "{$class}: query under a tenant context is not filtered by team_id",
+        );
+    }
+
+    public function test_factoried_models_do_not_leak_rows_across_teams(): void
+    {
+        $teamA = Team::factory()->create();
+        $teamB = Team::factory()->create();
+        $covered = [];
+
+        foreach (array_keys(self::tenantModels()) as $basename) {
+            $class = 'App\\Models\\'.$basename;
+
+            try {
+                $a = $class::factory()->create(['team_id' => $teamA->id]);
+                $b = $class::factory()->create(['team_id' => $teamB->id]);
+            } catch (\Throwable) {
+                continue; // no factory, or factory needs FKs we don't set up here
+            }
+
+            $key = $a->getKeyName();
+
+            TenantContext::set($teamA->id);
+            $visible = $class::pluck($key);
+            TenantContext::clear();
+
+            $this->assertTrue(
+                $visible->contains($a->getKey()),
+                "{$class}: team A cannot see its own row",
+            );
+            $this->assertFalse(
+                $visible->contains($b->getKey()),
+                "{$class}: team A leaked team B's row",
+            );
+
+            $covered[] = $basename;
+        }
+
+        $this->assertNotEmpty($covered, 'no tenant-scoped model had a usable factory to leak-test');
+        fwrite(STDERR, "\n[F2] data-level leak-proofed: ".implode(', ', $covered)."\n");
+    }
+}

--- a/tests/Feature/Tenancy/RecordLevelScopingTest.php
+++ b/tests/Feature/Tenancy/RecordLevelScopingTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Tests\Feature\Tenancy;
+
+use App\Models\Deal;
+use App\Models\Task;
+use App\Models\Team;
+use App\Models\User;
+use App\Support\AccessContext;
+use App\Support\TenantContext;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+/**
+ * F4 record-level scoping: within a team, sales_rep/free see only records they
+ * own; manager/admin/super_admin see all team records. Owner column defaults to
+ * user_id (Task overrides to assigned_to).
+ */
+class RecordLevelScopingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        foreach (['super_admin', 'admin', 'manager', 'sales_rep', 'free'] as $role) {
+            Role::findOrCreate($role, 'web');
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        AccessContext::clear();
+        TenantContext::clear();
+        parent::tearDown();
+    }
+
+    private function userWithRole(string $role, Team $team): User
+    {
+        $user = User::factory()->create(['current_team_id' => $team->id]);
+        $user->assignRole($role);
+
+        return $user;
+    }
+
+    public function test_sales_rep_sees_only_own_deals(): void
+    {
+        $team = Team::factory()->create();
+        $rep = $this->userWithRole('sales_rep', $team);
+        $mate = $this->userWithRole('sales_rep', $team);
+        $mine = Deal::factory()->create(['team_id' => $team->id, 'user_id' => $rep->id]);
+        $theirs = Deal::factory()->create(['team_id' => $team->id, 'user_id' => $mate->id]);
+
+        $this->actingAs($rep);
+        $ids = Deal::pluck('id');
+
+        $this->assertTrue($ids->contains($mine->id), 'rep must see own deal');
+        $this->assertFalse($ids->contains($theirs->id), 'rep must NOT see teammate deal');
+    }
+
+    public function test_manager_sees_all_team_deals(): void
+    {
+        $team = Team::factory()->create();
+        $manager = $this->userWithRole('manager', $team);
+        $rep = $this->userWithRole('sales_rep', $team);
+        Deal::factory()->create(['team_id' => $team->id, 'user_id' => $manager->id]);
+        Deal::factory()->create(['team_id' => $team->id, 'user_id' => $rep->id]);
+
+        $this->actingAs($manager);
+
+        $this->assertCount(2, Deal::all());
+    }
+
+    public function test_task_scopes_by_assigned_to(): void
+    {
+        $team = Team::factory()->create();
+        $rep = $this->userWithRole('sales_rep', $team);
+        $other = $this->userWithRole('sales_rep', $team);
+        $mine = Task::factory()->create(['team_id' => $team->id, 'assigned_to' => $rep->id]);
+        $theirs = Task::factory()->create(['team_id' => $team->id, 'assigned_to' => $other->id]);
+
+        $this->actingAs($rep);
+        $ids = Task::pluck('id');
+
+        $this->assertTrue($ids->contains($mine->id));
+        $this->assertFalse($ids->contains($theirs->id), 'rep must NOT see task assigned to someone else');
+    }
+
+    public function test_owner_scope_can_be_bypassed(): void
+    {
+        $team = Team::factory()->create();
+        $rep = $this->userWithRole('sales_rep', $team);
+        $mate = $this->userWithRole('sales_rep', $team);
+        Deal::factory()->create(['team_id' => $team->id, 'user_id' => $rep->id]);
+        Deal::factory()->create(['team_id' => $team->id, 'user_id' => $mate->id]);
+
+        $this->actingAs($rep);
+
+        $this->assertCount(2, Deal::withoutGlobalScope('owner')->get());
+    }
+
+    public function test_creating_stamps_owner_from_current_user(): void
+    {
+        $team = Team::factory()->create();
+        $rep = $this->userWithRole('sales_rep', $team);
+        $this->actingAs($rep);
+
+        $deal = Deal::factory()->create(['team_id' => $team->id, 'user_id' => null]);
+
+        $this->assertSame($rep->id, $deal->user_id, 'creator must be stamped as owner');
+        $this->assertTrue(Deal::pluck('id')->contains($deal->id), 'rep must see the deal they just created');
+    }
+}

--- a/tests/Feature/Tenancy/TenantScopingTest.php
+++ b/tests/Feature/Tenancy/TenantScopingTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\Feature\Tenancy;
+
+use App\Models\Contact;
+use App\Models\Team;
+use App\Support\TenantContext;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TenantScopingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function tearDown(): void
+    {
+        TenantContext::clear();
+        parent::tearDown();
+    }
+
+    public function test_global_scope_filters_reads_to_current_team(): void
+    {
+        $teamA = Team::factory()->create();
+        $teamB = Team::factory()->create();
+
+        // Seed rows in each team while no tenant context is active.
+        $a = Contact::factory()->create(['team_id' => $teamA->id]);
+        $b = Contact::factory()->create(['team_id' => $teamB->id]);
+
+        TenantContext::set($teamA->id);
+        $ids = Contact::pluck('id');
+        $this->assertTrue($ids->contains($a->id), 'team A must see its own contact');
+        $this->assertFalse($ids->contains($b->id), 'team A must NOT see team B contact (leak)');
+
+        TenantContext::set($teamB->id);
+        $this->assertEqualsCanonicalizing([$b->id], Contact::pluck('id')->all());
+    }
+
+    public function test_no_context_is_unscoped_for_admin(): void
+    {
+        $teamA = Team::factory()->create();
+        $teamB = Team::factory()->create();
+        Contact::factory()->create(['team_id' => $teamA->id]);
+        Contact::factory()->create(['team_id' => $teamB->id]);
+
+        TenantContext::clear();
+        $this->assertCount(2, Contact::all(), 'un-scoped context (admin/console) sees all teams');
+    }
+
+    public function test_creating_auto_sets_team_id_from_context(): void
+    {
+        $team = Team::factory()->create();
+        TenantContext::set($team->id);
+
+        $contact = Contact::create([
+            'name' => 'Auto',
+            'email' => 'auto@example.test',
+        ]);
+
+        $this->assertSame($team->id, $contact->team_id);
+    }
+
+    public function test_explicit_team_id_is_not_overwritten_on_create(): void
+    {
+        $ctxTeam = Team::factory()->create();
+        $explicitTeam = Team::factory()->create();
+        TenantContext::set($ctxTeam->id);
+
+        $contact = Contact::create([
+            'name' => 'Explicit',
+            'email' => 'explicit@example.test',
+            'team_id' => $explicitTeam->id,
+        ]);
+
+        $this->assertSame($explicitTeam->id, $contact->team_id);
+    }
+
+    public function test_scope_can_be_bypassed_for_global_queries(): void
+    {
+        $teamA = Team::factory()->create();
+        $teamB = Team::factory()->create();
+        Contact::factory()->create(['team_id' => $teamA->id]);
+        Contact::factory()->create(['team_id' => $teamB->id]);
+
+        TenantContext::set($teamA->id);
+        $this->assertCount(2, Contact::withoutGlobalScope('tenant')->get());
+    }
+}


### PR DESCRIPTION
## Tenant isolation foundation (TASKS.md F1, F2, F4 record-level)

Turns the half-built team-scoping into an enforced, tested isolation layer. Resolves decision gate **G1 = shared-DB team-scoping**.

### What & why

`IsTenantModel` was an empty marker trait — `belongsTo Team` + a manual `scopeByTeam`, **no global scope, no auto-stamp** — so reads were never actually scoped and leaked across teams. This PR makes the trait real and builds the tests + API guard around it.

| Commit | Change |
|--------|--------|
| `enforce team scope` | `IsTenantModel` gains a removable `'tenant'` global scope + `team_id` auto-stamp on create, gated by new `App\Support\TenantContext` (explicit override → Filament tenant → null = un-scoped). Migration backfills a nullable `team_id` FK on the **20 of 50** trait-using tables that lacked the column. |
| `F2 leakage suite` | `CrossTenantLeakageTest`: Layer A (dataprovider, 1 case/model) asserts every model's table has `team_id` and a scoped query emits the predicate; Layer B proves **20** models leak-free with real two-team rows. Tableless `SiteSettings` is skipped (drift flagged, not hidden). |
| `scope API to Sanctum team` | Closes a cross-tenant **IDOR**: route-model binding (`show`/`update`/`destroy`) resolved any team's record by id; the per-action policy only made it 403 (which discloses existence). `SetTenantContext` middleware sets the tenant from the Sanctum user before binding → foreign ids now **404**. Octane-safe (cleared on terminate). |
| `record-level ownership (F4)` | `RestrictsToOwner` trait + `AccessContext`: `sales_rep`/`free` see only records they own; manager/admin/super_admin (and roleless users) see all in scope. Auto-stamps the owner column from the creator. Applied to Deal (`user_id`), Lead (`user_id`), Task (`assigned_to`). |
| `chore: larastan path` | `phpstan.neon.dist` included the dead `nunomaduro/larastan` path; `composer analyse` exited 1 before analysing. Fixed → tool runs again. |

### Design notes
- Null tenant context = scope inert, so the admin panel (cross-team), console, and queue stay un-scoped — that's why the existing suite stayed green while the mechanism lit up all 50 models.
- Bypass either scope with `->withoutGlobalScope('tenant')` / `'owner'`.
- API team = the authenticated user's `currentTeam` (matches existing controller code; no team in the API path).

### Testing
- **487 passed, 1 skipped, 0 failed** (`php artisan test`).
- New: `TenantScopingTest`, `CrossTenantLeakageTest`, `ApiTenantScopingTest`, `RecordLevelScopingTest`.
- New tenancy code is Larastan-clean.

### Follow-ups (not in this PR)
- `team_id` is nullable → tighten to `NOT NULL` after prod backfill.
- Queue jobs are not auto-scoped yet (fold into F5 queue conventions).
- Per-team Spatie RBAC (F4's other half) still deferred; roles are global.
- `SiteSettings` is tableless — create the table or drop the trait.
- Fixing the Larastan include surfaced **~79 pre-existing errors** to triage (X2).
- Migrations verified on SQLite; **not yet run against MySQL** (dev MySQL unreachable from the container).
