### PR TITLE
P1 core: forecasting fix, lead scoring, contact tags

### DIFF
--- a/app/Models/Contact.php
+++ b/app/Models/Contact.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Str;
 
@@ -79,6 +80,11 @@ class Contact extends Model
     public function documents(): MorphMany
     {
         return $this->morphMany(Document::class, 'documentable');
+    }
+
+    public function tags(): MorphToMany
+    {
+        return $this->morphToMany(Tag::class, 'taggable');
     }
 
     #[\Override]

--- a/app/Models/Lead.php
+++ b/app/Models/Lead.php
@@ -71,28 +71,42 @@ class Lead extends Model implements OwnsRecords
         return $this->morphMany(Note::class, 'notable');
     }
 
+    /**
+     * Calculate this lead's score and persist it to the `score` column.
+     *
+     * Scoring rules (each term added, then the total clamped to 0..100):
+     *   - source:          referral +30, website +20, social_media +10, otherwise +5
+     *   - potential_value: + min(30, floor(potential_value / 1000))
+     *   - contact present: +15
+     *   - lifecycle_stage: customer +25, opportunity +20, lead +10, otherwise 0
+     *
+     * The maximum reachable total is exactly 100 (30 + 30 + 15 + 25); the clamp
+     * guards against future rule changes and negative/oversized inputs.
+     */
     public function calculateScore(): int
     {
-        $score = 0;
+        $score = match ($this->source) {
+            'referral' => 30,
+            'website' => 20,
+            'social_media' => 10,
+            default => 5,
+        };
 
-        // Score based on potential value
-        $score += min(100, $this->potential_value / 1000);
+        $score += (int) min(30, floor((float) $this->potential_value / 1000));
 
-        // Score based on lifecycle stage
-        $lifecycleStageScores = [
-            'subscriber' => 10,
-            'lead' => 20,
-            'marketing_qualified_lead' => 40,
-            'sales_qualified_lead' => 60,
-            'opportunity' => 80,
-        ];
-        $score += $lifecycleStageScores[$this->lifecycle_stage] ?? 0;
+        if ($this->contact_id !== null) {
+            $score += 15;
+        }
 
-        // Score based on activity count
-        $activityCount = $this->activities()->count();
-        $score += min(50, $activityCount * 5);
+        $score += match ($this->lifecycle_stage) {
+            'customer' => 25,
+            'opportunity' => 20,
+            'lead' => 10,
+            default => 0,
+        };
 
-        // Update the score
+        $score = (int) max(0, min(100, $score));
+
         $this->update(['score' => $score]);
 
         return $score;

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use App\Traits\IsTenantModel;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
+
+class Tag extends Model
+{
+    use HasFactory;
+    use IsTenantModel;
+
+    protected $fillable = [
+        'name',
+        'team_id',
+    ];
+
+    public function contacts(): MorphToMany
+    {
+        return $this->morphedByMany(Contact::class, 'taggable');
+    }
+}

--- a/app/Services/SalesForecastingService.php
+++ b/app/Services/SalesForecastingService.php
@@ -15,8 +15,8 @@ class SalesForecastingService
     public function generatePipelineForecast(Pipeline $pipeline, Carbon $startDate, Carbon $endDate): SalesForecast
     {
         $deals = Deal::where('pipeline_id', $pipeline->id)
-            ->whereBetween('expected_close_date', [$startDate, $endDate])
-            ->where('status', '!=', 'lost')
+            ->whereBetween('close_date', [$startDate, $endDate])
+            ->where('stage', '!=', 'lost')
             ->get();
 
         $predictedRevenue = $deals->sum(fn($deal) => $deal->value * ($deal->probability / 100));
@@ -69,13 +69,15 @@ class SalesForecastingService
      */
     public function generateWeightedForecast(Carbon $startDate, Carbon $endDate): SalesForecast
     {
-        $deals = Deal::whereBetween('expected_close_date', [$startDate, $endDate])
-            ->where('status', '!=', 'lost')
+        $deals = Deal::whereBetween('close_date', [$startDate, $endDate])
+            ->where('stage', '!=', 'lost')
             ->with('stage')
             ->get();
 
         $weightedRevenue = $deals->sum(function ($deal): float {
-            $stageWeight = $this->getStageWeight($deal->stage);
+            // getRelationValue() returns the eager-loaded Stage model; a plain
+            // $deal->stage would return the `stage` string column that shadows it.
+            $stageWeight = $this->getStageWeight($deal->getRelationValue('stage'));
             $probabilityWeight = $deal->probability / 100;
 
             return $deal->value * $stageWeight * $probabilityWeight;

--- a/database/factories/TagFactory.php
+++ b/database/factories/TagFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\Tag;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class TagFactory extends Factory
+{
+    protected $model = Tag::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->unique()->word(),
+        ];
+    }
+}

--- a/database/migrations/2026_07_06_140000_create_tags_table.php
+++ b/database/migrations/2026_07_06_140000_create_tags_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('tags', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name');
+            $table->foreignId('team_id')->nullable()->constrained()->nullOnDelete();
+            $table->timestamps();
+        });
+
+        Schema::create('taggables', function (Blueprint $table): void {
+            $table->foreignId('tag_id')->constrained()->cascadeOnDelete();
+            $table->unsignedBigInteger('taggable_id');
+            $table->string('taggable_type');
+            $table->unique(['tag_id', 'taggable_id', 'taggable_type'], 'taggables_unique');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('taggables');
+        Schema::dropIfExists('tags');
+    }
+};

--- a/tests/Feature/Tags/ContactTagTest.php
+++ b/tests/Feature/Tags/ContactTagTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Feature\Tags;
+
+use App\Models\Contact;
+use App\Models\Tag;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ContactTagTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_tags_can_be_attached_to_a_contact_and_read_back(): void
+    {
+        $contact = Contact::factory()->create();
+        $tags = Tag::factory()->count(2)->create();
+
+        $contact->tags()->attach($tags);
+
+        $this->assertCount(2, $contact->refresh()->tags);
+        $this->assertEqualsCanonicalizing(
+            $tags->pluck('name')->all(),
+            $contact->tags->pluck('name')->all()
+        );
+    }
+
+    public function test_a_tag_can_be_attached_to_multiple_contacts(): void
+    {
+        $tag = Tag::factory()->create();
+        $contacts = Contact::factory()->count(2)->create();
+
+        $tag->contacts()->attach($contacts);
+
+        $this->assertCount(2, $tag->refresh()->contacts);
+    }
+
+    public function test_sync_replaces_tags(): void
+    {
+        $contact = Contact::factory()->create();
+        [$a, $b, $c] = Tag::factory()->count(3)->create()->all();
+
+        $contact->tags()->attach([$a->id, $b->id]);
+        $contact->tags()->sync([$c->id]);
+
+        $this->assertEquals([$c->id], $contact->refresh()->tags->pluck('id')->all());
+    }
+
+    public function test_detach_removes_one_tag(): void
+    {
+        $contact = Contact::factory()->create();
+        [$a, $b] = Tag::factory()->count(2)->create()->all();
+
+        $contact->tags()->attach([$a->id, $b->id]);
+        $contact->tags()->detach($a->id);
+
+        $this->assertEquals([$b->id], $contact->refresh()->tags->pluck('id')->all());
+    }
+}

--- a/tests/Unit/LeadScoringServiceTest.php
+++ b/tests/Unit/LeadScoringServiceTest.php
@@ -2,9 +2,11 @@
 
 namespace Tests\Unit;
 
+use App\Models\Contact;
 use App\Models\Lead;
 use App\Services\LeadScoringService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
 class LeadScoringServiceTest extends TestCase
@@ -56,5 +58,89 @@ class LeadScoringServiceTest extends TestCase
             $this->assertNotNull($lead->score);
             $this->assertGreaterThanOrEqual(0, $lead->score);
         }
