### PR TITLE
P0 hardening: queue tenancy (F5), structured audit, policy fix

### DIFF
--- a/app/Jobs/Concerns/TenantAware.php
+++ b/app/Jobs/Concerns/TenantAware.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Jobs\Concerns;
+
+use App\Jobs\Middleware\RestoreTenantContext;
+use App\Support\TenantContext;
+
+/**
+ * Makes a queued job remember the team it was dispatched for and restore it
+ * inside the worker, so tenant-scoped (IsTenantModel) Eloquent queries stay
+ * scoped instead of leaking across teams.
+ *
+ * A trait constructor cannot run automatically alongside the job's own
+ * constructor, so opt in with ONE line in the job's constructor:
+ *
+ *   public function __construct(...) { ...; $this->captureTenant(); }
+ *
+ * captureTenant() snapshots the current tenant at dispatch time (serialized
+ * with the job); the RestoreTenantContext middleware sets it back before
+ * handle() runs and clears it afterwards.
+ */
+trait TenantAware
+{
+    public ?int $tenantId = null;
+
+    /**
+     * @return array<int, object>
+     */
+    public function middleware(): array
+    {
+        return [new RestoreTenantContext];
+    }
+
+    protected function captureTenant(): void
+    {
+        $this->tenantId = TenantContext::currentId();
+    }
+}

--- a/app/Jobs/Middleware/RestoreTenantContext.php
+++ b/app/Jobs/Middleware/RestoreTenantContext.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Jobs\Middleware;
+
+use App\Support\TenantContext;
+
+/**
+ * Restores the dispatching team's tenant context around a job's execution so
+ * IsTenantModel-scoped queries filter correctly inside the worker, then clears
+ * it in a finally block so a reused worker process can't leak the team into
+ * the next job.
+ */
+class RestoreTenantContext
+{
+    public function handle(object $job, callable $next): mixed
+    {
+        TenantContext::set($job->tenantId ?? null);
+
+        try {
+            return $next($job);
+        } finally {
+            TenantContext::clear();
+        }
+    }
+}

--- a/app/Models/AuditLog.php
+++ b/app/Models/AuditLog.php
@@ -6,6 +6,7 @@ namespace App\Models;
 
 use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 class AuditLog extends Model
 {
@@ -16,10 +17,23 @@ class AuditLog extends Model
         'action',
         'description',
         'ip_address',
+        'auditable_type',
+        'auditable_id',
+        'team_id',
+        'changes',
+    ];
+
+    protected $casts = [
+        'changes' => 'array',
     ];
 
     public function user()
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function auditable(): MorphTo
+    {
+        return $this->morphTo();
     }
 }

--- a/app/Observers/AuditObserver.php
+++ b/app/Observers/AuditObserver.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Observers;
 
-use App\Services\AuditLogService;
+use App\Models\AuditLog;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -16,11 +16,9 @@ use Illuminate\Database\Eloquent\Model;
  */
 class AuditObserver
 {
-    public function __construct(private readonly AuditLogService $audit) {}
-
     public function created(Model $model): void
     {
-        $this->record($model, 'created');
+        $this->record($model, 'created', $model->getAttributes());
     }
 
     public function updated(Model $model): void
@@ -30,13 +28,13 @@ class AuditObserver
 
     public function deleted(Model $model): void
     {
-        $this->record($model, 'deleted');
+        $this->record($model, 'deleted', null);
     }
 
     /**
-     * @param  array<string, mixed>  $changes
+     * @param  array<string, mixed>|null  $changes
      */
-    private function record(Model $model, string $action, array $changes = []): void
+    private function record(Model $model, string $action, ?array $changes): void
     {
         // audit_logs.user_id is NOT NULL + FK; nothing to attribute unauthenticated
         // writes to (seeders, console, queue), so skip rather than blow the constraint.
@@ -46,11 +44,20 @@ class AuditObserver
 
         $description = $model::class.'#'.$model->getKey().' '.$action;
 
-        if ($changes !== []) {
+        // Legacy description behaviour: only the update event appended the diff.
+        if ($action === 'updated' && $changes) {
             $description .= ' '.json_encode($changes);
         }
 
-        // Reuse the existing service: it stamps user_id + ip_address for us.
-        $this->audit->log($action, $description);
+        AuditLog::create([
+            'user_id' => auth()->id(),
+            'action' => $action,
+            'description' => $description,
+            'ip_address' => request()->ip(),
+            'auditable_type' => $model::class,
+            'auditable_id' => $model->getKey(),
+            'team_id' => $model->getAttribute('team_id'),
+            'changes' => $changes,
+        ]);
     }
 }

--- a/app/Policies/ContactPolicy.php
+++ b/app/Policies/ContactPolicy.php
@@ -19,7 +19,7 @@ class ContactPolicy
 
     public function view(User $user, Contact $contact): bool
     {
-        return $user->team_id === $contact->team_id;
+        return $contact->belongsToTeam($user->currentTeam?->getKey());
     }
 
     public function create(User $user): bool
@@ -29,21 +29,21 @@ class ContactPolicy
 
     public function update(User $user, Contact $contact): bool
     {
-        return $user->team_id === $contact->team_id;
+        return $contact->belongsToTeam($user->currentTeam?->getKey());
     }
 
     public function delete(User $user, Contact $contact): bool
     {
-        return $user->team_id === $contact->team_id;
+        return $contact->belongsToTeam($user->currentTeam?->getKey());
     }
 
     public function restore(User $user, Contact $contact): bool
     {
-        return $user->team_id === $contact->team_id;
+        return $contact->belongsToTeam($user->currentTeam?->getKey());
     }
 
     public function forceDelete(User $user, Contact $contact): bool
     {
-        return $user->team_id === $contact->team_id;
+        return $contact->belongsToTeam($user->currentTeam?->getKey());
     }
 }

