### PR TITLE
P0: telephony fix, record policies, audit logging

### DIFF
--- a/app/Http/Middleware/SetTenantContext.php
+++ b/app/Http/Middleware/SetTenantContext.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Middleware;
 
+use App\Models\User;
 use App\Support\TenantContext;
 use Closure;
 use Illuminate\Http\Request;
@@ -20,7 +21,8 @@ class SetTenantContext
 {
     public function handle(Request $request, Closure $next): Response
     {
-        TenantContext::set(auth('sanctum')->user()?->currentTeam?->id);
+        $user = auth('sanctum')->user();
+        TenantContext::set($user instanceof User ? $user->currentTeam?->getKey() : null);
 
         return $next($request);
     }

--- a/app/Livewire/CallManager.php
+++ b/app/Livewire/CallManager.php
@@ -35,7 +35,7 @@ class CallManager extends Component
             return;
         }
 
-        $call = $twilioService->initiateCall($contact->phone);
+        $call = $twilioService->initiateCall($contact->phone_number);
 
         if ($call) {
             $this->callSid = $call->sid;

--- a/app/Models/CallLog.php
+++ b/app/Models/CallLog.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use App\Traits\IsTenantModel;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class CallLog extends Model
+{
+    use HasFactory, IsTenantModel;
+
+    protected $fillable = [
+        'call_sid',
+        'contact_id',
+        'direction',
+        'duration',
+        'status',
+        'team_id',
+    ];
+
+    protected $casts = [
+        'contact_id' => 'integer',
+        'duration' => 'integer',
+    ];
+}

--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -7,6 +7,7 @@ use App\Traits\IsTenantModel;
 use App\Traits\RestrictsToOwner;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Task extends Model implements OwnsRecords
 {
@@ -43,27 +44,27 @@ class Task extends Model implements OwnsRecords
         'due_date' => 'datetime',
     ];
 
-    public function contact()
+    public function contact(): BelongsTo
     {
         return $this->belongsTo(Contact::class);
     }
 
-    public function lead()
+    public function lead(): BelongsTo
     {
         return $this->belongsTo(Lead::class);
     }
 
-    public function company()
+    public function company(): BelongsTo
     {
         return $this->belongsTo(Company::class);
     }
 
-    public function opportunity()
+    public function opportunity(): BelongsTo
     {
         return $this->belongsTo(Opportunity::class);
     }
 
-    public function assignedTo()
+    public function assignedTo(): BelongsTo
     {
         return $this->belongsTo(User::class, 'assigned_to');
     }

--- a/app/Modules/BaseModule.php
+++ b/app/Modules/BaseModule.php
@@ -144,7 +144,7 @@ abstract class BaseModule implements ModuleInterface
 
     protected function isDevelopmentMode(): bool
     {
-        return (bool) env('MODULES_DEVELOPMENT', config('modules.development', false));
+        return (bool) config('modules.development', false);
     }
 
     /**

--- a/app/Modules/ModuleManager.php
+++ b/app/Modules/ModuleManager.php
@@ -206,7 +206,7 @@ class ModuleManager
         }
 
         // app-modules/ convention (modular.php)
-        if (config('modules.load_composer', env('MODULES_LOAD_COMPOSER', false))) {
+        if (config('modules.load_composer', false)) {
             $composerPath = base_path(config('modular.module_directory', 'app-modules'));
             if (File::exists($composerPath)) {
                 foreach (File::directories($composerPath) as $dir) {

--- a/app/Modules/ModuleServiceProvider.php
+++ b/app/Modules/ModuleServiceProvider.php
@@ -48,7 +48,7 @@ class ModuleServiceProvider extends ServiceProvider
             }
         }
 
-        if (config('modules.load_composer', env('MODULES_LOAD_COMPOSER', false))) {
+        if (config('modules.load_composer', false)) {
             $composerPath = base_path(config('modular.module_directory', 'app-modules'));
             if (File::exists($composerPath)) {
                 foreach (File::directories($composerPath) as $dir) {

--- a/app/Observers/AuditObserver.php
+++ b/app/Observers/AuditObserver.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Observers;
+
+use App\Services\AuditLogService;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Records created/updated/deleted events for tenant models into AuditLog.
+ *
+ * Recursion is prevented by registration, not a guard: AuditObserver is only
+ * attached to the core tenant models in AppServiceProvider, never to AuditLog,
+ * so writing an audit row fires no further events.
+ */
+class AuditObserver
+{
+    public function __construct(private readonly AuditLogService $audit) {}
+
+    public function created(Model $model): void
+    {
+        $this->record($model, 'created');
+    }
+
+    public function updated(Model $model): void
+    {
+        $this->record($model, 'updated', $model->getChanges());
+    }
+
+    public function deleted(Model $model): void
+    {
+        $this->record($model, 'deleted');
+    }
+
+    /**
+     * @param  array<string, mixed>  $changes
+     */
+    private function record(Model $model, string $action, array $changes = []): void
+    {
+        // audit_logs.user_id is NOT NULL + FK; nothing to attribute unauthenticated
+        // writes to (seeders, console, queue), so skip rather than blow the constraint.
+        if (! auth()->check()) {
+            return;
+        }
+
+        $description = $model::class.'#'.$model->getKey().' '.$action;
+
+        if ($changes !== []) {
+            $description .= ' '.json_encode($changes);
+        }
+
+        // Reuse the existing service: it stamps user_id + ip_address for us.
+        $this->audit->log($action, $description);
+    }
+}

--- a/app/Policies/DealPolicy.php
+++ b/app/Policies/DealPolicy.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Models\Deal;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class DealPolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    public function view(User $user, Deal $deal): bool
+    {
+        return $deal->belongsToTeam($user->currentTeam?->getKey());
+    }
+
+    public function create(User $user): bool
+    {
+        return true;
+    }
+
+    public function update(User $user, Deal $deal): bool
+    {
+        return $deal->belongsToTeam($user->currentTeam?->getKey());
+    }
+
+    public function delete(User $user, Deal $deal): bool
+    {
+        return $deal->belongsToTeam($user->currentTeam?->getKey());
+    }
+
+    public function restore(User $user, Deal $deal): bool
+    {
+        return $deal->belongsToTeam($user->currentTeam?->getKey());
+    }
+
+    public function forceDelete(User $user, Deal $deal): bool
+    {
+        return $deal->belongsToTeam($user->currentTeam?->getKey());
+    }
+}