+    }
+
+    /**
+     * source: referral +30 vs the "otherwise" +5 default -> the isolated gap is 25.
+     * (Everything else is held at zero so the score is purely the source term.)
+     */
+    public function test_referral_source_contributes_its_documented_weight(): void
+    {
+        $base = [
+            'potential_value' => 0,
+            'contact_id' => null,
+            'lifecycle_stage' => 'subscriber', // valid stage, not in the scoring map -> 0
+        ];
+
+        $referral = Lead::factory()->create($base + ['source' => 'referral']);
+        $other = Lead::factory()->create($base + ['source' => 'other']);
+
+        $this->leadScoringService->scoreLeads($referral);
+        $this->leadScoringService->scoreLeads($other);
+
+        $this->assertSame(30, $referral->score);
+        $this->assertSame(5, $other->score);
+        $this->assertSame(25, $referral->score - $other->score);
+    }
+
+    /**
+     * contact present: +15 over an otherwise-identical lead with no contact.
+     */
+    public function test_contact_presence_adds_15(): void
+    {
+        $base = [
+            'source' => 'other',
+            'potential_value' => 0,
+            'lifecycle_stage' => 'subscriber',
+        ];
+
+        $withoutContact = Lead::factory()->create($base + ['contact_id' => null]);
+        $withContact = Lead::factory()->create($base + ['contact_id' => Contact::factory()->create()->id]);
+
+        $this->leadScoringService->scoreLeads($withoutContact);
+        $this->leadScoringService->scoreLeads($withContact);
+
+        $this->assertSame($withoutContact->score + 15, $withContact->score);
+    }
+
+    /**
+     * Every term at its maximum: referral (30) + value cap (30) + contact (15)
+     * + customer (25) = 100, and the clamp holds it at 100.
+     */
+    public function test_maxed_out_lead_clamps_to_100(): void
+    {
+        $lead = Lead::factory()->create([
+            'source' => 'referral',
+            'potential_value' => 5_000_000, // floor(/1000) = 5000, capped at 30
+            'contact_id' => Contact::factory()->create()->id,
+            'lifecycle_stage' => 'opportunity', // placeholder; the setter rejects 'customer'
+        ]);
+
+        // 'customer' is a scored stage but is NOT in Lead::LIFECYCLE_STAGES, whose
+        // mutator throws on it, so set it past the mutator via the query builder.
+        DB::table('leads')->where('id', $lead->id)->update(['lifecycle_stage' => 'customer']);
+        $lead->refresh();
+
+        $this->leadScoringService->scoreLeads($lead);
+
+        $this->assertSame(100, $lead->score);
+    }
+
+    /**
+     * A bare lead (no matching source, no value, no contact, unscored stage)
+     * scores the documented minimum: the +5 "otherwise" source floor.
+     */
+    public function test_bare_lead_scores_documented_minimum(): void
+    {
+        $lead = Lead::factory()->create([
+            'source' => 'other',
+            'potential_value' => 0,
+            'contact_id' => null,
+            'lifecycle_stage' => 'subscriber',
+        ]);
+
+        $this->leadScoringService->scoreLeads($lead);
+
+        $this->assertSame(5, $lead->score);
     }
 }

