### PR TITLE
Test + harden: workflow engine, live chat, personalization (+ MySQL verify)

### DIFF
--- a/app/Models/ChatMessage.php
+++ b/app/Models/ChatMessage.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use App\Traits\IsTenantModel;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ChatMessage extends Model
+{
+    use HasFactory;
+    use IsTenantModel;
+
+    protected $fillable = [
+        'chat_id',
+        'sender',
+        'sender_id',
+        'content',
+        'team_id',
+    ];
+
+    public function chat(): BelongsTo
+    {
+        return $this->belongsTo(LiveChat::class, 'chat_id');
+    }
+}

--- a/app/Models/LiveChat.php
+++ b/app/Models/LiveChat.php
@@ -55,9 +55,9 @@ class LiveChat extends Model
         return $this->belongsTo(User::class);
     }
 
-    public function messages()
+    public function messages(): \Illuminate\Database\Eloquent\Relations\HasMany
     {
-        return $this->hasMany(Message::class, 'chat_id');
+        return $this->hasMany(ChatMessage::class, 'chat_id');
     }
 
     public function getDurationAttribute(): ?int

--- a/app/Models/Workflow.php
+++ b/app/Models/Workflow.php
@@ -7,6 +7,7 @@ namespace App\Models;
 use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Workflow extends Model
 {
@@ -44,12 +45,14 @@ class Workflow extends Model
         return $this->belongsToMany(Deal::class);
     }
 
-    public function workflowTriggers()
+    /** @return HasMany<WorkflowTrigger, $this> */
+    public function workflowTriggers(): HasMany
     {
         return $this->hasMany(WorkflowTrigger::class);
     }
 
-    public function workflowActions()
+    /** @return HasMany<WorkflowAction, $this> */
+    public function workflowActions(): HasMany
     {
         return $this->hasMany(WorkflowAction::class);
     }

--- a/app/Services/LiveChatService.php
+++ b/app/Services/LiveChatService.php
@@ -2,9 +2,10 @@
 
 namespace App\Services;
 
+use App\Models\ChatMessage;
 use App\Models\Contact;
 use App\Models\LiveChat;
-use App\Models\Message;
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Auth;
 
@@ -76,14 +77,12 @@ class LiveChatService
     /**
      * Send message in chat
      */