--- a/app/Policies/LeadPolicy.php
+++ b/app/Policies/LeadPolicy.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Models\Lead;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class LeadPolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    public function view(User $user, Lead $lead): bool
+    {
+        return $lead->belongsToTeam($user->currentTeam?->getKey());
+    }
+
+    public function create(User $user): bool
+    {
+        return true;
+    }
+
+    public function update(User $user, Lead $lead): bool
+    {
+        return $lead->belongsToTeam($user->currentTeam?->getKey());
+    }
+
+    public function delete(User $user, Lead $lead): bool
+    {
+        return $lead->belongsToTeam($user->currentTeam?->getKey());
+    }
+
+    public function restore(User $user, Lead $lead): bool
+    {
+        return $lead->belongsToTeam($user->currentTeam?->getKey());
+    }
+
+    public function forceDelete(User $user, Lead $lead): bool
+    {
+        return $lead->belongsToTeam($user->currentTeam?->getKey());
+    }
+}

--- a/app/Policies/OpportunityPolicy.php
+++ b/app/Policies/OpportunityPolicy.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Models\Opportunity;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class OpportunityPolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    public function view(User $user, Opportunity $opportunity): bool
+    {
+        return $opportunity->belongsToTeam($user->currentTeam?->getKey());
+    }
+
+    public function create(User $user): bool
+    {
+        return true;
+    }
+
+    public function update(User $user, Opportunity $opportunity): bool
+    {
+        return $opportunity->belongsToTeam($user->currentTeam?->getKey());
+    }
+
+    public function delete(User $user, Opportunity $opportunity): bool
+    {
+        return $opportunity->belongsToTeam($user->currentTeam?->getKey());
+    }
+
+    public function restore(User $user, Opportunity $opportunity): bool
+    {
+        return $opportunity->belongsToTeam($user->currentTeam?->getKey());
+    }
+
+    public function forceDelete(User $user, Opportunity $opportunity): bool
+    {
+        return $opportunity->belongsToTeam($user->currentTeam?->getKey());
+    }
+}

--- a/app/Policies/TaskPolicy.php
+++ b/app/Policies/TaskPolicy.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Models\Task;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class TaskPolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    public function view(User $user, Task $task): bool
+    {
+        return $task->belongsToTeam($user->currentTeam?->getKey());
+    }
+
+    public function create(User $user): bool
+    {
+        return true;
+    }
+
+    public function update(User $user, Task $task): bool
+    {
+        return $task->belongsToTeam($user->currentTeam?->getKey());
+    }
+
+    public function delete(User $user, Task $task): bool
+    {
+        return $task->belongsToTeam($user->currentTeam?->getKey());
+    }
+
+    public function restore(User $user, Task $task): bool
+    {
+        return $task->belongsToTeam($user->currentTeam?->getKey());
+    }
+
+    public function forceDelete(User $user, Task $task): bool
+    {
+        return $task->belongsToTeam($user->currentTeam?->getKey());
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,8 +4,14 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
+use App\Models\Contact;
+use App\Models\Deal;
+use App\Models\Lead;
+use App\Models\Opportunity;
+use App\Models\Task;
 use App\Modules\ModuleManager;
 use App\Modules\ModuleServiceProvider;
+use App\Observers\AuditObserver;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +25,9 @@ class AppServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
-        //
+        // Audit core tenant models. Never observe AuditLog itself -> infinite recursion.
+        foreach ([Contact::class, Deal::class, Lead::class, Opportunity::class, Task::class] as $model) {
+            $model::observe(AuditObserver::class);
+        }
     }
 }

