### PR TITLE
Complete workflow task action, fix enrichment data-loss, cover LanguageService

### DIFF
--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -25,6 +25,7 @@ class Company extends Model
         'size',
         'location',
         'domain',
+        'annual_revenue',
     ];
 
     public function notes(): HasMany

--- a/app/Services/WorkflowAutomationService.php
+++ b/app/Services/WorkflowAutomationService.php
@@ -2,8 +2,11 @@
 
 namespace App\Services;
 
+use App\Models\Company;
 use App\Models\Contact;
 use App\Models\Deal;
+use App\Models\Lead;
+use App\Models\Opportunity;
 use App\Models\Task;
 use App\Models\Workflow;
 use App\Models\WorkflowAction;
@@ -183,13 +186,30 @@ class WorkflowAutomationService
 
     protected function createTask($entity, array $config): void
     {
-        Task::create([
-            'title' => $config['title'] ?? 'Workflow Task',
+        $data = [
+            'name' => $config['title'] ?? $config['name'] ?? 'Workflow Task',
             'description' => $config['description'] ?? '',
-            'due_date' => $config['due_date'] ?? null,
-            'taskable_type' => $entity::class,
-            'taskable_id' => $entity->id,
-        ]);
+            'due_date' => $config['due_date'] ?? now()->addDay(), // due_date is NOT NULL
+            'status' => $config['status'] ?? 'pending',
+        ];
+
+        // Task has no polymorphic relation; link by the entity's typed FK column.
+        $column = match (true) {
+            $entity instanceof Contact => 'contact_id',
+            $entity instanceof Lead => 'lead_id',
+            $entity instanceof Company => 'company_id',
+            $entity instanceof Opportunity => 'opportunity_id',
+            default => null,
+        };
+        if ($column) {
+            $data[$column] = $entity->id;
+        }
+
+        if (! empty($entity->team_id)) {
+            $data['team_id'] = $entity->team_id;
+        }
+
+        Task::create($data);
     }
 
     protected function addTag($entity, array $config): void

--- a/database/migrations/2026_07_06_160000_add_annual_revenue_to_companies_table.php
+++ b/database/migrations/2026_07_06_160000_add_annual_revenue_to_companies_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * companies had no annual_revenue column, so DataEnrichmentService's revenue
+ * enrichment was silently dropped by mass-assignment. Add it.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasColumn('companies', 'annual_revenue')) {
+            return;
+        }
+
+        Schema::table('companies', function (Blueprint $table) {
+            $table->decimal('annual_revenue', 15, 2)->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasColumn('companies', 'annual_revenue')) {
+            return;
+        }
+
+        Schema::table('companies', function (Blueprint $table) {
+            $table->dropColumn('annual_revenue');
+        });
+    }
+};