--- a/tests/Unit/LeadTest.php
+++ b/tests/Unit/LeadTest.php
@@ -71,23 +71,22 @@ class LeadTest extends TestCase
 
     public function test_lead_score_calculation(): void
     {
+        // Scoring rules: source referral +30, potential_value +min(30, value/1000),
+        // lifecycle opportunity +20, contact +15, clamp 0..100. NOTE: the rules
+        // rewrite dropped the old activity-engagement and mql/sql lifecycle
+        // signals — revisit if product wants engagement-weighted scoring back.
         $lead = Lead::factory()->create([
+            'source' => 'referral',
             'potential_value' => 50000,
-            'lifecycle_stage' => 'marketing_qualified_lead',
-        ]);
-
-        // Create some activities for the lead
-        Activity::factory()->count(5)->create([
-            'activitable_id' => $lead->id,
-            'activitable_type' => Lead::class,
+            'lifecycle_stage' => 'opportunity',
+            'contact_id' => null,
         ]);
 
         $score = $lead->calculateScore();
 
-        // Expected score:
-        // 50 (from potential value) + 40 (from lifecycle stage) + 25 (from activities) = 115
-        $this->assertEquals(115, $score);
-        $this->assertEquals(115, $lead->score);
+        // 30 (referral) + 30 (value, capped) + 20 (opportunity) = 80
+        $this->assertEquals(80, $score);
+        $this->assertEquals(80, $lead->score);
     }
 
     public function test_lead_custom_fields(): void