--- a/app/Services/TwilioService.php
+++ b/app/Services/TwilioService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Models\CallLog;
 use Illuminate\Support\Facades\Log;
 use Twilio\Exceptions\TwilioException;
 use Twilio\Rest\Client;
@@ -117,6 +118,26 @@ class TwilioService
         foreach ($recordings as $recording) {
             $recording->update('stopped');
         }
+
+        return true;
+    }
+
+    public function logCall(string $sid, ?int $contactId, string $direction, ?int $duration, string $status): CallLog
+    {
+        return CallLog::create([
+            'call_sid' => $sid,
+            'contact_id' => $contactId,
+            'direction' => $direction,
+            'duration' => $duration,
+            'status' => $status,
+        ]);
+    }
+
+    public function endCall(string $sid): bool
+    {
+        $this->getClient()->calls($sid)->update(['status' => 'completed']);
+
+        CallLog::where('call_sid', $sid)->update(['status' => 'completed']);
 
         return true;
     }

--- a/database/migrations/2026_07_06_120000_create_call_logs_table.php
+++ b/database/migrations/2026_07_06_120000_create_call_logs_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('call_logs', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('team_id')->nullable()->constrained()->nullOnDelete();
+            $table->string('call_sid');
+            $table->unsignedBigInteger('contact_id')->nullable();
+            $table->string('direction');
+            $table->unsignedInteger('duration')->nullable();
+            $table->string('status');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('call_logs');
+    }
+};

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -37,18 +37,6 @@ parameters:
 			path: app/Actions/Socialstream/CreateConnectedAccount.php
 
 		-
-			message: '#^Call to an undefined method App\\Models\\User\:\:setProfilePhotoFromUrl\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Actions/Socialstream/CreateUserFromProvider.php
-
-		-
-			message: '#^Call to an undefined method App\\Models\\User\:\:setProfilePhotoFromUrl\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Actions/Socialstream/CreateUserWithTeamsFromProvider.php
-
-		-
 			message: '#^Access to an undefined property Laravel\\Socialite\\Contracts\\User\:\:\$email\.$#'
 			identifier: property.notFound
 			count: 1
@@ -115,34 +103,10 @@ parameters:
 			path: app/Filament/App/Pages/EditProfile.php
 
 		-
-			message: '#^Call to an undefined static method Filament\\Facades\\Filament\:\:notify\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Filament/App/Pages/EditProfile.php
-
-		-
 			message: '#^Call to an undefined method App\\Models\\User\:\:canCreateTeams\(\)\.$#'
 			identifier: method.notFound
 			count: 1
 			path: app/Filament/App/Pages/EditTeam.php
-
-		-
-			message: '#^Call to an undefined static method Filament\\Pages\\Page\<Filament\\Pages\\PageConfiguration\>\:\:__construct\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Filament/App/Pages/ReportPage.php
-
-		-
-			message: '#^Call to an undefined method App\\Filament\\App\\Pages\\UpdateProfileInformationPage\:\:notify\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Filament/App/Pages/UpdateProfileInformationPage.php
-
-		-
-			message: '#^Call to an undefined static method Filament\\Pages\\Page\<Filament\\Pages\\PageConfiguration\>\:\:__construct\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Filament/App/Pages/UpdateProfileInformationPage.php
 
 		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$activities\.$#'
@@ -215,18 +179,6 @@ parameters:
 			identifier: method.notFound
 			count: 1
 			path: app/Filament/App/Resources/TaskResource/Pages/CreateTask.php
-
-		-
-			message: '#^Call to an undefined static method Filament\\Resources\\Pages\\CreateRecord\<Illuminate\\Database\\Eloquent\\Model\>\:\:getFormSchema\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Filament/App/Resources/TaskResource/Pages/CreateTask.php
-
-		-
-			message: '#^Call to an undefined static method Filament\\Resources\\Pages\\EditRecord\<Illuminate\\Database\\Eloquent\\Model\>\:\:getFormSchema\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: app/Filament/App/Resources/TaskResource/Pages/EditTask.php
 
 		-
 			message: '#^Cannot access property \$sync_to_google_calendar on Illuminate\\Database\\Eloquent\\Model\|int\|string\.$#'