--- a/tests/Feature/DataEnrichmentServiceTest.php
+++ b/tests/Feature/DataEnrichmentServiceTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Company;
+use App\Services\DataEnrichmentService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class DataEnrichmentServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private DataEnrichmentService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['services.data_enrichment.api_key' => 'test-key']);
+        $this->service = new DataEnrichmentService;
+    }
+
+    public function test_enrich_updates_fillable_fields_and_returns_true(): void
+    {
+        Http::fake([
+            'api.example.com/*' => Http::response([
+                'industry' => 'Software',
+                'size' => '500-1000',
+                'location' => 'Berlin, DE',
+                'annual_revenue' => '9000000',
+            ], 200),
+        ]);
+
+        $company = Company::factory()->create([
+            'domain' => 'acme.test',
+            'industry' => 'Old',
+            'size' => 'tiny',
+            'location' => 'nowhere',
+        ]);
+
+        $this->assertTrue($this->service->enrichCompanyData($company));
+
+        $this->assertDatabaseHas('companies', [
+            'id' => $company->id,
+            'industry' => 'Software',
+            'size' => '500-1000',
+            'location' => 'Berlin, DE',
+        ]);
+
+        $company->refresh();
+        $this->assertEquals(9000000, $company->annual_revenue);
+    }
+
+    public function test_enrich_returns_false_and_leaves_company_untouched_on_failure(): void
+    {
+        Http::fake([
+            'api.example.com/*' => Http::response(['error' => 'boom'], 500),
+        ]);
+
+        $company = Company::factory()->create([
+            'domain' => 'acme.test',
+            'industry' => 'Old',
+            'size' => 'tiny',
+            'location' => 'nowhere',
+        ]);
+
+        $this->assertFalse($this->service->enrichCompanyData($company));
+
+        $this->assertDatabaseHas('companies', [
+            'id' => $company->id,
+            'industry' => 'Old',
+            'size' => 'tiny',
+            'location' => 'nowhere',
+        ]);
+    }
+
+    public function test_enrich_keeps_existing_values_for_fields_the_api_omits(): void
+    {
+        Http::fake([
+            // Response only carries `industry`; size/location are absent.
+            'api.example.com/*' => Http::response(['industry' => 'Fintech'], 200),
+        ]);
+
+        $company = Company::factory()->create([
+            'domain' => 'acme.test',
+            'industry' => 'Old',
+            'size' => 'medium',
+            'location' => 'Paris, FR',
+        ]);
+
+        $this->assertTrue($this->service->enrichCompanyData($company));
+
+        $this->assertDatabaseHas('companies', [
+            'id' => $company->id,
+            'industry' => 'Fintech',
+            'size' => 'medium',      // preserved via null-coalescing
+            'location' => 'Paris, FR', // preserved via null-coalescing
+        ]);
+    }
+
+    public function test_enrich_sends_company_domain_with_bearer_token(): void
+    {
+        Http::fake([
+            'api.example.com/*' => Http::response([], 200),
+        ]);
+
+        $company = Company::factory()->create(['domain' => 'lookup-me.test']);
+
+        $this->service->enrichCompanyData($company);
+
+        Http::assertSent(function ($request) {
+            return str_contains($request->url(), 'api.example.com/v1/companies')
+                && $request['domain'] === 'lookup-me.test'
+                && $request->hasHeader('Authorization', 'Bearer test-key');
+        });
+    }
+}

--- a/tests/Feature/LanguageServiceTest.php
+++ b/tests/Feature/LanguageServiceTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Services\LanguageService;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Session;
+use InvalidArgumentException;
+use Tests\TestCase;
+
+// ponytail: no RefreshDatabase — the service only touches App locale + array session.
+class LanguageServiceTest extends TestCase
+{
+    private LanguageService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new LanguageService;
+    }
+
+    public function test_set_locale_changes_app_locale_and_persists_to_session(): void
+    {
+        $this->service->setLocale('es');
+
+        $this->assertSame('es', App::getLocale());
+        $this->assertSame('es', Session::get('locale'));
+    }
+
+    public function test_get_locale_returns_current_locale(): void
+    {
+        App::setLocale('fr');
+
+        $this->assertSame('fr', $this->service->getLocale());
+    }
+
+    public function test_set_locale_rejects_unsupported_locale(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->service->setLocale('de');
+    }
+
+    public function test_set_locale_does_not_change_state_when_locale_unsupported(): void
+    {
+        App::setLocale('en');
+
+        try {
+            $this->service->setLocale('de');
+        } catch (InvalidArgumentException) {
+            // expected
+        }
+
+        $this->assertSame('en', App::getLocale());
+        $this->assertNull(Session::get('locale'));
+    }
+
+    public function test_restore_from_session_reapplies_stored_locale(): void
+    {
+        Session::put('locale', 'fr');
+        App::setLocale('en');
+
+        $this->service->restoreFromSession();
+
+        $this->assertSame('fr', App::getLocale());
+    }
+
+    public function test_restore_from_session_falls_back_to_config_locale_when_absent(): void
+    {
+        Session::forget('locale');
+        App::setLocale('fr');
+
+        $this->service->restoreFromSession();
+
+        $this->assertSame(config('app.locale'), App::getLocale());
+    }
+
+    public function test_restore_from_session_ignores_unsupported_stored_locale(): void
+    {
+        Session::put('locale', 'de');
+        App::setLocale('en');
+
+        $this->service->restoreFromSession();
+
+        // Unsupported stored value is not applied; current locale is left intact.
+        $this->assertSame('en', App::getLocale());
+    }
+
+    public function test_is_supported_recognises_supported_and_unsupported_locales(): void
+    {
+        $this->assertTrue($this->service->isSupported('en'));
+        $this->assertFalse($this->service->isSupported('de'));
+    }
+
+    public function test_get_supported_locales_returns_the_locale_map(): void
+    {
+        $locales = $this->service->getSupportedLocales();
+
+        $this->assertArrayHasKey('en', $locales);
+        $this->assertSame('English', $locales['en']);
+    }
+}