--- a/tests/Unit/SalesForecastingServiceTest.php
+++ b/tests/Unit/SalesForecastingServiceTest.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Deal;
+use App\Models\Pipeline;
+use App\Models\SalesForecast;
+use App\Models\Stage;
+use App\Services\SalesForecastingService;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use ReflectionMethod;
+use Tests\TestCase;
+
+class SalesForecastingServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private SalesForecastingService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new SalesForecastingService;
+    }
+
+    /** Invoke a protected method for direct unit testing. */
+    private function invokeProtected(string $method, array $args): mixed
+    {
+        $ref = new ReflectionMethod($this->service, $method);
+        $ref->setAccessible(true);
+
+        return $ref->invokeArgs($this->service, $args);
+    }
+
+    public function test_generate_weighted_forecast_sums_value_times_stage_and_probability_weight(): void
+    {
+        // getStageWeight = min(1, order/5 + 0.2)
+        $stageOrder3 = Stage::factory()->create(['order' => 3]); // weight 0.8
+        $stageOrder5 = Stage::factory()->create(['order' => 5]); // weight 1.0
+
+        // In-range, not lost -> counted.
+        Deal::factory()->create([
+            'value' => 10000, 'probability' => 50, 'stage' => 'open',
+            'stage_id' => $stageOrder3->id, 'close_date' => '2026-02-10',
+        ]); // 10000 * 0.8 * 0.50 = 4000
+        Deal::factory()->create([
+            'value' => 20000, 'probability' => 80, 'stage' => 'open',
+            'stage_id' => $stageOrder5->id, 'close_date' => '2026-02-20',
+        ]); // 20000 * 1.0 * 0.80 = 16000
+
+        // Excluded: stage is "lost".
+        Deal::factory()->create([
+            'value' => 99999, 'probability' => 90, 'stage' => 'lost',
+            'stage_id' => $stageOrder5->id, 'close_date' => '2026-02-15',
+        ]);
+        // Excluded: close_date outside the window.
+        Deal::factory()->create([
+            'value' => 99999, 'probability' => 90, 'stage' => 'open',
+            'stage_id' => $stageOrder3->id, 'close_date' => '2025-06-01',
+        ]);
+
+        $forecast = $this->service->generateWeightedForecast(
+            Carbon::parse('2026-01-01'),
+            Carbon::parse('2026-03-31'),
+        );
+
+        $this->assertInstanceOf(SalesForecast::class, $forecast);
+        $this->assertEqualsWithDelta(20000.0, (float) $forecast->predicted_revenue, 0.01);
+        $this->assertSame(2, $forecast->deal_count);
+        $this->assertDatabaseHas('sales_forecasts', [
+            'id' => $forecast->id,
+            'forecast_type' => SalesForecast::TYPE_WEIGHTED,
+            'deal_count' => 2,
+        ]);
+    }
+
+    public function test_get_stage_weight_for_known_orders_and_default(): void
+    {
+        // No stage -> default 0.5
+        $this->assertSame(0.5, $this->invokeProtected('getStageWeight', [null]));
+
+        // order/5 + 0.2, capped at 1.0
+        $this->assertSame(0.2, $this->invokeProtected('getStageWeight', [new Stage(['order' => 0])]));
+        $this->assertSame(0.8, $this->invokeProtected('getStageWeight', [new Stage(['order' => 3])]));
+        $this->assertSame(1.0, $this->invokeProtected('getStageWeight', [new Stage(['order' => 5])]));
+        // Cap kicks in for high orders.
+        $this->assertSame(1.0, $this->invokeProtected('getStageWeight', [new Stage(['order' => 10])]));
+    }
+
+    public function test_calculate_confidence_returns_zero_for_empty_and_no_division_by_zero(): void
+    {
+        $this->assertEqualsWithDelta(0.0, (float) $this->invokeProtected('calculateConfidence', [collect([])]), 0.001);
+    }
+
+    public function test_calculate_confidence_weights_count_and_probability(): void
+    {
+        $deals = collect([
+            Deal::factory()->make(['probability' => 50]),
+            Deal::factory()->make(['probability' => 80]),
+        ]);
+
+        // countScore = min(100, 2/10*100) = 20; avgProbability = 65
+        // confidence = 20*0.3 + 65*0.7 = 51.5
+        $this->assertEqualsWithDelta(51.5, (float) $this->invokeProtected('calculateConfidence', [$deals]), 0.001);
+    }
+
+    public function test_generate_pipeline_forecast_is_scoped_to_the_pipeline(): void
+    {
+        $pipeline = Pipeline::factory()->create();
+        $otherPipeline = Pipeline::factory()->create();
+
+        // Counted: this pipeline, in range, not lost. value * probability/100.
+        Deal::factory()->create([
+            'pipeline_id' => $pipeline->id, 'value' => 10000, 'probability' => 50,
+            'stage' => 'open', 'close_date' => '2026-02-10',
+        ]); // 5000
+        Deal::factory()->create([
+            'pipeline_id' => $pipeline->id, 'value' => 40000, 'probability' => 25,
+            'stage' => 'open', 'close_date' => '2026-02-20',
+        ]); // 10000
+
+        // Excluded: lost / other pipeline / out of range.
+        Deal::factory()->create([
+            'pipeline_id' => $pipeline->id, 'value' => 99999, 'probability' => 99,
+            'stage' => 'lost', 'close_date' => '2026-02-15',
+        ]);
+        Deal::factory()->create([
+            'pipeline_id' => $otherPipeline->id, 'value' => 99999, 'probability' => 99,
+            'stage' => 'open', 'close_date' => '2026-02-15',
+        ]);
+        Deal::factory()->create([
+            'pipeline_id' => $pipeline->id, 'value' => 99999, 'probability' => 99,
+            'stage' => 'open', 'close_date' => '2025-01-01',
+        ]);
+
+        $forecast = $this->service->generatePipelineForecast(
+            $pipeline,
+            Carbon::parse('2026-01-01'),
+            Carbon::parse('2026-03-31'),
+        );
+
+        $this->assertInstanceOf(SalesForecast::class, $forecast);
+        $this->assertSame($pipeline->id, $forecast->pipeline_id);
+        $this->assertSame(SalesForecast::TYPE_PIPELINE, $forecast->forecast_type);
+        $this->assertEqualsWithDelta(15000.0, (float) $forecast->predicted_revenue, 0.01);
+        $this->assertSame(2, $forecast->deal_count);
+        $this->assertDatabaseHas('sales_forecasts', [
+            'id' => $forecast->id,
+            'pipeline_id' => $pipeline->id,
+            'forecast_type' => SalesForecast::TYPE_PIPELINE,
+        ]);
+    }
+}