@@ -313,6 +265,12 @@ parameters:
 			path: app/Http/Controllers/LeadFormController.php
 
 		-
+			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Collection\<int, Illuminate\\Database\\Eloquent\\Model\>\|Illuminate\\Database\\Eloquent\\Model\:\:markAsRead\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: app/Http/Controllers/NotificationController.php
+
+		-
 			message: '#^Access to an undefined property Laravel\\Socialite\\Contracts\\User\:\:\$refreshToken\.$#'
 			identifier: property.notFound
 			count: 1
@@ -367,6 +325,12 @@ parameters:
 			path: app/Http/Controllers/TeamInvitationController.php
 
 		-
+			message: '#^Call to an undefined method App\\Services\\TwilioService\:\:logCall\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: app/Http/Controllers/TwilioController.php
+
+		-
 			message: '#^Access to an undefined property App\\Models\\Contact\|Illuminate\\Database\\Eloquent\\Collection\<int, App\\Models\\Contact\>\:\:\$phone\.$#'
 			identifier: property.notFound
 			count: 1
@@ -391,12 +355,6 @@ parameters:
 			path: app/Http/Livewire/CallManager.php
 
 		-
-			message: '#^Relation ''lead'' is not found in App\\Models\\Task model\.$#'
-			identifier: larastan.relationExistence
-			count: 1
-			path: app/Http/Livewire/TaskList.php
-
-		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
 			count: 1
@@ -413,6 +371,24 @@ parameters:
 			identifier: class.notFound
 			count: 1
 			path: app/Listeners/EmailTracker.php
+
+		-
+			message: '#^Call to an undefined method App\\Services\\TwilioService\:\:endCall\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: app/Livewire/CallManager.php
+
+		-
+			message: '#^Call to an undefined method App\\Services\\TwilioService\:\:logCall\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: app/Livewire/CallManager.php
+
+		-
+			message: '#^Call to static method where\(\) on an unknown class App\\Models\\CallLog\.$#'
+			identifier: class.notFound
+			count: 1
+			path: app/Livewire/CallManager.php
 
 		-
 			message: '#^Access to an undefined property App\\Models\\Activation\:\:\$team_id\.$#'
@@ -673,16 +649,16 @@ parameters:
 			path: app/Models/WorkflowTrigger.php
 
 		-
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$name\.$#'
+			identifier: property.notFound
+			count: 2
+			path: app/Notifications/TaskReminderNotification.php
+
+		-
 			message: '#^Access to an undefined property App\\Models\\Task\:\:\$sync_to_google_calendar\.$#'
 			identifier: property.notFound
 			count: 3
 			path: app/Observers/TaskObserver.php
-
-		-
-			message: '#^Call to an undefined method App\\Models\\User\:\:ownsConnectedAccount\(\)\.$#'
-			identifier: method.notFound
-			count: 3
-			path: app/Policies/ConnectedAccountPolicy.php
 
 		-
 			message: '#^Access to an undefined property App\\Models\\Contact\:\:\$team_id\.$#'
@@ -835,6 +811,42 @@ parameters:
 			path: app/Providers/TeamServiceProvider.php
 
 		-
+			message: '#^Call to method connect\(\) on an unknown class App\\Services\\QuickBooksService\.$#'
+			identifier: class.notFound
+			count: 1
+			path: app/Services/AccountingService.php
+
+		-
+			message: '#^Call to method connect\(\) on an unknown class App\\Services\\XeroService\.$#'
+			identifier: class.notFound
+			count: 1
+			path: app/Services/AccountingService.php
+
+		-
+			message: '#^Call to method syncInvoice\(\) on an unknown class App\\Services\\QuickBooksService\.$#'
+			identifier: class.notFound
+			count: 1
+			path: app/Services/AccountingService.php
+
+		-
+			message: '#^Call to method syncInvoice\(\) on an unknown class App\\Services\\XeroService\.$#'
+			identifier: class.notFound
+			count: 1
+			path: app/Services/AccountingService.php
+
+		-
+			message: '#^Call to method syncPayment\(\) on an unknown class App\\Services\\QuickBooksService\.$#'
+			identifier: class.notFound
+			count: 1
+			path: app/Services/AccountingService.php
+
+		-
+			message: '#^Call to method syncPayment\(\) on an unknown class App\\Services\\XeroService\.$#'
+			identifier: class.notFound
+			count: 1
+			path: app/Services/AccountingService.php
+
+		-
 			message: '#^Instantiated class App\\Exceptions\\AccountingIntegrationException not found\.$#'
 			identifier: class.notFound
 			count: 3
@@ -848,6 +860,18 @@ parameters:
 
 		-
 			message: '#^Parameter \$xeroService of method App\\Services\\AccountingService\:\:__construct\(\) has invalid type App\\Services\\XeroService\.$#'