--- a/database/migrations/2026_07_06_130000_add_auditable_columns_to_audit_logs.php
+++ b/database/migrations/2026_07_06_130000_add_auditable_columns_to_audit_logs.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Make audit rows structured: a polymorphic target (auditable_type/_id), the
+ * owning team, and a JSON diff — instead of cramming everything into the
+ * free-text `description`. All nullable so pre-existing AuditLogService writes
+ * (which only set action/description/user_id/ip_address) keep working.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('audit_logs', function (Blueprint $table): void {
+            $table->string('auditable_type')->nullable();
+            $table->unsignedBigInteger('auditable_id')->nullable();
+            $table->json('changes')->nullable();
+            $table->index(['auditable_type', 'auditable_id']);
+
+            // team_id may already exist (add_team_id_to_tenant_scoped_tables).
+            if (! Schema::hasColumn('audit_logs', 'team_id')) {
+                $table->foreignId('team_id')->nullable()->constrained()->nullOnDelete();
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('audit_logs', function (Blueprint $table): void {
+            $table->dropIndex(['auditable_type', 'auditable_id']);
+            $table->dropColumn(['auditable_type', 'auditable_id', 'changes']);
+        });
+    }
+};

--- a/tests/Feature/Audit/AuditEnrichmentTest.php
+++ b/tests/Feature/Audit/AuditEnrichmentTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Audit;
+
+use App\Models\AuditLog;
+use App\Models\Contact;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AuditEnrichmentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_updating_a_contact_records_a_structured_audit_log(): void
+    {
+        $this->actingAs(User::factory()->create());
+
+        $team = Team::factory()->create();
+        $contact = Contact::factory()->create(['team_id' => $team->id]);
+
+        $contact->update(['name' => 'Renamed']);
+
+        $log = AuditLog::where('action', 'updated')
+            ->where('auditable_type', Contact::class)
+            ->where('auditable_id', $contact->getKey())
+            ->firstOrFail();
+
+        $this->assertSame('updated', $log->action);
+        $this->assertSame(Contact::class, $log->auditable_type);
+        $this->assertEquals($contact->getKey(), $log->auditable_id);
+
+        // changes is cast to array and carries the changed attribute.
+        $this->assertIsArray($log->changes);
+        $this->assertArrayHasKey('name', $log->changes);
+        $this->assertSame('Renamed', $log->changes['name']);
+
+        // team_id is stamped from the audited model.
+        $this->assertEquals($team->id, $log->team_id);
+
+        // auditable morphs back to the Contact.
+        $this->assertTrue($contact->is($log->auditable));
+    }
+}

--- a/tests/Feature/Policies/ContactPolicyTest.php
+++ b/tests/Feature/Policies/ContactPolicyTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Policies;
+
+use App\Models\Contact;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * ContactPolicy authorizes a Contact when it belongs to the user's current team
+ * ($contact->belongsToTeam($user->currentTeam?->getKey())) — the same idiom the
+ * controllers and sibling record policies use. currentTeam resolves via the real
+ * current_team_id column (there is no team_id column on users).
+ */
+class ContactPolicyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_same_team_user_may_view_update_delete_restore_force_delete(): void
+    {
+        $team = Team::factory()->create();
+        $user = User::factory()->create();
+        $user->current_team_id = $team->id;
+
+        $contact = Contact::factory()->create();
+        $contact->team_id = $team->id;
+
+        $this->assertTrue($user->can('view', $contact));
+        $this->assertTrue($user->can('update', $contact));
+        $this->assertTrue($user->can('delete', $contact));
+        $this->assertTrue($user->can('restore', $contact));
+        $this->assertTrue($user->can('forceDelete', $contact));
+    }
+
+    public function test_other_team_user_is_denied(): void
+    {
+        $team = Team::factory()->create();
+        $otherTeam = Team::factory()->create();
+
+        $user = User::factory()->create();
+        $user->current_team_id = $otherTeam->id;
+
+        $contact = Contact::factory()->create();
+        $contact->team_id = $team->id;
+
+        $this->assertFalse($user->can('view', $contact));
+        $this->assertFalse($user->can('update', $contact));
+        $this->assertFalse($user->can('delete', $contact));
+        $this->assertFalse($user->can('restore', $contact));
+        $this->assertFalse($user->can('forceDelete', $contact));
+    }
+}