--- a/tests/Feature/WorkflowAutomationServiceTest.php
+++ b/tests/Feature/WorkflowAutomationServiceTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Models\Contact;
+use App\Models\Task;
 use App\Models\Workflow;
 use App\Models\WorkflowAction;
 use App\Models\WorkflowCondition;
@@ -51,6 +52,32 @@ class WorkflowAutomationServiceTest extends TestCase
         $this->assertTrue($workflow->executions()->whereKey($execution->id)->exists());
         // the action actually ran
         $this->assertDatabaseHas('contacts', ['id' => $contact->id, 'status' => 'converted']);
+    }
+
+    public function test_create_task_action_creates_task_for_contact_and_completes(): void
+    {
+        $contact = Contact::factory()->create();
+        $workflow = Workflow::factory()->create(['is_active' => true]);
+        WorkflowAction::create([
+            'workflow_id' => $workflow->id,
+            'type' => WorkflowAction::TYPE_CREATE_TASK,
+            'name' => 'Follow up',
+            'config' => ['title' => 'Follow up with contact'],
+            'order' => 1,
+            'is_active' => true,
+        ]);
+
+        $execution = $this->service()->executeWorkflow($workflow, $contact);
+
+        // action ran without throwing => execution completed, not failed
+        $this->assertSame(WorkflowExecution::STATUS_COMPLETED, $execution->status);
+        $this->assertNull($execution->error_message);
+
+        $task = Task::query()->where('contact_id', $contact->id)->first();
+        $this->assertNotNull($task);
+        $this->assertSame('Follow up with contact', $task->name);
+        $this->assertSame($contact->id, $task->contact_id);
+        $this->assertNotNull($task->due_date);
     }
 
     public function test_trigger_executes_workflow_with_matching_trigger(): void


### PR DESCRIPTION
## Complete the workflow task action, fix enrichment data-loss, cover LanguageService

| Commit | What |
|--------|------|
| `4567d95` | **fix(workflow)** — the `create_task` action wrote `title`/`taskable_*`/null `due_date` (invalid on `tasks`; `name`/`due_date` are NOT NULL, entities link via typed FKs), so every `create_task` action threw → execution `failed`. Mapped to real columns + entity-typed FK (`contact_id`/`lead_id`/`company_id`/`opportunity_id`) + `team_id` from the entity. The C5 automation engine's task action now works. |
| `ea001ef` | **fix(enrichment)** — `DataEnrichmentService` wrote `annual_revenue`, but `companies` had no such column (not fillable either), so revenue enrichment was **silently dropped**. Added the nullable decimal column + fillable key; covered the service with `Http::fake` (success/failure/omitted-field/request-shape). |
| `b66c2e3` | **test(i18n)** — 9 tests over `LanguageService`; no bugs (clean `en`/`es`/`fr` validation + session persistence). |

### Testing
- **583 passed, 1 skipped, 0 failed**.
- `composer analyse` clean.
- New migration verified on **MySQL 8.4** (`migrate` applied `add_annual_revenue_to_companies` cleanly).

### Follow-ups
- Remaining untested services are the external-ad ones (Google/Facebook Ads SDKs aren't installed; LinkedIn uses raw Guzzle) — each needs SDK stubbing or a DI refactor to test.
- `MessageFactory` still references columns absent from `messages` (flagged two rounds ago).
