### PR TITLE
Test + harden untested services: teams, email tracking, forecast

### DIFF
--- a/app/Actions/Fortify/CreateNewUserWithTeams.php
+++ b/app/Actions/Fortify/CreateNewUserWithTeams.php
@@ -3,6 +3,7 @@
 namespace App\Actions\Fortify;
 
 use App\Models\User;
+use App\Services\TeamManagementService;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;

--- a/app/Models/Contact.php
+++ b/app/Models/Contact.php
@@ -33,6 +33,7 @@ class Contact extends Model
         'lifecycle_stage',
         'company_id',
         'custom_fields',
+        'metadata',
     ];
 
     protected $with = ['notes', 'deals', 'activities', 'company'];
@@ -44,6 +45,7 @@ class Contact extends Model
     {
         return [
             'custom_fields' => 'array',
+            'metadata' => 'array',
         ];
     }
 

--- a/app/Services/SalesForecastingService.php
+++ b/app/Services/SalesForecastingService.php
@@ -42,8 +42,8 @@ class SalesForecastingService
         $historicalStart = $startDate->copy()->subYear();
         $historicalEnd = $endDate->copy()->subYear();
 
-        $historicalRevenue = Deal::where('status', 'won')
-            ->whereBetween('closed_at', [$historicalStart, $historicalEnd])
+        $historicalRevenue = Deal::where('stage', 'won')
+            ->whereBetween('close_date', [$historicalStart, $historicalEnd])
             ->sum('value');
 
         // Apply growth factor based on recent trends