--- a/tests/Feature/Queue/TenantAwareJobTest.php
+++ b/tests/Feature/Queue/TenantAwareJobTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Feature\Queue;
+
+use App\Jobs\Concerns\TenantAware;
+use App\Support\TenantContext;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Tests\TestCase;
+
+/**
+ * Test job: opts into TenantAware and captures the tenant in its constructor.
+ * handle() records whatever tenant the worker saw at run time.
+ */
+class RecordingTenantJob implements ShouldQueue
+{
+    use Dispatchable, SerializesModels, TenantAware;
+
+    public static ?int $seenTenantId = null;
+
+    public function __construct()
+    {
+        $this->captureTenant();
+    }
+
+    public function handle(): void
+    {
+        self::$seenTenantId = TenantContext::currentId();
+    }
+}
+
+class TenantAwareJobTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        RecordingTenantJob::$seenTenantId = null;
+        TenantContext::clear();
+    }
+
+    protected function tearDown(): void
+    {
+        TenantContext::clear();
+        parent::tearDown();
+    }
+
+    public function test_middleware_restores_the_captured_tenant_inside_the_worker(): void
+    {
+        // Dispatch happens inside a tenant context...
+        TenantContext::set(42);
+        $job = new RecordingTenantJob;
+
+        // ...but the worker runs in a fresh, un-scoped process.
+        TenantContext::clear();
+        $this->assertNull(TenantContext::currentId());
+
+        $this->runThroughMiddleware($job);
+
+        $this->assertSame(42, RecordingTenantJob::$seenTenantId);
+        // Context is cleared again so the worker can't leak it to the next job.
+        $this->assertNull(TenantContext::currentId());
+    }
+
+    public function test_job_dispatched_with_no_tenant_captures_and_restores_null(): void
+    {
+        $job = new RecordingTenantJob; // no context set
+        $this->assertNull($job->tenantId);
+
+        $this->runThroughMiddleware($job);
+
+        $this->assertNull(RecordingTenantJob::$seenTenantId);
+    }
+
+    private function runThroughMiddleware(RecordingTenantJob $job): void
+    {
+        // Single middleware — invoke it directly around handle().
+        $job->middleware()[0]->handle($job, fn ($job) => $job->handle());
+    }
+}


### PR DESCRIPTION
## P0 hardening: queue tenancy, structured audit, policy fix

Three independent, TDD'd increments (built in parallel) closing gaps flagged in the prior PR.

| Commit | What |
|--------|------|
| `9302bbf` | **feat(queue) — F5**: `TenantAware` trait + `RestoreTenantContext` job middleware. Queued jobs ran with no tenant context (tenant-scoped queries un-scoped); a job now captures `TenantContext::currentId()` at construct time and the middleware re-applies it around `handle()`. Opt-in: `use TenantAware` + `captureTenant()` in the constructor. |
| `6bb3398` | **feat(audit)**: replace the description-string hack with real columns — nullable `auditable_type`/`auditable_id` (morph), `changes` (json), `team_id`. `AuditLog::auditable()` morphs back. Nullable so existing `AuditLogService` writes keep working. |
| `30968b3` | **fix(authz)**: `ContactPolicy` compared `$user->team_id` (always null — users use `current_team_id`), denying everyone. Switched all 5 methods to `$contact->belongsToTeam($user->currentTeam?->getKey())`, matching the sibling record policies. Confirmed ContactPolicy was the only policy with this bug. |

### Testing
- **497 passed, 1 skipped, 0 failed** (`php artisan test`).
- New: `TenantAwareJobTest`, `AuditEnrichmentTest`, `ContactPolicyTest`.
- `composer analyse` clean (no new errors beyond baseline).

### Notes / follow-ups
- Queue tenancy is **opt-in** — existing jobs don't carry tenant context until they add the trait + `captureTenant()`. Retro-fit jobs that query tenant models.
- Audit observer writes `AuditLog` directly (not via `AuditLogService`, which was out of scope for the task); consider routing through the service later. Legacy `description` still populated for back-compat.
- Migration verified on SQLite only — confirm against MySQL before prod (the new migration guards `team_id` with `Schema::hasColumn` since the F1 backfill already added it to `audit_logs`).