### PR DESCRIPTION
## P1 core: forecasting fix, lead scoring, contact tags

First revenue-path (P1) round. Three independent TDD'd slices — and the forecasting one uncovered a live bug.

| Commit | What |
|--------|------|
| `df045f8` | **fix(forecast)**: `SalesForecastingService` was **untested and broken** — `generateWeightedForecast`/`generatePipelineForecast` queried `expected_close_date`/`status` (leads columns; deals use `close_date`/`stage`), so they threw at runtime; and `$deal->stage` returned the string column, shadowing the `Stage` relation, so stage-weighting silently collapsed to 0.2. Fixed + covered with tests (weighted math, stage weights, empty-set confidence, pipeline scoping). |
| `d3d19c8` | **feat(contacts)**: native polymorphic tags — team-scoped `Tag` + `taggables` pivot, `Contact::tags()`. |
| `07d97ba` | **feat(leads)**: `Lead::calculateScore()` reimplemented with documented, clamped rules (source / potential_value / contact / lifecycle) replacing the ad-hoc uncapped formula; rule-contribution tests added. |

### Testing
- **511 passed, 1 skipped, 0 failed** (`php artisan test`).
- New: `SalesForecastingServiceTest`, `ContactTagTest`, expanded `LeadScoringServiceTest`; updated `LeadTest`.
- `composer analyse` clean.

### Decisions / follow-ups
- **Forecasting still has drift** in `generateHistoricalForecast`, `getRevenueTrend`, `updateForecastActuals`, `generateAiForecast` — they query `status='won'`/`closed_at`, which don't exist on `deals`. Left unfixed: `closed_at` has no obvious deals equivalent, so it needs a schema/product decision, not a mechanical rename.
- **Lead scoring simplified**: the rewrite dropped the old activity-engagement bonus and the mql/sql lifecycle rungs. The old formula was buggy (uncapped, could return a float), so this ships a clean capped v1 — but if product wants engagement-weighted scoring, that signal needs re-adding. Also `'customer'` is scored in the rules but isn't in `Lead::LIFECYCLE_STAGES` (the mutator rejects it), so that branch is currently unreachable via Eloquent.
- Tags: only `Contact` wired so far; extend `morphToMany` to Deal/Lead/etc. as needed. UI (Filament) integration not included.
- MySQL still unverified from the container.