+			identifier: class.notFound
+			count: 1
+			path: app/Services/AccountingService.php
+
+		-
+			message: '#^Property App\\Services\\AccountingService\:\:\$quickbooksService has unknown class App\\Services\\QuickBooksService as its type\.$#'
+			identifier: class.notFound
+			count: 1
+			path: app/Services/AccountingService.php
+
+		-
+			message: '#^Property App\\Services\\AccountingService\:\:\$xeroService has unknown class App\\Services\\XeroService as its type\.$#'
 			identifier: class.notFound
 			count: 1
 			path: app/Services/AccountingService.php
@@ -874,6 +898,12 @@ parameters:
 			message: '#^Call to method getCampaigns\(\) on an unknown class FacebookAds\\Object\\AdAccount\.$#'
 			identifier: class.notFound
 			count: 1
+			path: app/Services/FacebookAdsService.php
+
+		-
+			message: '#^Call to method getCode\(\) on an unknown class FacebookAds\\Exception\\FacebookException\.$#'
+			identifier: class.notFound
+			count: 2
 			path: app/Services/FacebookAdsService.php
 
 		-
@@ -925,6 +955,24 @@ parameters:
 			path: app/Services/FacebookMessengerService.php
 
 		-
+			message: '#^Call to method get\(\) on an unknown class Facebook\\Facebook\.$#'
+			identifier: class.notFound
+			count: 1
+			path: app/Services/FacebookService.php
+
+		-
+			message: '#^Call to method getCode\(\) on an unknown class Facebook\\Exceptions\\FacebookResponseException\.$#'
+			identifier: class.notFound
+			count: 2
+			path: app/Services/FacebookService.php
+
+		-
+			message: '#^Call to method getCode\(\) on an unknown class Facebook\\Exceptions\\FacebookSDKException\.$#'
+			identifier: class.notFound
+			count: 2
+			path: app/Services/FacebookService.php
+
+		-
 			message: '#^Call to method getMessage\(\) on an unknown class Facebook\\Exceptions\\FacebookResponseException\.$#'
 			identifier: class.notFound
 			count: 2
@@ -934,6 +982,12 @@ parameters:
 			message: '#^Call to method getMessage\(\) on an unknown class Facebook\\Exceptions\\FacebookSDKException\.$#'
 			identifier: class.notFound
 			count: 2
+			path: app/Services/FacebookService.php
+
+		-
+			message: '#^Call to method post\(\) on an unknown class Facebook\\Facebook\.$#'
+			identifier: class.notFound
+			count: 1
 			path: app/Services/FacebookService.php
 
 		-
@@ -955,8 +1009,44 @@ parameters:
 			path: app/Services/FacebookService.php
 
 		-
+			message: '#^Property App\\Services\\FacebookService\:\:\$fb has unknown class Facebook\\Facebook as its type\.$#'
+			identifier: class.notFound
+			count: 1
+			path: app/Services/FacebookService.php
+
+		-
 			message: '#^Access to constant GMAIL_MODIFY on an unknown class Google_Service_Gmail\.$#'
 			identifier: class.notFound
+			count: 1
+			path: app/Services/GmailService.php
+
+		-
+			message: '#^Call to an undefined method Google_Client\:\:setAccessToken\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: app/Services/GmailService.php
+
+		-
+			message: '#^Call to an undefined method Google_Client\:\:setAccessType\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: app/Services/GmailService.php
+
+		-
+			message: '#^Call to an undefined method Google_Client\:\:setApplicationName\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: app/Services/GmailService.php
+
+		-
+			message: '#^Call to an undefined method Google_Client\:\:setPrompt\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: app/Services/GmailService.php
+
+		-
+			message: '#^Call to an undefined method Google_Client\:\:setScopes\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: app/Services/GmailService.php
 
@@ -985,9 +1075,21 @@ parameters:
 			path: app/Services/GmailService.php
 
 		-
+			message: '#^Method App\\Services\\GmailService\:\:createReplyMessage\(\) has invalid return type Google_Service_Gmail_Message\.$#'
+			identifier: class.notFound
+			count: 1
+			path: app/Services/GmailService.php
+
+		-
 			message: '#^Access to constant PAUSED on an unknown class Google\\Ads\\GoogleAds\\V14\\Enums\\CampaignStatusEnum\\CampaignStatus\.$#'
 			identifier: class.notFound
 			count: 1
+			path: app/Services/GoogleAdsService.php
+
+		-
+			message: '#^Call to method getCode\(\) on an unknown class Google\\ApiCore\\ApiException\.$#'
+			identifier: class.notFound
+			count: 4
 			path: app/Services/GoogleAdsService.php
 
 		-