-    public function sendMessage(LiveChat $chat, string $content, bool $isAgent = false): Message
+    public function sendMessage(LiveChat $chat, string $content, bool $isAgent = false): ChatMessage
     {
-        return Message::create([
-            'chat_id' => $chat->id,
-            'sender_type' => $isAgent ? 'agent' : 'visitor',
+        return $chat->messages()->create([
+            'sender' => $isAgent ? 'agent' : 'visitor',
             'sender_id' => $isAgent ? Auth::id() : null,
             'content' => $content,
-            'sent_at' => now(),
         ]);
     }
 

--- a/app/Services/WorkflowAutomationService.php
+++ b/app/Services/WorkflowAutomationService.php
@@ -29,7 +29,7 @@ class WorkflowAutomationService
      */
     public function trigger(string $triggerType, $entity, array $context = []): void
     {
-        $workflows = Workflow::whereHas('triggers', function ($query) use ($triggerType): void {
+        $workflows = Workflow::whereHas('workflowTriggers', function ($query) use ($triggerType): void {
             $query->where('type', $triggerType)
                 ->where('is_active', true);
         })->where('is_active', true)->get();
@@ -58,7 +58,7 @@ class WorkflowAutomationService
                 'started_at' => now(),
             ]);
 
-            $actions = $workflow->actions()->orderBy('order')->get();
+            $actions = $workflow->workflowActions()->orderBy('order')->get();
 
             foreach ($actions as $action) {
                 if (! $action->is_active) {

--- a/database/factories/LiveChatFactory.php
+++ b/database/factories/LiveChatFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\LiveChat;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class LiveChatFactory extends Factory
+{
+    protected $model = LiveChat::class;
+
+    public function definition(): array
+    {
+        return [
+            'visitor_id' => uniqid('visitor_'),
+            'status' => LiveChat::STATUS_WAITING,
+            'visitor_name' => $this->faker->name(),
+            'visitor_email' => $this->faker->unique()->safeEmail(),
+            'started_at' => now(),
+        ];
+    }
+}

--- a/database/migrations/2026_07_06_150000_create_chat_messages_table.php
+++ b/database/migrations/2026_07_06_150000_create_chat_messages_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Dedicated store for live-chat messages. The general `messages` table is a
+ * different domain (channel/thread/ticket/unified-inbox), so live chat gets its
+ * own table keyed on chat_id — matching LiveChat::messages().
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('chat_messages', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('chat_id')->constrained('live_chats')->cascadeOnDelete();
+            $table->string('sender'); // 'agent' | 'visitor'
+            $table->foreignId('sender_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->text('content');
+            $table->foreignId('team_id')->nullable()->constrained()->nullOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('chat_messages');
+    }
+};

--- a/tests/Feature/LiveChatServiceTest.php
+++ b/tests/Feature/LiveChatServiceTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\ChatMessage;
+use App\Models\LiveChat;
+use App\Models\User;
+use App\Services\LiveChatService;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LiveChatServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private LiveChatService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new LiveChatService;
+    }
+
+    public function test_start_chat_creates_a_waiting_chat_with_visitor_data(): void
+    {
+        $chat = $this->service->startChat([
+            'visitor_id' => 'visitor_abc',
+            'name' => 'Ada Lovelace',
+            'email' => 'ada@example.com',
+        ]);
+
+        $this->assertInstanceOf(LiveChat::class, $chat);
+        $this->assertTrue($chat->exists);
+        $this->assertSame(LiveChat::STATUS_WAITING, $chat->status);
+        $this->assertSame('visitor_abc', $chat->visitor_id);
+        $this->assertSame('Ada Lovelace', $chat->visitor_name);
+        $this->assertSame('ada@example.com', $chat->visitor_email);
+        $this->assertNotNull($chat->started_at);
+        $this->assertDatabaseHas('live_chats', [
+            'visitor_id' => 'visitor_abc',
+            'status' => LiveChat::STATUS_WAITING,
+        ]);
+    }
+
+    public function test_start_chat_defaults_visitor_name_when_missing(): void
+    {
+        $chat = $this->service->startChat([]);
+
+        $this->assertSame('Anonymous', $chat->visitor_name);
+        $this->assertNotEmpty($chat->visitor_id);
+    }
+
+    public function test_assign_chat_sets_agent_and_moves_status_to_active(): void
+    {
+        $chat = LiveChat::factory()->create(['status' => LiveChat::STATUS_WAITING]);
+        $agent = User::factory()->create();
+
+        $this->service->assignChat($chat, $agent->id);
+
+        $chat->refresh();
+        $this->assertSame($agent->id, $chat->user_id);
+        $this->assertSame(LiveChat::STATUS_ACTIVE, $chat->status);
+    }
+
+    public function test_end_chat_marks_ended_and_stores_rating_and_feedback(): void
+    {
+        $chat = LiveChat::factory()->create(['status' => LiveChat::STATUS_ACTIVE]);
+
+        $this->service->endChat($chat, 5, 'Great support');
+
+        $chat->refresh();
+        $this->assertSame(LiveChat::STATUS_ENDED, $chat->status);
+        $this->assertNotNull($chat->ended_at);
+        $this->assertSame(5, $chat->rating);
+        $this->assertSame('Great support', $chat->feedback);
+    }
+
+    public function test_send_message_creates_message_linked_to_chat_from_agent(): void
+    {
+        $chat = LiveChat::factory()->create();
+
+        $message = $this->service->sendMessage($chat, 'Hello there', true);
+
+        $this->assertInstanceOf(ChatMessage::class, $message);
+        $this->assertTrue($message->exists);
+        $this->assertSame('Hello there', $message->content);
+        $this->assertSame('agent', $message->sender);
+        $this->assertSame($chat->id, $message->chat_id);
+    }
+
+    public function test_send_message_defaults_to_visitor_sender(): void
+    {
+        $chat = LiveChat::factory()->create();
+
+        $message = $this->service->sendMessage($chat, 'I need help');
+
+        $this->assertSame('visitor', $message->sender);
+        $this->assertSame('I need help', $message->content);
+    }
+
+    public function test_get_active_chats_returns_only_active_chats(): void
+    {
+        LiveChat::factory()->create(['status' => LiveChat::STATUS_WAITING]);
+        $active = LiveChat::factory()->create(['status' => LiveChat::STATUS_ACTIVE]);
+        LiveChat::factory()->create(['status' => LiveChat::STATUS_ENDED]);
+
+        $result = $this->service->getActiveChats();
+
+        $this->assertInstanceOf(Collection::class, $result);
+        $this->assertCount(1, $result);
+        $this->assertSame($active->id, $result->first()->id);
+    }
+
+    public function test_get_active_chats_filters_by_user_id(): void
+    {
+        $agent = User::factory()->create();
+        $other = User::factory()->create();
+        $mine = LiveChat::factory()->create([
+            'status' => LiveChat::STATUS_ACTIVE,
+            'user_id' => $agent->id,
+        ]);
+        LiveChat::factory()->create([
+            'status' => LiveChat::STATUS_ACTIVE,
+            'user_id' => $other->id,
+        ]);
+
+        $result = $this->service->getActiveChats($agent->id);
+
+        $this->assertCount(1, $result);
+        $this->assertSame($mine->id, $result->first()->id);
+    }
+
+    public function test_get_waiting_chats_returns_only_waiting_chats(): void
+    {
+        $waiting = LiveChat::factory()->create(['status' => LiveChat::STATUS_WAITING]);
+        LiveChat::factory()->create(['status' => LiveChat::STATUS_ACTIVE]);
+        LiveChat::factory()->create(['status' => LiveChat::STATUS_ENDED]);
+
+        $result = $this->service->getWaitingChats();
+
+        $this->assertCount(1, $result);
+        $this->assertSame($waiting->id, $result->first()->id);
+    }
+}

--- a/tests/Feature/WorkflowAutomationServiceTest.php
+++ b/tests/Feature/WorkflowAutomationServiceTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Contact;
+use App\Models\Workflow;
+use App\Models\WorkflowAction;
+use App\Models\WorkflowCondition;
+use App\Models\WorkflowExecution;
+use App\Models\WorkflowTrigger;
+use App\Services\WorkflowAutomationService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class WorkflowAutomationServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function service(): WorkflowAutomationService
+    {
+        return app(WorkflowAutomationService::class);
+    }
+
+    /** update_contact is a schema-safe, observable action (maps to real Contact columns). */
+    private function updateContactAction(Workflow $workflow, string $status = 'converted'): WorkflowAction
+    {
+        return WorkflowAction::create([
+            'workflow_id' => $workflow->id,
+            'type' => WorkflowAction::TYPE_UPDATE_CONTACT,
+            'name' => 'Set status',
+            'config' => ['fields' => ['status' => $status]],
+            'order' => 1,
+            'is_active' => true,
+        ]);
+    }
+
+    public function test_execute_workflow_runs_actions_and_records_completed_execution(): void
+    {
+        $contact = Contact::factory()->create(['status' => 'lead']);
+        $workflow = Workflow::factory()->create(['is_active' => true]);
+        $this->updateContactAction($workflow);
+
+        $execution = $this->service()->executeWorkflow($workflow, $contact);
+
+        $this->assertInstanceOf(WorkflowExecution::class, $execution);
+        $this->assertSame(WorkflowExecution::STATUS_COMPLETED, $execution->status);
+        $this->assertSame($workflow->id, $execution->workflow_id);
+        $this->assertSame(Contact::class, $execution->entity_type);
+        $this->assertSame($contact->id, $execution->entity_id);
+        // execution is reachable via the workflow relation
+        $this->assertTrue($workflow->executions()->whereKey($execution->id)->exists());
+        // the action actually ran
+        $this->assertDatabaseHas('contacts', ['id' => $contact->id, 'status' => 'converted']);
+    }
+
+    public function test_trigger_executes_workflow_with_matching_trigger(): void
+    {
+        $contact = Contact::factory()->create(['status' => 'lead']);
+        $workflow = Workflow::factory()->create(['is_active' => true]);
+        WorkflowTrigger::create([
+            'workflow_id' => $workflow->id,
+            'type' => WorkflowTrigger::TYPE_CONTACT_CREATED,
+            'is_active' => true,
+        ]);
+        $this->updateContactAction($workflow);
+
+        $this->service()->trigger(WorkflowTrigger::TYPE_CONTACT_CREATED, $contact);
+
+        $this->assertSame(1, WorkflowExecution::count());
+        $this->assertSame(WorkflowExecution::STATUS_COMPLETED, WorkflowExecution::first()->status);
+        $this->assertDatabaseHas('contacts', ['id' => $contact->id, 'status' => 'converted']);
+    }
+
+    public function test_trigger_ignores_non_matching_trigger(): void
+    {
+        $contact = Contact::factory()->create();
+        $workflow = Workflow::factory()->create(['is_active' => true]);
+        WorkflowTrigger::create([
+            'workflow_id' => $workflow->id,
+            'type' => WorkflowTrigger::TYPE_CONTACT_CREATED,
+            'is_active' => true,
+        ]);
+
+        $this->service()->trigger(WorkflowTrigger::TYPE_DEAL_CREATED, $contact);
+
+        $this->assertSame(0, WorkflowExecution::count());
+    }
+
+    public function test_condition_blocks_action_when_not_met(): void
+    {
+        $contact = Contact::factory()->create(['status' => 'lead']);
+        $workflow = Workflow::factory()->create(['is_active' => true]);
+        $action = $this->updateContactAction($workflow);
+        WorkflowCondition::create([
+            'workflow_action_id' => $action->id,
+            'field' => 'status',
+            'operator' => WorkflowCondition::OPERATOR_EQUALS,
+            'value' => 'vip', // contact status is 'lead' => condition false
+            'logical_operator' => 'and',
+        ]);
+
+        $execution = $this->service()->executeWorkflow($workflow, $contact);
+
+        // execution completes, but the gated action did NOT run
+        $this->assertSame(WorkflowExecution::STATUS_COMPLETED, $execution->status);
+        $this->assertDatabaseHas('contacts', ['id' => $contact->id, 'status' => 'lead']);
+    }
+
+    public function test_condition_allows_action_when_met(): void
+    {
+        $contact = Contact::factory()->create(['status' => 'lead']);
+        $workflow = Workflow::factory()->create(['is_active' => true]);
+        $action = $this->updateContactAction($workflow);
+        WorkflowCondition::create([
+            'workflow_action_id' => $action->id,
+            'field' => 'status',
+            'operator' => WorkflowCondition::OPERATOR_EQUALS,
+            'value' => 'lead', // matches => condition true
+            'logical_operator' => 'and',
+        ]);
+
+        $this->service()->executeWorkflow($workflow, $contact);
+
+        $this->assertDatabaseHas('contacts', ['id' => $contact->id, 'status' => 'converted']);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,9 +4,24 @@ declare(strict_types=1);
 
 namespace Tests;
 
+use App\Support\AccessContext;
+use App\Support\TenantContext;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use Illuminate\Support\Carbon;
 
 abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
+
+    protected function tearDown(): void
+    {
+        // Process-level statics survive PHPUnit's per-test app reset, so a test
+        // that leaves a tenant/owner scope or a frozen clock set would silently
+        // poison later tests. Reset them for every test.
+        TenantContext::clear();
+        AccessContext::clear();
+        Carbon::setTestNow();
+
+        parent::tearDown();
+    }
 }

--- a/tests/Unit/PersonalizationServiceTest.php
+++ b/tests/Unit/PersonalizationServiceTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\Models\LandingPage;
+use App\Services\PersonalizationService;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+class PersonalizationServiceTest extends TestCase
+{
+    private PersonalizationService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new PersonalizationService;
+    }
+
+    /**
+     * @return array<string, array{0: array<string, mixed>, 1: string}>
+     */
+    public static function segmentProvider(): array
+    {
+        return [
+            'customer stage wins'            => [['lifecycle_stage' => 'customer', 'activity_count' => 0], 'customer'],
+            'opportunity stage'              => [['lifecycle_stage' => 'opportunity'], 'opportunity'],
+            'sql stage'                      => [['lifecycle_stage' => 'sql'], 'sales_qualified'],
+            'mql stage'                      => [['lifecycle_stage' => 'mql'], 'marketing_qualified'],
+            'activity>=5 => marketing'       => [['activity_count' => 5], 'marketing_qualified'],
+            'activity 8 no stage => mkt'     => [['activity_count' => 8], 'marketing_qualified'],
+            'lead stage'                     => [['lifecycle_stage' => 'lead'], 'engaged_lead'],
+            'activity>=3 => engaged'         => [['activity_count' => 3], 'engaged_lead'],
+            'subscriber stage'               => [['lifecycle_stage' => 'subscriber'], 'prospect'],
+            'activity>=1 => prospect'        => [['activity_count' => 1], 'prospect'],
+            'empty => new_visitor'           => [[], 'new_visitor'],
+            'zero activity => new_visitor'   => [['activity_count' => 0], 'new_visitor'],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $userData
+     */
+    #[DataProvider('segmentProvider')]
+    public function test_determine_segment_maps_user_data_to_expected_segment(array $userData, string $expected): void
+    {
+        $this->assertSame($expected, $this->service->determineSegment($userData));
+    }
+
+    public function test_apply_segment_blocks_keeps_matching_block_and_strips_others(): void
+    {
+        $content = '[segment:prospect]Welcome prospect![/segment]'
+            .'[segment:customer]Thanks customer![/segment]Common';
+
+        $result = $this->service->applySegmentBlocks($content, 'prospect');
+
+        $this->assertSame('Welcome prospect!Common', $result);
+    }
+
+    public function test_apply_segment_blocks_supports_comma_separated_segments(): void
+    {
+        $content = '[segment:prospect, engaged_lead]Hi there![/segment]';
+
+        $this->assertSame('Hi there!', $this->service->applySegmentBlocks($content, 'engaged_lead'));
+        $this->assertSame('', $this->service->applySegmentBlocks($content, 'customer'));
+    }
+
+    public function test_apply_segment_blocks_handles_not_segment_inverse(): void
+    {
+        $content = '[not_segment:customer]Sign up now[/not_segment]';
+
+        $this->assertSame('Sign up now', $this->service->applySegmentBlocks($content, 'prospect'));
+        $this->assertSame('', $this->service->applySegmentBlocks($content, 'customer'));
+    }
+
+    public function test_apply_conditional_content_includes_only_matching_conditions(): void
+    {
+        $content = '[if:industry=tech]Tech content[/if][if:industry=finance]Finance content[/if]';
+
+        $result = $this->service->applyConditionalContent($content, ['industry' => 'tech']);
+
+        $this->assertSame('Tech content', $result);
+    }
+
+    public function test_apply_conditional_content_excludes_when_key_missing_or_mismatched(): void
+    {
+        $content = '[if:plan=pro]Pro perks[/if]';
+
+        $this->assertSame('', $this->service->applyConditionalContent($content, []));
+        $this->assertSame('', $this->service->applyConditionalContent($content, ['plan' => 'free']));
+        $this->assertSame('Pro perks', $this->service->applyConditionalContent($content, ['plan' => 'pro']));
+    }
+
+    public function test_personalize_content_runs_end_to_end(): void
+    {
+        $page = new LandingPage;
+        $page->content = 'Hello {name}! '
+            .'[segment:prospect]You are a prospect.[/segment]'
+            .'[segment:customer]VIP treatment.[/segment]'
+            .'[if:industry=tech]Tech offer[/if]'
+            .'[not_segment:customer]Join us[/not_segment]';
+
+        $userData = [
+            'name' => 'Alice',
+            'lifecycle_stage' => 'subscriber', // => prospect segment
+            'industry' => 'tech',
+        ];
+
+        $result = $this->service->personalizeContent($page, $userData);
+
+        // Placeholder replaced.
+        $this->assertStringContainsString('Hello Alice!', $result);
+        // Matching segment kept, non-matching stripped.
+        $this->assertStringContainsString('You are a prospect.', $result);
+        $this->assertStringNotContainsString('VIP treatment.', $result);
+        // Conditional matched; not_segment (inverse) kept for a non-customer.
+        $this->assertStringContainsString('Tech offer', $result);
+        $this->assertStringContainsString('Join us', $result);
+        // No leftover markup.
+        $this->assertStringNotContainsString('[segment', $result);
+        $this->assertStringNotContainsString('[/segment', $result);
+        $this->assertStringNotContainsString('[if:', $result);
+        $this->assertStringNotContainsString('[not_segment', $result);
+    }
+}


### PR DESCRIPTION
## Test + harden 3 more untested services (+ MySQL verification)

| Commit | What |
|--------|------|
| `9e2ec5a` | **fix(workflow)** — the automation engine (C5) was **dead**: `whereHas('triggers')` / `$workflow->actions()` hit JSON columns, not the `workflowTriggers()`/`workflowActions()` relations, so no trigger ever matched and every execution was silently caught → `failed`. Fixed + typed the relations + 5 tests. |
| `1527e88` | **feat(livechat)** — `sendMessage` wrote into the general `messages` table (wrong domain; would pollute the unified inbox) and eager-loaded a broken relation. Added a dedicated `chat_messages` table + `ChatMessage` model, repointed `LiveChat::messages()`, rewrote `sendMessage`. Fixed a latent `?Carbon` type-hint bug in `getChatAnalytics`. 9 tests. |
| `1e5d68c` | **test(personalization)** — 18 tests; no bugs, the service was correct. |
| `e8541cd` | **test** — reset `TenantContext`/`AccessContext`/`Carbon::setTestNow` in the base `TestCase` tearDown (a leaked static was poisoning an unrelated search test in the full suite). |

### Testing
- **569 passed, 1 skipped, 0 failed**.
- `composer analyse` clean (typed the Workflow relations with generics so larastan resolves `WorkflowAction` members).
- **MySQL verification (new):** recreated the mysql container (it had detached from every network) and ran `migrate:fresh` on **MySQL 8.4** — all migrations apply cleanly, including this branch's `chat_messages` and every migration from the last 5 PRs. The "sqlite-green ≠ MySQL-safe" gap is now closed.

### Follow-ups
- Workflow `create_task` action writes nonexistent/NOT-NULL columns (`title`, `taskable_*`) → any `create_task` workflow still fatals; needs a product decision (map to `name`, choose `contact_id`/`lead_id`, default `due_date`).
- Live chat: only `sendMessage`/`getActiveChats` reworked; wire `chat_messages` into any UI/controllers.
- `src/.env` is missing (dev app falls back to `127.0.0.1`/`forge`); the mysql container was off-network until this session recreated it — worth pinning in the dev setup.
- `MessageFactory` references columns that don't exist on `messages` (found while testing LiveChat) — separate fix.