@@ -179,12 +179,12 @@ class SalesForecastingService
      */
     protected function calculateGrowthFactor(): float
     {
-        $currentQuarter = Deal::where('status', 'won')
-            ->whereBetween('closed_at', [now()->startOfQuarter(), now()])
+        $currentQuarter = Deal::where('stage', 'won')
+            ->whereBetween('close_date', [now()->startOfQuarter(), now()])
             ->sum('value');
 
-        $previousQuarter = Deal::where('status', 'won')
-            ->whereBetween('closed_at', [
+        $previousQuarter = Deal::where('stage', 'won')
+            ->whereBetween('close_date', [
                 now()->subQuarter()->startOfQuarter(),
                 now()->subQuarter()->endOfQuarter(),
             ])
@@ -218,8 +218,8 @@ class SalesForecastingService
      */
     public function updateForecastActuals(SalesForecast $forecast): void
     {
-        $actualRevenue = Deal::where('status', 'won')
-            ->whereBetween('closed_at', [$forecast->period_start, $forecast->period_end])
+        $actualRevenue = Deal::where('stage', 'won')
+            ->whereBetween('close_date', [$forecast->period_start, $forecast->period_end])
             ->sum('value');
 
         $forecast->update([
@@ -269,8 +269,8 @@ class SalesForecastingService
             $startDate = $date->copy()->startOfMonth();
             $endDate = $date->copy()->endOfMonth();
 
-            $revenue = Deal::where('status', 'won')
-                ->whereBetween('closed_at', [$startDate, $endDate])
+            $revenue = Deal::where('stage', 'won')
+                ->whereBetween('close_date', [$startDate, $endDate])
                 ->sum('value');
 
             $data[] = [

--- a/app/Services/TeamManagementService.php
+++ b/app/Services/TeamManagementService.php
@@ -40,7 +40,7 @@ class TeamManagementService
         if (! $defaultTeam) {
             try {
                 $defaultTeam = $this->createDefaultTeamForUser($user);
-            } catch (Exception) {
+            } catch (\Throwable) {
                 // Fallback: create a personal team when no branch/default team exists
                 $defaultTeam = $this->createPersonalTeamForUser($user);
                 $user->current_team_id = $defaultTeam->id;
@@ -57,6 +57,7 @@ class TeamManagementService
     {
         if (! $user->belongsToTeam($team)) {
             $user->teams()->attach($team, ['role' => 'member']);
+            $user->unsetRelation('teams'); // drop cached (pre-attach) relation so switchTeam re-checks membership
         }
         $user->switchTeam($team);
     }

--- a/tests/Feature/EmailTrackingServiceTest.php
+++ b/tests/Feature/EmailTrackingServiceTest.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Contact;
+use App\Models\Email;
+use App\Models\EmailTracking;
+use App\Services\EmailTrackingService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class EmailTrackingServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private EmailTrackingService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new EmailTrackingService;
+    }
+
+    public function test_create_tracking_persists_row_linked_to_email_and_contact(): void
+    {
+        $email = Email::factory()->create();
+        $contact = Contact::factory()->create();
+
+        $tracking = $this->service->createTracking($email, $contact);
+
+        $this->assertInstanceOf(EmailTracking::class, $tracking);
+        $this->assertNotEmpty($tracking->tracking_id);
+        $this->assertNotNull($tracking->sent_at);
+        $this->assertDatabaseHas('email_trackings', [
+            'id' => $tracking->id,
+            'email_id' => $email->id,
+            'contact_id' => $contact->id,
+            'subject' => $email->subject,
+        ]);
+    }
+
+    public function test_record_open_persists_contact_engagement_metadata(): void
+    {
+        $email = Email::factory()->create();
+        $contact = Contact::factory()->create();
+        $tracking = $this->service->createTracking($email, $contact);
+
+        $this->service->recordOpen($tracking->tracking_id);
+
+        $contact->refresh();
+        $this->assertSame(1, $contact->metadata['email_engagement']['total_opens']);
+        $this->assertSame(1, $contact->metadata['email_engagement']['score']);
+    }
+
+    public function test_record_open_marks_tracking_opened_and_returns_true(): void
+    {
+        $tracking = EmailTracking::factory()->create();
+
+        $result = $this->service->recordOpen($tracking->tracking_id, 'Mozilla/5.0', '1.2.3.4');
+
+        $this->assertTrue($result);
+
+        $tracking->refresh();
+        $this->assertNotNull($tracking->opened_at);
+        $this->assertNotNull($tracking->first_opened_at);
+        $this->assertNotNull($tracking->last_opened_at);
+        $this->assertSame(1, $tracking->open_count);
+        $this->assertSame('Mozilla/5.0', $tracking->user_agent);
+        $this->assertSame('1.2.3.4', $tracking->ip_address);
+    }
+
+    public function test_record_open_returns_false_for_unknown_tracking_id(): void
+    {
+        $this->assertFalse($this->service->recordOpen('00000000-0000-0000-0000-000000000000'));
+    }
+
+    public function test_record_open_increments_open_count_on_repeat(): void
+    {
+        $tracking = EmailTracking::factory()->create();
+
+        $this->service->recordOpen($tracking->tracking_id);
+        $this->service->recordOpen($tracking->tracking_id);
+
+        $this->assertSame(2, $tracking->fresh()->open_count);
+    }
+
+    public function test_record_open_updates_contact_engagement_without_error(): void
+    {
+        // Exercises the contact-attached branch (updateContactEngagement).
+        $email = Email::factory()->create();
+        $contact = Contact::factory()->create();
+        $tracking = $this->service->createTracking($email, $contact);
+
+        $this->assertTrue($this->service->recordOpen($tracking->tracking_id));
+        $this->assertSame(1, $tracking->fresh()->open_count);
+    }
+
+    public function test_record_click_records_link_click_and_returns_true(): void
+    {
+        $tracking = EmailTracking::factory()->create();
+
+        $result = $this->service->recordClick(
+            $tracking->tracking_id,
+            'https://example.com/page',
+            'Mozilla/5.0',
+            '1.2.3.4'
+        );
+
+        $this->assertTrue($result);
+
+        $tracking->refresh();
+        $this->assertNotNull($tracking->clicked_at);
+        $this->assertNotNull($tracking->first_clicked_at);
+        $this->assertSame(1, $tracking->click_count);
+
+        $this->assertDatabaseHas('email_link_clicks', [
+            'email_tracking_id' => $tracking->id,
+            'url' => 'https://example.com/page',
+        ]);
+    }
+
+    public function test_record_click_returns_false_for_unknown_tracking_id(): void
+    {
+        $this->assertFalse($this->service->recordClick('nope', 'https://example.com'));
+    }
+
+    public function test_signature_is_deterministic_and_url_round_trips(): void
+    {
+        $tracking = EmailTracking::factory()->create();
+        $original = 'https://example.com/path?a=1&b=2';
+        $encoded = base64_encode($original);
+
+        $sig = $this->service->generateLinkSignature($tracking->tracking_id, $encoded);
+
+        // Same inputs -> same signature (this is what the controller's hash_equals relies on).
+        $this->assertSame($sig, $this->service->generateLinkSignature($tracking->tracking_id, $encoded));
+        $this->assertNotEmpty($sig);
+
+        // Encoded URL decodes back to the original.
+        $this->assertSame($original, $this->service->decodeTrackedUrl($encoded));
+    }
+
+    public function test_tampered_url_produces_a_different_signature(): void
+    {
+        $tracking = EmailTracking::factory()->create();
+        $goodSig = $this->service->generateLinkSignature($tracking->tracking_id, base64_encode('https://example.com'));
+        $tamperedSig = $this->service->generateLinkSignature($tracking->tracking_id, base64_encode('https://evil.com'));
+
+        $this->assertNotSame($goodSig, $tamperedSig);
+        $this->assertFalse(hash_equals($goodSig, $tamperedSig));
+    }
+
+    public function test_decode_invalid_base64_returns_empty_string(): void
+    {
+        $this->assertSame('', $this->service->decodeTrackedUrl('!!!not-valid-base64!!!'));
+    }
+
+    public function test_inject_tracking_pixel_before_closing_body(): void
+    {
+        $tracking = EmailTracking::factory()->create();
+        $pixelUrl = route('email.tracking.pixel', ['tracking_id' => $tracking->tracking_id]);
+
+        $result = $this->service->injectTrackingPixel('<html><body><p>Hi</p></body></html>', $tracking);
+
+        $this->assertStringContainsString('<img', $result);
+        $this->assertStringContainsString($pixelUrl, $result);
+        // Pixel is placed before the closing body tag, not after it.
+        $this->assertLessThan(strpos($result, '</body>'), strpos($result, '<img'));
+    }
+
+    public function test_inject_tracking_pixel_appends_when_no_body_tag(): void
+    {
+        $tracking = EmailTracking::factory()->create();
+
+        $result = $this->service->injectTrackingPixel('<p>Hi</p>', $tracking);
+
+        $this->assertStringStartsWith('<p>Hi</p><img', $result);
+    }
+
+    public function test_replace_links_rewrites_href_to_tracked_url(): void
+    {
+        $tracking = EmailTracking::factory()->create();
+        $html = '<a href="https://example.com/page">Click</a>';
+
+        $result = $this->service->replaceLinksWithTracked($html, $tracking);
+
+        $this->assertStringNotContainsString('href="https://example.com/page"', $result);
+        $this->assertStringContainsString('email/track/link/'.$tracking->tracking_id, $result);
+    }
+
+    public function test_replace_links_skips_mailto_tel_and_anchors(): void
+    {
+        $tracking = EmailTracking::factory()->create();
+        $html = '<a href="mailto:x@y.com">Mail</a><a href="tel:+123">Call</a><a href="#top">Top</a>';
+
+        $this->assertSame($html, $this->service->replaceLinksWithTracked($html, $tracking));
+    }
+
+    public function test_process_email_html_adds_both_tracking_and_rewrites_links(): void
+    {
+        $tracking = EmailTracking::factory()->create();
+        $html = '<html><body><a href="https://example.com">Go</a></body></html>';
+
+        $result = $this->service->processEmailHtml($html, $tracking);
+
+        $this->assertStringContainsString('email/track/link/'.$tracking->tracking_id, $result);
+        $this->assertStringContainsString('email/track/pixel/'.$tracking->tracking_id, $result);
+        $this->assertStringNotContainsString('href="https://example.com"', $result);
+    }
+}

--- a/tests/Feature/TeamManagementServiceTest.php
+++ b/tests/Feature/TeamManagementServiceTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Team;
+use App\Models\User;
+use App\Services\TeamManagementService;
+use Exception;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TeamManagementServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private TeamManagementService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = app(TeamManagementService::class);
+    }
+
+    public function test_creates_personal_team_owned_by_user(): void
+    {
+        $user = User::factory()->create(['name' => 'Ada']);
+
+        $team = $this->service->createPersonalTeamForUser($user);
+
+        $this->assertTrue($team->personal_team);
+        $this->assertSame("Ada's Team", $team->name);
+        $this->assertTrue($user->ownsTeam($team));
+        $this->assertDatabaseHas('teams', [
+            'id' => $team->id,
+            'user_id' => $user->id,
+            'personal_team' => true,
+        ]);
+    }
+
+    public function test_assign_user_to_team_adds_membership_and_switches_current_team(): void
+    {
+        // Team owned by someone else — the realistic "join a shared team" case.
+        $team = Team::factory()->create(['personal_team' => false]);
+        $user = User::factory()->create();
+
+        $this->service->assignUserToTeam($user, $team);
+
+        $this->assertTrue($user->fresh()->belongsToTeam($team));
+        $this->assertDatabaseHas('team_user', [
+            'team_id' => $team->id,
+            'user_id' => $user->id,
+            'role' => 'member',
+        ]);
+        $this->assertSame($team->id, $user->fresh()->current_team_id);
+    }
+
+    public function test_switch_team_throws_when_user_is_not_a_member(): void
+    {
+        $team = Team::factory()->create();
+        $user = User::factory()->create();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('User does not belong to the specified team.');
+
+        $this->service->switchTeam($user, $team);
+    }
+
+    public function test_switch_team_switches_current_team_for_a_member(): void
+    {
+        $team = Team::factory()->create(['personal_team' => false]);
+        $user = User::factory()->create();
+        $user->teams()->attach($team, ['role' => 'member']);
+
+        $this->service->switchTeam($user, $team);
+
+        $this->assertSame($team->id, $user->fresh()->current_team_id);
+    }
+
+    public function test_assign_user_to_default_team_uses_existing_non_personal_team(): void
+    {
+        $defaultTeam = Team::factory()->create(['personal_team' => false]);
+        $user = User::factory()->create();
+
+        $this->service->assignUserToDefaultTeam($user);
+
+        $this->assertTrue($user->fresh()->belongsToTeam($defaultTeam));
+        $this->assertSame($defaultTeam->id, $user->fresh()->current_team_id);
+    }
+
+    public function test_assign_user_to_default_team_falls_back_to_personal_team_when_none_exists(): void
+    {
+        // Fresh DB: no non-personal team and no Branch model/table exist,
+        // so the service must fall back to creating a personal team.
+        $user = User::factory()->create();
+
+        $this->service->assignUserToDefaultTeam($user);
+
+        $user->refresh();
+        $personalTeam = $user->ownedTeams()->where('personal_team', true)->first();
+        $this->assertNotNull($personalTeam, 'Expected a personal team fallback to be created.');
+        $this->assertSame($personalTeam->id, $user->current_team_id);
+    }
+}

--- a/tests/Unit/SalesForecastingServiceTest.php
+++ b/tests/Unit/SalesForecastingServiceTest.php
@@ -75,6 +75,85 @@ class SalesForecastingServiceTest extends TestCase
         ]);
     }
 
+    public function test_generate_historical_forecast_sums_won_deals_from_same_period_last_year(): void
+    {
+        // Growth factor reads now(); freeze it. No deals fall in the current/previous
+        // quarter windows, so calculateGrowthFactor() returns 0 -> predicted == historical.
+        Carbon::setTestNow('2026-07-06');
+
+        // Forecast period 2026-Q1 -> historical window is 2025-01-01..2025-03-31.
+        Deal::factory()->create(['value' => 5000, 'stage' => 'won', 'close_date' => '2025-02-10']);
+        Deal::factory()->create(['value' => 3000, 'stage' => 'won', 'close_date' => '2025-03-15']);
+        // Excluded: won but outside the historical window.
+        Deal::factory()->create(['value' => 99999, 'stage' => 'won', 'close_date' => '2025-06-01']);
+        // Excluded: inside the window but not won.
+        Deal::factory()->create(['value' => 99999, 'stage' => 'lost', 'close_date' => '2025-02-15']);
+
+        $forecast = $this->service->generateHistoricalForecast(
+            Carbon::parse('2026-01-01'),
+            Carbon::parse('2026-03-31'),
+        );
+
+        $this->assertInstanceOf(SalesForecast::class, $forecast);
+        $this->assertSame(SalesForecast::TYPE_HISTORICAL, $forecast->forecast_type);
+        $this->assertEqualsWithDelta(8000.0, (float) $forecast->metadata['historical_revenue'], 0.01);
+        $this->assertEqualsWithDelta(0.0, (float) $forecast->metadata['growth_factor'], 0.001);
+        $this->assertEqualsWithDelta(8000.0, (float) $forecast->predicted_revenue, 0.01);
+
+        Carbon::setTestNow();
+    }
+
+    public function test_update_forecast_actuals_sums_won_deals_in_the_forecast_period(): void
+    {
+        $forecast = SalesForecast::create([
+            'name' => 'Q1 Forecast',
+            'period_start' => '2026-01-01',
+            'period_end' => '2026-03-31',
+            'forecast_type' => SalesForecast::TYPE_WEIGHTED,
+            'predicted_revenue' => 12345,
+            'confidence_level' => 50,
+        ]);
+
+        // Counted: won, in period.
+        Deal::factory()->create(['value' => 4000, 'stage' => 'won', 'close_date' => '2026-01-20']);
+        Deal::factory()->create(['value' => 2500, 'stage' => 'won', 'close_date' => '2026-03-10']);
+        // Excluded: not won.
+        Deal::factory()->create(['value' => 99999, 'stage' => 'lost', 'close_date' => '2026-02-01']);
+        // Excluded: won but out of period.
+        Deal::factory()->create(['value' => 99999, 'stage' => 'won', 'close_date' => '2026-05-01']);
+
+        $this->service->updateForecastActuals($forecast);
+
+        $this->assertEqualsWithDelta(6500.0, (float) $forecast->fresh()->actual_revenue, 0.01);
+    }
+
+    public function test_get_revenue_trend_returns_monthly_won_totals(): void
+    {
+        Carbon::setTestNow('2026-07-15');
+
+        // Trend window for 3 months from 2026-07-15: May, June, July 2026.
+        Deal::factory()->create(['value' => 1000, 'stage' => 'won', 'close_date' => '2026-05-10']);
+        Deal::factory()->create(['value' => 2000, 'stage' => 'won', 'close_date' => '2026-06-20']);
+        Deal::factory()->create(['value' => 4000, 'stage' => 'won', 'close_date' => '2026-07-05']);
+        // Excluded: not won.
+        Deal::factory()->create(['value' => 99999, 'stage' => 'lost', 'close_date' => '2026-06-10']);
+        // Excluded: won but before the window.
+        Deal::factory()->create(['value' => 99999, 'stage' => 'won', 'close_date' => '2026-01-01']);
+
+        $trend = $this->service->getRevenueTrend(3);
+
+        $this->assertCount(3, $trend);
+        $this->assertSame('May 2026', $trend[0]['month']);
+        $this->assertEqualsWithDelta(1000.0, $trend[0]['revenue'], 0.01);
+        $this->assertSame('Jun 2026', $trend[1]['month']);
+        $this->assertEqualsWithDelta(2000.0, $trend[1]['revenue'], 0.01);
+        $this->assertSame('Jul 2026', $trend[2]['month']);
+        $this->assertEqualsWithDelta(4000.0, $trend[2]['revenue'], 0.01);
+        $this->assertEqualsWithDelta(7000.0, array_sum(array_column($trend, 'revenue')), 0.01);
+
+        Carbon::setTestNow();
+    }
+
     public function test_get_stage_weight_for_known_orders_and_default(): void
     {
         // No stage -> default 0.5


### PR DESCRIPTION
## Test + harden three untested services (each was broken)

Same play as last round: point TDD at untested PARTIAL services; each turned up real, shipped bugs.

| Commit | What |
|--------|------|
| `d123bac` | **fix(teams)**: `TeamManagementService` was untested and **registration was broken** — (1) `CreateNewUserWithTeams` referenced `TeamManagementService::class` unqualified → resolved to a nonexistent `App\Actions\Fortify\TeamManagementService` (class-not-found); (2) `assignUserToDefaultTeam` caught `Exception` but the missing `Branch` class throws `Error`, so the personal-team fallback never ran on a fresh DB; (3) a stale relation cache left `current_team_id` null after a team switch. All fixed + 6 tests. |
| `9bb35ce` | **fix(email)**: `EmailTrackingService::updateContactEngagement` wrote `contact.metadata`, but `Contact` had no `metadata` in `$fillable`/casts → every open/click **silently dropped** the engagement update. Added the fillable key + array cast. + 16 tests covering open/click/signature/HTML-rewrite (the tested service paths were otherwise correct). |
| `a6bdba3` | **fix(forecast)**: the remaining 4 `SalesForecastingService` methods (`generateHistoricalForecast`, `calculateGrowthFactor`, `updateForecastActuals`, `getRevenueTrend`) still queried `status`/`closed_at` (leads columns) on deals → runtime fatal. Switched to `stage`/`close_date` and covered them. The service is now fully drift-free + tested. |

### Testing
- **536 passed, 1 skipped, 0 failed** (`php artisan test`).
- New: `TeamManagementServiceTest`, `EmailTrackingServiceTest`, expanded `SalesForecastingServiceTest`.
- `composer analyse` clean.

### Follow-ups
- `TeamManagementService::createDefaultTeamForUser()` references a `Branch` model/table that doesn't exist — dead code; remove it or build the Branch feature (it's the only remaining `use App\Models\Branch` reference).
- Email engagement now persists; consider surfacing `metadata.email_engagement` in the UI / lead scoring.
- MySQL still unverified from the container.