@@ -1063,6 +1165,12 @@ parameters:
 			path: app/Services/GoogleAdsService.php
 
 		-
+			message: '#^Class Google_Service_Calendar does not have a constructor and must be instantiated without any parameters\.$#'
+			identifier: new.noConstructor
+			count: 1
+			path: app/Services/GoogleCalendarService.php
+
+		-
 			message: '#^Parameter \$endDate of method App\\Services\\LiveChatService\:\:getChatAnalytics\(\) has invalid type App\\Services\\Carbon\.$#'
 			identifier: class.notFound
 			count: 1
@@ -1081,9 +1189,39 @@ parameters:
 			path: app/Services/LiveChatService.php
 
 		-
+			message: '#^Access to an undefined property MailchimpMarketing\\ApiClient\:\:\$campaigns\.$#'
+			identifier: property.notFound
+			count: 7
+			path: app/Services/MailChimpService.php
+
+		-
+			message: '#^Access to an undefined property MailchimpMarketing\\ApiClient\:\:\$lists\.$#'
+			identifier: property.notFound
+			count: 3
+			path: app/Services/MailChimpService.php
+
+		-
+			message: '#^Access to an undefined property MailchimpMarketing\\ApiClient\:\:\$reports\.$#'
+			identifier: property.notFound
+			count: 3
+			path: app/Services/MailChimpService.php
+
+		-
 			message: '#^Access to constant GMAIL_MODIFY on an unknown class Google_Service_Gmail\.$#'
 			identifier: class.notFound
 			count: 1
+			path: app/Services/MessageService.php
+
+		-
+			message: '#^Access to property \$users_messages on an unknown class Google_Service_Gmail\.$#'
+			identifier: class.notFound
+			count: 4
+			path: app/Services/MessageService.php
+
+		-
+			message: '#^Call to an undefined method Google_Client\:\:setAccessToken\(\)\.$#'
+			identifier: method.notFound
+			count: 3
 			path: app/Services/MessageService.php
 
 		-
@@ -1135,6 +1273,18 @@ parameters:
 			path: app/Services/MessageService.php
 
 		-
+			message: '#^Method App\\Services\\MessageService\:\:createReplyMessage\(\) has invalid return type Google_Service_Gmail_Message\.$#'
+			identifier: class.notFound
+			count: 1
+			path: app/Services/MessageService.php
+
+		-
+			message: '#^Property App\\Services\\MessageService\:\:\$gmailService has unknown class Google_Service_Gmail as its type\.$#'
+			identifier: class.notFound
+			count: 1
+			path: app/Services/MessageService.php
+
+		-
 			message: '#^Call to an undefined method DateTimeInterface\:\:subMinutes\(\)\.$#'
 			identifier: method.notFound
 			count: 1
@@ -1153,21 +1303,9 @@ parameters:
 			path: app/Services/PersonalizationService.php
 
 		-
-			message: '#^Access to an undefined property App\\Models\\Task\:\:\$assignedTo\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/ReminderService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Task\:\:\$contact\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Services/ReminderService.php
-
-		-
-			message: '#^Access to an undefined property App\\Models\\Task\:\:\$lead\.$#'
-			identifier: property.notFound
-			count: 1
+			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Model\:\:notify\(\)\.$#'
+			identifier: method.notFound
+			count: 3
 			path: app/Services/ReminderService.php
 
 		-
@@ -1207,6 +1345,12 @@ parameters:
 			path: app/Services/StripeService.php
 
 		-
+			message: '#^Call to method getCode\(\) on an unknown class Stripe\\Exception\\ApiErrorException\.$#'
+			identifier: class.notFound
+			count: 3
+			path: app/Services/StripeService.php
+
+		-
 			message: '#^Call to method getMessage\(\) on an unknown class Stripe\\Exception\\ApiErrorException\.$#'
 			identifier: class.notFound
 			count: 3
@@ -1237,7 +1381,31 @@ parameters:
 			path: app/Services/TeamManagementService.php
 
 		-
+			message: '#^Call to method get\(\) on an unknown class Abraham\\TwitterOAuth\\TwitterOAuth\.$#'
+			identifier: class.notFound
+			count: 1
+			path: app/Services/TwitterService.php
+
+		-
+			message: '#^Call to method post\(\) on an unknown class Abraham\\TwitterOAuth\\TwitterOAuth\.$#'
+			identifier: class.notFound
+			count: 1
+			path: app/Services/TwitterService.php
+
+		-
+			message: '#^Call to method setOauthToken\(\) on an unknown class Abraham\\TwitterOAuth\\TwitterOAuth\.$#'
+			identifier: class.notFound
+			count: 2
+			path: app/Services/TwitterService.php
+
+		-
 			message: '#^Instantiated class Abraham\\TwitterOAuth\\TwitterOAuth not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: app/Services/TwitterService.php
+
+		-
+			message: '#^Property App\\Services\\TwitterService\:\:\$connection has unknown class Abraham\\TwitterOAuth\\TwitterOAuth as its type\.$#'
 			identifier: class.notFound
 			count: 1
 			path: app/Services/TwitterService.php

--- a/tests/Feature/Audit/AuditLoggingTest.php
+++ b/tests/Feature/Audit/AuditLoggingTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Audit;
+
+use App\Models\AuditLog;
+use App\Models\Contact;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AuditLoggingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // user_id on audit_logs is NOT NULL + FK -> need an authenticated user.
+        $this->actingAs(User::factory()->create());
+    }
+
+    public function test_creating_a_contact_writes_a_created_audit_log(): void
+    {
+        $contact = Contact::factory()->create();
+
+        $this->assertDatabaseHas('audit_logs', ['action' => 'created']);
+        $this->assertSame(1, AuditLog::count());
+        // description carries the audited model class + id.
+        $this->assertStringContainsString(
+            $contact::class.'#'.$contact->getKey(),
+            (string) AuditLog::first()->description,
+        );
+    }
+
+    public function test_updating_a_contact_writes_an_updated_audit_log(): void
+    {
+        $contact = Contact::factory()->create();
+        $contact->update(['name' => 'Renamed']);
+
+        $this->assertDatabaseHas('audit_logs', ['action' => 'updated']);
+        // updated log records the changed attributes.
+        $updated = AuditLog::where('action', 'updated')->firstOrFail();
+        $this->assertStringContainsString('Renamed', (string) $updated->description);
+    }
+
+    public function test_deleting_a_contact_writes_a_deleted_audit_log(): void
+    {
+        $contact = Contact::factory()->create();
+        $contact->delete();
+
+        $this->assertDatabaseHas('audit_logs', ['action' => 'deleted']);
+    }
+
+    public function test_no_infinite_recursion(): void
+    {
+        $contact = Contact::factory()->create(); // created
+        $contact->update(['name' => 'X']);       // updated
+        $contact->delete();                      // deleted
+
+        // Exactly one row per event, and writing AuditLog itself is not audited.
+        $this->assertSame(3, AuditLog::count());
+    }
+}

--- a/tests/Feature/Policies/RecordPolicyTest.php
+++ b/tests/Feature/Policies/RecordPolicyTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Policies;
+
+use App\Models\Deal;
+use App\Models\Lead;
+use App\Models\Opportunity;
+use App\Models\Task;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+/**
+ * Deal/Lead/Task/Opportunity policies authorize a record when it belongs to the
+ * user's current team ($model->belongsToTeam($user->currentTeam?->id)) — the
+ * same idiom the controllers use. currentTeam resolves via the real
+ * current_team_id column (there is no team_id column on users).
+ */
+class RecordPolicyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @return array<string, array{class-string<Model>}>
+     */
+    public static function recordModels(): array
+    {
+        return [
+            'Deal' => [Deal::class],
+            'Lead' => [Lead::class],
+            'Task' => [Task::class],
+            'Opportunity' => [Opportunity::class],
+        ];
+    }
+
+    /**
+     * @param  class-string<Model>  $modelClass
+     */
+    #[DataProvider('recordModels')]
+    public function test_same_team_user_may_view_update_delete(string $modelClass): void
+    {
+        $team = Team::factory()->create();
+        $user = User::factory()->create();
+        $user->current_team_id = $team->id;
+
+        $record = $modelClass::factory()->create();
+        $record->team_id = $team->id;
+
+        $this->assertTrue($user->can('view', $record));
+        $this->assertTrue($user->can('update', $record));
+        $this->assertTrue($user->can('delete', $record));
+    }
+
+    /**
+     * @param  class-string<Model>  $modelClass
+     */
+    #[DataProvider('recordModels')]
+    public function test_other_team_user_is_denied(string $modelClass): void
+    {
+        $team = Team::factory()->create();
+        $otherTeam = Team::factory()->create();
+
+        $user = User::factory()->create();
+        $user->current_team_id = $otherTeam->id;
+
+        $record = $modelClass::factory()->create();
+        $record->team_id = $team->id;
+
+        $this->assertFalse($user->can('view', $record));
+        $this->assertFalse($user->can('update', $record));
+        $this->assertFalse($user->can('delete', $record));
+    }
+}

--- a/tests/Feature/Telephony/CallLoggingTest.php
+++ b/tests/Feature/Telephony/CallLoggingTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Feature\Telephony;
+
+use App\Models\CallLog;
+use App\Services\TwilioService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Tests\TestCase;
+use Twilio\Rest\Client;
+
+class CallLoggingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_log_call_persists_a_call_log(): void
+    {
+        $callLog = (new TwilioService)->logCall('CA123', 42, 'outbound', null, 'initiated');
+
+        $this->assertInstanceOf(CallLog::class, $callLog);
+        $this->assertDatabaseHas('call_logs', [
+            'call_sid' => 'CA123',
+            'contact_id' => 42,
+            'direction' => 'outbound',
+            'duration' => null,
+            'status' => 'initiated',
+        ]);
+    }
+
+    public function test_end_call_updates_status_to_completed(): void
+    {
+        CallLog::create([
+            'call_sid' => 'CA999',
+            'contact_id' => null,
+            'direction' => 'outbound',
+            'duration' => null,
+            'status' => 'initiated',
+        ]);
+
+        // Mirror the client-mocking approach used for stopCallRecording:
+        // calls($sid)->update([...]) hangs the call up via the Twilio client.
+        $callContext = Mockery::mock();
+        $callContext->shouldReceive('update')
+            ->once()
+            ->with(['status' => 'completed'])
+            ->andReturn(Mockery::mock());
+
+        $client = Mockery::mock(Client::class);
+        $client->shouldReceive('calls')
+            ->once()
+            ->with('CA999')
+            ->andReturn($callContext);
+
+        $service = new TwilioService;
+        $service->setClient($client);
+
+        $result = $service->endCall('CA999');
+
+        $this->assertTrue($result);
+        $this->assertDatabaseHas('call_logs', [
+            'call_sid' => 'CA999',
+            'status' => 'completed',
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+}

--- a/tests/Feature/TwilioIntegrationTest.php
+++ b/tests/Feature/TwilioIntegrationTest.php
@@ -30,7 +30,7 @@ class TwilioIntegrationTest extends TestCase
 
         $this->twilioService->shouldReceive('logCall')
             ->once()
-            ->andReturn(true);
+            ->andReturn(new \App\Models\CallLog);
 
         $call = app(TwilioService::class)->initiateCall($contact->phone_number);
         app(TwilioService::class)->logCall($call->sid, $contact->id, 'outbound', null, 'initiated');


### PR DESCRIPTION
## P0 continued: telephony bug fix, record policies, audit logging

Three independent, TDD'd increments built in parallel, plus recovery of triage fixes that missed the #457 merge window.

### Commits
| Commit | What |
|--------|------|
| `dfd6ddc` | **fix**: real larastan findings (recovered — these were pushed after #457 merged, so never landed): `Contact->phone_number` click-to-call bug, `env()`→`config()`, Task relation return types, `SetTenantContext` typing |
| `6a45c9f` | **chore**: regenerate phpstan baseline for current main → `composer analyse` green |
| `aea6aaf` | **fix(telephony)**: `CallManager` called `TwilioService::logCall()`/`endCall()` and referenced `App\Models\CallLog` — none existed. Added the CallLog model + migration + the two service methods |
| `e3a326e` | **feat(authz)**: policies for Deal/Lead/Task/Opportunity |
| `f68308f` | **feat(audit)**: create/update/delete audit logging on core tenant models (F6) |

### Notes on the policies
Mirror-of-ContactPolicy would have been a bug: `ContactPolicy` compares `$user->team_id === $model->team_id`, but the `users` table has no `team_id` (Jetstream uses `current_team_id`) — so it denies everyone against real records. The new policies use the working controller idiom `$model->belongsToTeam($user->currentTeam?->getKey())`. **ContactPolicy still has the latent deny-all bug — left for a separate fix** (it isn't reached by the API, which does its own `belongsToTeam` check).

### Audit logging (F6, minimal)
`audit_logs` is a minimal table (no `auditable_*`/`team_id`/`changes` columns), so the observer encodes `class#id` + changed-attrs JSON into `description` and reuses `AuditLogService`. Registered only on the 5 tenant models (never AuditLog → no recursion). Skips unauthenticated writes because `user_id` is NOT NULL + FK — **so console/queue/system actions are not audited yet** (schema limitation).

### Testing
- **492 passed, 1 skipped, 0 failed** (`php artisan test`).
- New: `CallLoggingTest`, `RecordPolicyTest`, `AuditLoggingTest`.
- `composer analyse` green (new code adds no errors beyond the baseline).

### Follow-ups
- Fix `ContactPolicy`'s deny-all `$user->team_id` check (same idiom as here).
- `TwilioService::endCall` hangup path is stub-tested only; verify against the live Twilio client.
- Audit: give `audit_logs` structured columns (auditable_type/id, team_id, changes) and drop the auth-only guard so system actions are captured.
- Legacy duplicate `app/Http/Livewire/CallManager.php` still references a `notes` column — drift to reconcile.
