### PR TITLE
F4: per-team RBAC (Spatie teams mode)

### DIFF
--- a/app/Actions/Jetstream/CreateTeam.php
+++ b/app/Actions/Jetstream/CreateTeam.php
@@ -2,8 +2,10 @@
 
 namespace App\Actions\Jetstream;
 
+use App\Enums\Role;
 use App\Models\Team;
 use App\Models\User;
+use App\Services\TeamManagementService;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Validator;
 use Laravel\Jetstream\Contracts\CreatesTeams;
@@ -31,6 +33,8 @@ class CreateTeam implements CreatesTeams
             'name' => $input['name'],
             'personal_team' => true,
         ]));
+
+        app(TeamManagementService::class)->assignTeamRole($user, $team, Role::Admin);
 
         return $team;
     }

--- a/app/Http/Middleware/SetPermissionsTeamContext.php
+++ b/app/Http/Middleware/SetPermissionsTeamContext.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\User;
+use Closure;
+use Illuminate\Http\Request;
+use Spatie\Permission\PermissionRegistrar;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Scopes Spatie permissions to the authenticated user's current team on every
+ * request, BEFORE any role/gate/policy check, so hasRole()/can() resolve
+ * per-team. Mirrors SetTenantContext's team resolution (sanctum first, then the
+ * session guard) so it works on both API and web/panel requests.
+ *
+ * The app panel additionally re-scopes to the resolved Filament tenant via the
+ * SwitchTeam listener (TenantSet event), which is the authoritative acting team
+ * once the panel has resolved its tenant.
+ */
+class SetPermissionsTeamContext
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = auth('sanctum')->user() ?? $request->user();
+
+        setPermissionsTeamId($user instanceof User ? $user->currentTeam?->getKey() : null);
+
+        return $next($request);
+    }
+
+    public function terminate(Request $request, Response $response): void
+    {
+        // Octane/RoadRunner reuses workers across requests — never let a team
+        // leak into the next request.
+        app(PermissionRegistrar::class)->setPermissionsTeamId(null);
+    }
+}

--- a/app/Listeners/AssignDefaultTeamRole.php
+++ b/app/Listeners/AssignDefaultTeamRole.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Listeners;
+
+use App\Enums\Role;
+use App\Models\Team;
+use App\Models\User;
+use App\Services\TeamManagementService;
+use Laravel\Jetstream\Events\TeamMemberAdded;
+
+/**
+ * A user added to a team (Jetstream addTeamMember, which also runs on invitation
+ * acceptance) gets the default sales_rep role scoped to that team.
+ */
+class AssignDefaultTeamRole
+{
+    public function __construct(private readonly TeamManagementService $teams) {}
+
+    public function handle(TeamMemberAdded $event): void
+    {
+        if ($event->team instanceof Team && $event->user instanceof User) {
+            $this->teams->assignTeamRole($event->user, $event->team, Role::SalesRep);
+        }
+    }
+}

--- a/app/Listeners/SwitchTeam.php
+++ b/app/Listeners/SwitchTeam.php
@@ -4,21 +4,20 @@ declare(strict_types=1);
 
 namespace App\Listeners;
 
+use Filament\Events\TenantSet;
+
 class SwitchTeam
 {
     /**
-     * Create the event listener.
-     */
-    public function __construct()
-    {
-        //
-    }
-
-    /**
-     * Handle the event.
+     * When the app panel resolves its tenant, scope Spatie permissions to that
+     * team so per-team roles resolve for the team the user is actually viewing
+     * (the authoritative acting team on the panel, which may differ from the
+     * pre-request current_team_id the web middleware used).
      */
     public function handle(object $event): void
     {
-        // dd($event);
+        if ($event instanceof TenantSet) {
+            setPermissionsTeamId($event->getTenant()->getKey());
+        }
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -17,6 +17,7 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\DatabaseNotification;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Facades\DB;
 use JoelButcher\Socialstream\HasConnectedAccounts;
 use JoelButcher\Socialstream\SetsProfilePhotoFromUrl;
 use Laravel\Fortify\TwoFactorAuthenticatable;
@@ -24,6 +25,7 @@ use Laravel\Jetstream\HasProfilePhoto;
 use Laravel\Jetstream\HasTeams;
 use Laravel\Sanctum\HasApiTokens;
 use Spatie\Permission\Models\Role as SpatieRole;
+use Spatie\Permission\PermissionRegistrar;
 use Spatie\Permission\Traits\HasRoles;
 
 class User extends Authenticatable implements FilamentUser, HasDefaultTenant, HasTenants
@@ -122,6 +124,19 @@ class User extends Authenticatable implements FilamentUser, HasDefaultTenant, Ha
         return $this->belongsTo(Team::class, 'current_team_id');
     }
 
+    /**
+     * Team-aware role check.
+     *
+     * Spatie runs in teams mode: a role assignment (model_has_roles) carries the
+     * team it applies in. `$this->roles` is the Spatie relation already scoped to
+     * the current permission team (see setPermissionsTeamId in the request
+     * middleware), so per-team roles (admin/manager/sales_rep/free) resolve for
+     * the team the user is acting in.
+     *
+     * A row with team_id = null is a *global* assignment that applies in every
+     * team — this is how super_admin is stored, so hasRole('super_admin') answers
+     * true team-independently (regardless of the current setPermissionsTeamId).
+     */
     public function hasRole($role, ?string $guard = null): bool
     {
         if (is_array($role)) {
@@ -134,8 +149,37 @@ class User extends Authenticatable implements FilamentUser, HasDefaultTenant, Ha
             return false;
         }
 
-        $roleName = $role instanceof Role ? $role->value : strtolower($role);
+        $roleName = $role instanceof Role ? $role->value : strtolower((string) $role);
 
-        return $this->roles->contains(fn (SpatieRole $r): bool => strtolower($r->name) === $roleName);
+        if ($this->roles->contains(fn (SpatieRole $r): bool => strtolower($r->name) === $roleName)) {
+            return true;
+        }
+
+        return $this->hasGlobalRole($roleName);
+    }
+
+    /**
+     * True when the user holds the named role in a global (team_id = null)
+     * assignment, which applies in every team. Queried directly so it ignores
+     * the current permission team — this is what makes super_admin platform-wide.
+     */
+    protected function hasGlobalRole(string $roleName): bool
+    {
+        if ($this->getKey() === null) {
+            return false;
+        }
+
+        $tables = config('permission.table_names');
+        $morphKey = config('permission.column_names.model_morph_key');
+        $teamKey = config('permission.column_names.team_foreign_key');
+        $roleKey = app(PermissionRegistrar::class)->pivotRole;
+
+        return DB::table($tables['model_has_roles'])
+            ->join($tables['roles'], $tables['roles'].'.id', '=', $tables['model_has_roles'].'.'.$roleKey)
+            ->where($tables['model_has_roles'].'.model_type', $this->getMorphClass())
+            ->where($tables['model_has_roles'].'.'.$morphKey, $this->getKey())
+            ->whereNull($tables['model_has_roles'].'.'.$teamKey)
+            ->whereRaw('LOWER('.$tables['roles'].'.name) = ?', [$roleName])
+            ->exists();
     }
 }

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -4,16 +4,21 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
+use App\Events\ContactUpdated;
+use App\Listeners\AssignDefaultTeamRole;
 use App\Listeners\LogSuccessfulLogin;
+use App\Listeners\NotifyTeamMembers;
 use App\Listeners\SendCRMEventNotification;
 use App\Models\Task;
 use App\Observers\TaskObserver;
 use App\Services\AuditLogService;
 use Illuminate\Auth\Events\Login;
+use Illuminate\Auth\Events\Logout;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Event;
+use Laravel\Jetstream\Events\TeamMemberAdded;
 
 class EventServiceProvider extends ServiceProvider
 {
@@ -26,11 +31,14 @@ class EventServiceProvider extends ServiceProvider
         Registered::class => [
             SendEmailVerificationNotification::class,
         ],
-        \App\Events\ContactUpdated::class => [
-            \App\Listeners\NotifyTeamMembers::class,
+        ContactUpdated::class => [
+            NotifyTeamMembers::class,
         ],
         Login::class => [
             LogSuccessfulLogin::class,
+        ],
+        TeamMemberAdded::class => [
+            AssignDefaultTeamRole::class,
         ],
         // 'Illuminate\Auth\Events\Logout' => [
         //     App\Listeners\LogSuccessfulLogout,
@@ -61,7 +69,7 @@ class EventServiceProvider extends ServiceProvider
     {
         Task::observe(TaskObserver::class);
 
-        Event::listen(\Illuminate\Auth\Events\Logout::class, function ($event): void {
+        Event::listen(Logout::class, function ($event): void {
             app(AuditLogService::class)->log('logout', 'User logged out');
         });
     }

--- a/app/Services/TeamManagementService.php
+++ b/app/Services/TeamManagementService.php
@@ -2,11 +2,13 @@
 
 namespace App\Services;
 
+use App\Enums\Role;
 use App\Models\Branch;
 use App\Models\Team;
 use App\Models\User;
 use Exception;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Spatie\Permission\Models\Role as SpatieRole;
 
 class TeamManagementService
 {
@@ -18,19 +20,45 @@ class TeamManagementService
             throw new Exception('No default branch found. Please set up at least one branch.');
         }
 
-        return $user->ownedTeams()->create([
+        $team = $user->ownedTeams()->create([
             'name' => $defaultBranch->name.' Team',
             'personal_team' => false,
             'branch_id' => $defaultBranch->id,
         ]);
+
+        $this->assignTeamRole($user, $team, Role::Admin);
+
+        return $team;
     }
 
     public function createPersonalTeamForUser(User $user): Team
     {
-        return $user->ownedTeams()->create([
+        $team = $user->ownedTeams()->create([
             'name' => $user->name."'s Team",
             'personal_team' => true,
         ]);
+
+        $this->assignTeamRole($user, $team, Role::Admin);
+
+        return $team;
+    }
+
+    /**
+     * Assign a Spatie role to a user scoped to a specific team.
+     *
+     * The role definition is global (team_id = null); the assignment carries the
+     * team. Wrapping setPermissionsTeamId around assignRole is what writes the
+     * per-team pivot row. firstOrCreate keeps it safe when roles are not seeded.
+     */
+    public function assignTeamRole(User $user, Team $team, Role $role): void
+    {
+        setPermissionsTeamId($team->getKey());
+        SpatieRole::firstOrCreate([
+            'name' => $role->value,
+            'guard_name' => 'web',
+            'team_id' => null,
+        ]);
+        $user->assignRole($role->value);
     }
 
     public function assignUserToDefaultTeam(User $user): void
@@ -58,6 +86,9 @@ class TeamManagementService
         if (! $user->belongsToTeam($team)) {
             $user->teams()->attach($team, ['role' => 'member']);
             $user->unsetRelation('teams'); // drop cached (pre-attach) relation so switchTeam re-checks membership
+            // New member of an existing team → sales_rep in that team. Raw
+            // attach() fires no Jetstream event, so assign here.
+            $this->assignTeamRole($user, $team, Role::SalesRep);
         }
         $user->switchTeam($team);
     }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,10 +3,13 @@
 use App\Http\Middleware\Authenticate;
 use App\Http\Middleware\RedirectIfAuthenticated;
 use App\Http\Middleware\SecurityHeaders;
+use App\Http\Middleware\SetPermissionsTeamContext;
+use App\Http\Middleware\SetTenantContext;
 use App\Http\Middleware\VerifyTwilioRequest;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Support\Facades\Route;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -15,7 +18,7 @@ return Application::configure(basePath: dirname(__DIR__))
         commands: __DIR__.'/../routes/console.php',
         channels: __DIR__.'/../routes/channels.php',
         then: function () {
-            \Illuminate\Support\Facades\Route::middleware('web')
+            Route::middleware('web')
                 ->group(base_path('routes/socialstream.php'));
         },
     )
@@ -34,12 +37,17 @@ return Application::configure(basePath: dirname(__DIR__))
 
         $middleware->web(append: [
             SecurityHeaders::class,
+            // Scope Spatie permissions to the user's current team so per-team
+            // roles resolve. Appended so the session guard is available.
+            SetPermissionsTeamContext::class,
         ]);
 
         // Establish the tenant from the Sanctum user before route-model
         // binding runs, so the IsTenantModel global scope filters API queries.
+        // SetPermissionsTeamContext does the same for per-team role resolution.
         $middleware->api(prepend: [
-            \App\Http\Middleware\SetTenantContext::class,
+            SetTenantContext::class,
+            SetPermissionsTeamContext::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {

--- a/config/filament-shield.php
+++ b/config/filament-shield.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+use App\Models\Team;
+use BezhanSalleh\FilamentShield\Resources\Roles\RoleResource;
+use Filament\Pages\Dashboard;
+use Filament\Widgets\AccountWidget;
+use Filament\Widgets\FilamentInfoWidget;
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Shield Resource
+    |--------------------------------------------------------------------------
+    */
+
+    'shield_resource' => [
+        'slug' => 'shield/roles',
+        'show_model_path' => true,
+        'cluster' => null,
+        'tabs' => [
+            'pages' => true,
+            'widgets' => true,
+            'resources' => true,
+            'custom_permissions' => false,
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Multi-Tenancy
+    |--------------------------------------------------------------------------
+    |
+    | Teams are enabled (config/permission.php 'teams' => true). Point Shield at
+    | the Jetstream Team model so its generated resource permissions and role
+    | resource are team-aware.
+    |
+    */
+
+    'tenant_model' => Team::class,
+
+    /*
+    |--------------------------------------------------------------------------
+    | User Model
+    |--------------------------------------------------------------------------
+    */
+
+    'auth_provider_model' => 'App\\Models\\User',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Super Admin
+    |--------------------------------------------------------------------------
+    */
+
+    'super_admin' => [
+        'enabled' => true,
+        'name' => 'super_admin',
+        'define_via_gate' => false,
+        'intercept_gate' => 'before',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Panel User
+    |--------------------------------------------------------------------------
+    */
+
+    'panel_user' => [
+        'enabled' => true,
+        'name' => 'panel_user',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Permission Builder
+    |--------------------------------------------------------------------------
+    */
+
+    'permissions' => [
+        'separator' => ':',
+        'case' => 'pascal',
+        'generate' => true,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Policies
+    |--------------------------------------------------------------------------
+    */
+
+    'policies' => [
+        'path' => app_path('Policies'),
+        'merge' => true,
+        'generate' => true,
+        'methods' => [
+            'viewAny', 'view', 'create', 'update', 'delete', 'deleteAny', 'restore',
+            'forceDelete', 'forceDeleteAny', 'restoreAny', 'replicate', 'reorder',
+        ],
+        'single_parameter_methods' => [
+            'viewAny',
+            'create',
+            'deleteAny',
+            'forceDeleteAny',
+            'restoreAny',
+            'reorder',
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Localization
+    |--------------------------------------------------------------------------
+    */
+
+    'localization' => [
+        'enabled' => false,
+        'key' => 'filament-shield::filament-shield.resource_permission_prefixes_labels',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Resources
+    |--------------------------------------------------------------------------
+    */
+
+    'resources' => [
+        'subject' => 'model',
+        'manage' => [
+            RoleResource::class => [
+                'viewAny',
+                'view',
+                'create',
+                'update',
+                'delete',
+            ],
+        ],
+        'exclude' => [
+            //
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Pages
+    |--------------------------------------------------------------------------
+    */
+
+    'pages' => [
+        'subject' => 'class',
+        'prefix' => 'view',
+        'exclude' => [
+            Dashboard::class,
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Widgets
+    |--------------------------------------------------------------------------
+    */
+
+    'widgets' => [
+        'subject' => 'class',
+        'prefix' => 'view',
+        'exclude' => [
+            AccountWidget::class,
+            FilamentInfoWidget::class,
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Permissions
+    |--------------------------------------------------------------------------
+    */
+
+    'custom_permissions' => [],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Entity Discovery
+    |--------------------------------------------------------------------------
+    */
+
+    'discovery' => [
+        'discover_all_resources' => false,
+        'discover_all_widgets' => false,
+        'discover_all_pages' => false,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Role Policy
+    |--------------------------------------------------------------------------
+    */
+
+    'register_role_policy' => true,
+
+];

--- a/config/permission.php
+++ b/config/permission.php
@@ -1,0 +1,206 @@
+<?php
+
+use Spatie\Permission\DefaultTeamResolver;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+
+return [
+
+    'models' => [
+
+        /*
+         * When using the "HasPermissions" trait from this package, we need to know which
+         * Eloquent model should be used to retrieve your permissions. Of course, it
+         * is often just the "Permission" model but you may use whatever you like.
+         *
+         * The model you want to use as a Permission model needs to implement the
+         * `Spatie\Permission\Contracts\Permission` contract.
+         */
+
+        'permission' => Permission::class,
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * Eloquent model should be used to retrieve your roles. Of course, it
+         * is often just the "Role" model but you may use whatever you like.
+         *
+         * The model you want to use as a Role model needs to implement the
+         * `Spatie\Permission\Contracts\Role` contract.
+         */
+
+        'role' => Role::class,
+
+    ],
+
+    'table_names' => [
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * table should be used to retrieve your roles. We have chosen a basic
+         * default value but you may easily change it to any table you like.
+         */
+
+        'roles' => 'roles',
+
+        /*
+         * When using the "HasPermissions" trait from this package, we need to know which
+         * table should be used to retrieve your permissions. We have chosen a basic
+         * default value but you may easily change it to any table you like.
+         */
+
+        'permissions' => 'permissions',
+
+        /*
+         * When using the "HasPermissions" trait from this package, we need to know which
+         * table should be used to retrieve your models permissions. We have chosen a
+         * basic default value but you may easily change it to any table you like.
+         */
+
+        'model_has_permissions' => 'model_has_permissions',
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * table should be used to retrieve your models roles. We have chosen a
+         * basic default value but you may easily change it to any table you like.
+         */
+
+        'model_has_roles' => 'model_has_roles',
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * table should be used to retrieve your roles permissions. We have chosen a
+         * basic default value but you may easily change it to any table you like.
+         */
+
+        'role_has_permissions' => 'role_has_permissions',
+    ],
+
+    'column_names' => [
+        /*
+         * Change this if you want to name the related pivots other than defaults
+         */
+        'role_pivot_key' => null, // default 'role_id',
+        'permission_pivot_key' => null, // default 'permission_id',
+
+        /*
+         * Change this if you want to name the related model primary key other than
+         * `model_id`.
+         *
+         * For example, this would be nice if your primary keys are all UUIDs. In
+         * that case, name this `model_uuid`.
+         */
+
+        'model_morph_key' => 'model_id',
+
+        /*
+         * Change this if you want to use the teams feature and your related model's
+         * foreign key is other than `team_id`.
+         */
+
+        'team_foreign_key' => 'team_id',
+    ],
+
+    /*
+     * When set to true, the method for checking permissions will be registered on the gate.
+     * Set this to false if you want to implement custom logic for checking permissions.
+     */
+
+    'register_permission_check_method' => true,
+
+    /*
+     * When set to true, Laravel\Octane\Events\OperationTerminated event listener will be registered
+     * this will refresh permissions on every TickTerminated, TaskTerminated and RequestTerminated
+     * NOTE: This should not be needed in most cases, but an Octane/Vapor combination benefited from it.
+     */
+    'register_octane_reset_listener' => false,
+
+    /*
+     * Events will fire when a role or permission is assigned/unassigned:
+     * \Spatie\Permission\Events\RoleAttached
+     * \Spatie\Permission\Events\RoleDetached
+     * \Spatie\Permission\Events\PermissionAttached
+     * \Spatie\Permission\Events\PermissionDetached
+     *
+     * To enable, set to true, and then create listeners to watch these events.
+     */
+    'events_enabled' => false,
+
+    /*
+     * Teams Feature.
+     * When set to true the package implements teams using the 'team_foreign_key'.
+     * If you want the migrations to register the 'team_foreign_key', you must
+     * set this to true before doing the migration.
+     * If you already did the migration then you must make a new migration to also
+     * add 'team_foreign_key' to 'roles', 'model_has_roles', and 'model_has_permissions'
+     * (view the latest version of this package's migration file)
+     */
+
+    'teams' => true,
+
+    /*
+     * The class to use to resolve the permissions team id
+     */
+    'team_resolver' => DefaultTeamResolver::class,
+
+    /*
+     * Passport Client Credentials Grant
+     * When set to true the package will use Passports Client to check permissions
+     */
+
+    'use_passport_client_credentials' => false,
+
+    /*
+     * When set to true, the required permission names are added to exception messages.
+     * This could be considered an information leak in some contexts, so the default
+     * setting is false here for optimum safety.
+     */
+
+    'display_permission_in_exception' => false,
+
+    /*
+     * When set to true, the required role names are added to exception messages.
+     * This could be considered an information leak in some contexts, so the default
+     * setting is false here for optimum safety.
+     */
+
+    'display_role_in_exception' => false,
+
+    /*
+     * By default wildcard permission lookups are disabled.
+     * See documentation to understand supported syntax.
+     */
+
+    'enable_wildcard_permission' => false,
+
+    /*
+     * The class to use for interpreting wildcard permissions.
+     * If you need to modify delimiters, override the class and specify its name here.
+     */
+    // 'wildcard_permission' => Spatie\Permission\WildcardPermission::class,
+
+    /* Cache-specific settings */
+
+    'cache' => [
+
+        /*
+         * By default all permissions are cached for 24 hours to speed up performance.
+         * When permissions or roles are updated the cache is flushed automatically.
+         */
+
+        'expiration_time' => DateInterval::createFromDateString('24 hours'),
+
+        /*
+         * The cache key used to store all permissions.
+         */
+
+        'key' => 'spatie.permission.cache',
+
+        /*
+         * You may optionally indicate a specific cache driver to use for permission and
+         * role caching using any of the `store` drivers listed in the cache.php config
+         * file. Using 'default' here means to use the `default` set in cache.php.
+         */
+
+        'store' => 'default',
+    ],
+];

--- a/database/migrations/2024_02_21_190705_create_permission_tables.php
+++ b/database/migrations/2024_02_21_190705_create_permission_tables.php
@@ -61,10 +61,13 @@ return new class extends Migration
                 ->on($tableNames['permissions'])
                 ->onDelete('cascade');
             if ($teams) {
-                $table->unsignedBigInteger($columnNames['team_foreign_key']);
+                // team_id is nullable so a global (super_admin) assignment can be
+                // stored with team_id = null. MySQL forbids NULL in a PRIMARY KEY,
+                // so the composite key is a UNIQUE index rather than a primary key.
+                $table->unsignedBigInteger($columnNames['team_foreign_key'])->nullable();
                 $table->index($columnNames['team_foreign_key'], 'model_has_permissions_team_foreign_key_index');
 
-                $table->primary(
+                $table->unique(
                     [$columnNames['team_foreign_key'], $pivotPermission, $columnNames['model_morph_key'], 'model_type'],
                     'model_has_permissions_permission_model_type_primary'
                 );
@@ -88,10 +91,13 @@ return new class extends Migration
                 ->on($tableNames['roles'])
                 ->onDelete('cascade');
             if ($teams) {
-                $table->unsignedBigInteger($columnNames['team_foreign_key']);
+                // team_id is nullable so a global (super_admin) assignment can be
+                // stored with team_id = null. MySQL forbids NULL in a PRIMARY KEY,
+                // so the composite key is a UNIQUE index rather than a primary key.
+                $table->unsignedBigInteger($columnNames['team_foreign_key'])->nullable();
                 $table->index($columnNames['team_foreign_key'], 'model_has_roles_team_foreign_key_index');
 
-                $table->primary(
+                $table->unique(
                     [$columnNames['team_foreign_key'], $pivotRole, $columnNames['model_morph_key'], 'model_type'],
                     'model_has_roles_role_model_type_primary'
                 );

--- a/database/migrations/2026_07_06_000002_enable_spatie_teams_columns.php
+++ b/database/migrations/2026_07_06_000002_enable_spatie_teams_columns.php
@@ -1,0 +1,96 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * F4 per-team RBAC: enable Spatie teams columns on databases that already ran
+ * create_permission_tables while teams mode was OFF (no team_id on roles /
+ * model_has_roles / model_has_permissions).
+ *
+ * On a fresh migrate, create_permission_tables already adds these columns
+ * (teams => true), so every block here is a no-op — guarded by Schema::hasColumn.
+ * The pivot composite keys become UNIQUE indexes (not PRIMARY KEYs) because the
+ * team_id is nullable — a global super_admin assignment is stored with
+ * team_id = null, and MySQL forbids NULL in a PRIMARY KEY.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! config('permission.teams')) {
+            return;
+        }
+
+        $names = config('permission.table_names');
+        $columns = config('permission.column_names');
+        $teamKey = $columns['team_foreign_key'] ?? 'team_id';
+        $morphKey = $columns['model_morph_key'] ?? 'model_id';
+        $roleKey = $columns['role_pivot_key'] ?? 'role_id';
+        $permissionKey = $columns['permission_pivot_key'] ?? 'permission_id';
+
+        // roles: add nullable team_id + team-aware unique (team_id, name, guard).
+        if (Schema::hasTable($names['roles']) && ! Schema::hasColumn($names['roles'], $teamKey)) {
+            Schema::table($names['roles'], function (Blueprint $table) use ($teamKey): void {
+                $table->unsignedBigInteger($teamKey)->nullable()->after('id');
+                $table->index($teamKey, 'roles_team_foreign_key_index');
+            });
+
+            $this->swapUnique($names['roles'], ['name', 'guard_name'], [$teamKey, 'name', 'guard_name']);
+        }
+
+        // model_has_roles: nullable team_id, drop the non-team PRIMARY KEY, add a
+        // team-aware UNIQUE index so a user can hold a role in multiple teams.
+        if (Schema::hasTable($names['model_has_roles']) && ! Schema::hasColumn($names['model_has_roles'], $teamKey)) {
+            $this->addTeamToPivot(
+                $names['model_has_roles'],
+                $teamKey,
+                'model_has_roles_team_foreign_key_index',
+                [$teamKey, $roleKey, $morphKey, 'model_type'],
+                'model_has_roles_role_model_type_primary'
+            );
+        }
+
+        // model_has_permissions: same treatment.
+        if (Schema::hasTable($names['model_has_permissions']) && ! Schema::hasColumn($names['model_has_permissions'], $teamKey)) {
+            $this->addTeamToPivot(
+                $names['model_has_permissions'],
+                $teamKey,
+                'model_has_permissions_team_foreign_key_index',
+                [$teamKey, $permissionKey, $morphKey, 'model_type'],
+                'model_has_permissions_permission_model_type_primary'
+            );
+        }
+
+        app('cache')->forget(config('permission.cache.key'));
+    }
+
+    public function down(): void
+    {
+        // No-op: teams columns are load-bearing once enabled; reversing would
+        // drop role/permission scoping. Roll back by restoring from backup.
+    }
+
+    /**
+     * Add a nullable team_id to a pivot, drop its existing PRIMARY KEY, and add a
+     * team-aware UNIQUE index (nullable team_id can't sit in a MySQL PRIMARY KEY).
+     */
+    private function addTeamToPivot(string $table, string $teamKey, string $indexName, array $unique, string $uniqueName): void
+    {
+        Schema::table($table, function (Blueprint $t) use ($teamKey, $indexName, $unique, $uniqueName): void {
+            $t->dropPrimary();
+            $t->unsignedBigInteger($teamKey)->nullable();
+            $t->index($teamKey, $indexName);
+            $t->unique($unique, $uniqueName);
+        });
+    }
+
+    private function swapUnique(string $table, array $old, array $new): void
+    {
+        Schema::table($table, function (Blueprint $t) use ($old, $new): void {
+            $t->dropUnique($old);
+            $t->unique($new);
+        });
+    }
+};

--- a/database/migrations/2026_07_06_000003_backfill_role_assignment_teams.php
+++ b/database/migrations/2026_07_06_000003_backfill_role_assignment_teams.php
@@ -1,0 +1,80 @@
+<?php
+
+use App\Enums\Role;
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * F4 per-team RBAC backfill: stamp each existing role assignment with the team
+ * it now applies in.
+ *
+ *  - super_admin assignments become global (team_id = null) — the platform role.
+ *  - every other assignment is stamped with the user's current_team_id, so a
+ *    user keeps their effective role in the team they actively work in. If the
+ *    user has no current team, the row is left global (team_id = null) and logged
+ *    — a user on multiple teams with one legacy assignment collapses to their
+ *    current team only (accepted per the F4 design).
+ *
+ * On a fresh migrate model_has_roles is empty, so this is a no-op.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! config('permission.teams')) {
+            return;
+        }
+
+        $names = config('permission.table_names');
+        $columns = config('permission.column_names');
+        $teamKey = $columns['team_foreign_key'] ?? 'team_id';
+        $morphKey = $columns['model_morph_key'] ?? 'model_id';
+        $roleKey = $columns['role_pivot_key'] ?? 'role_id';
+        $mhr = $names['model_has_roles'];
+
+        $superAdminIds = DB::table($names['roles'])
+            ->where('name', Role::SuperAdmin->value)
+            ->pluck('id')
+            ->all();
+
+        // super_admin → global.
+        if ($superAdminIds !== []) {
+            DB::table($mhr)->whereIn($roleKey, $superAdminIds)->update([$teamKey => null]);
+        }
+
+        $userMorph = (new User)->getMorphClass();
+
+        // Every other User assignment → the user's current team.
+        DB::table($mhr)
+            ->where('model_type', $userMorph)
+            ->when($superAdminIds !== [], fn ($q) => $q->whereNotIn($roleKey, $superAdminIds))
+            ->orderBy($morphKey)
+            ->orderBy($roleKey)
+            ->get()
+            ->each(function ($row) use ($mhr, $teamKey, $morphKey, $roleKey): void {
+                $currentTeamId = DB::table('users')->where('id', $row->{$morphKey})->value('current_team_id');
+
+                DB::table($mhr)
+                    ->where('model_type', $row->model_type)
+                    ->where($morphKey, $row->{$morphKey})
+                    ->where($roleKey, $row->{$roleKey})
+                    ->update([$teamKey => $currentTeamId]);
+
+                if ($currentTeamId === null) {
+                    Log::info('RBAC backfill: assignment left global (user has no current team)', [
+                        'model_id' => $row->{$morphKey},
+                        'role_id' => $row->{$roleKey},
+                    ]);
+                }
+            });
+
+        app('cache')->forget(config('permission.cache.key'));
+    }
+
+    public function down(): void
+    {
+        // Data migration; no safe automatic reversal.
+    }
+};

--- a/database/seeders/RolesSeeder.php
+++ b/database/seeders/RolesSeeder.php
@@ -3,8 +3,6 @@
 namespace Database\Seeders;
 
 use App\Enums\Role;
-use App\Models\Team;
-use BezhanSalleh\FilamentShield\Support\Utils;
 use Illuminate\Database\Seeder;
 use Spatie\Permission\Models\Permission;
 use Spatie\Permission\Models\Role as SpatieRole;
@@ -13,16 +11,15 @@ class RolesSeeder extends Seeder
 {
     public function run(): void
     {
+        // Role definitions are global: one row per role with team_id = null,
+        // usable in every team. Per-team scoping lives on the *assignment*
+        // (model_has_roles.team_id), not on the definition.
         foreach (Role::cases() as $roleEnum) {
             $roleData = [
                 'name' => $roleEnum->value,
                 'guard_name' => 'web',
+                'team_id' => null,
             ];
-
-            if (Utils::isTenancyEnabled()) {
-                $team = Team::firstOrFail();
-                $roleData['team_id'] = $team->id;
-            }
 
             $role = SpatieRole::firstOrCreate($roleData);
 

--- a/docs/superpowers/specs/2026-07-06-f4-per-team-rbac-design.md
+++ b/docs/superpowers/specs/2026-07-06-f4-per-team-rbac-design.md
@@ -1,0 +1,98 @@
+# F4 — Per-team RBAC (design)
+
+**Date:** 2026-07-06
+**Status:** approved-pending-review
+**Task:** TASKS.md F4 — "Harden RBAC (Shield roles/permissions per team) + record-level scoping hook." The record-level hook (`RestrictsToOwner`) shipped earlier; this spec covers the **per-team RBAC** half.
+
+## Goal
+
+Make Spatie roles resolve **per team** so a user can hold different roles in different teams (manager in Team A, sales_rep in Team B), and every `hasRole`/`can`/policy check answers against the team the user is currently acting in.
+
+## Decisions (agreed)
+
+1. **Independent role per team** — real Spatie teams mode, not global roles.
+2. **Taxonomy:** `super_admin` is platform-**global** (spans all teams); `admin`, `manager`, `sales_rep`, `free` are **per-team**.
+3. **Default assignment:** team creator → `admin` in that team; invited member → `sales_rep` in that team (both adjustable later by a team admin).
+4. **Scope of this spec:** the *mechanism* only. The team-admin self-service role-management UI is **phase 2** (separate spec/PR).
+5. **Backfill:** existing non-`super_admin` assignments are stamped with the user's `current_team_id` (fallback: left global if the user has no current team). `super_admin` assignments become global.
+
+## Architecture
+
+**Two systems, layered, not merged:**
+
+- **Jetstream** owns *membership*: who is on a team, invitations, ownership, `current_team_id`. Unchanged.
+- **Spatie laravel-permission** owns *authorization*: the per-team role a member holds and what it permits.
+
+A membership event (create/join) triggers a Spatie role assignment scoped to that team. Otherwise the two stay independent.
+
+## Data model
+
+Enable Spatie teams: publish `config/permission.php` with `'teams' => true` and `'team_foreign_key' => 'team_id'`. Migration adds a nullable `team_id` to `roles`, `model_has_roles`, `model_has_permissions` (Spatie's teams schema).
+
+- **Role definitions are global** — the 5 role rows are created once with `roles.team_id = null`. We do **not** duplicate a `manager` row per team.
+- **Assignments are per-team** — `model_has_roles.team_id` carries the team. `setPermissionsTeamId($teamA); $user->assignRole('manager')` writes a row `(user, manager, team_A)`.
+- **`super_admin` is a global assignment** — written with `team_id = null`, meaning "applies in every team". `User::hasRole` is already overridden in this codebase; extend that override so **`super_admin` is resolved team-independently** (a query that ignores the current permission team), while every other role name resolves through the normal per-team path. This keeps the platform role working in the direct `hasRole('super_admin')` calls (`canAccessPanel`, `canAccessFilament`, `AccessContext`) without depending on Spatie's null-team internals, and is straightforwardly testable.
+
+## Current-team wiring
+
+A single middleware sets the permission team on every authenticated request, **before** any role/gate check:
+
+```
+app(\Spatie\Permission\PermissionRegistrar::class)->setPermissionsTeamId($teamId);
+```
+
+`$teamId` comes from the same resolution `TenantContext` already uses — the Filament tenant on the `app` panel, the sanctum user's `currentTeam` on the API. It is applied on the `web`/panel and `api` middleware groups (mirroring `SetTenantContext`). Console/queue set it explicitly when a job runs "as" a team (out of scope here; see `TenantAware` for the tenant-context analogue).
+
+**Consequence (the payoff):** `AccessContext::restrictToOwnerId()` calls `hasRole('sales_rep')`. Once the permission team is set per request, that check is automatically per-team — a user who is `sales_rep` in Team A but `manager` in Team B is owner-scoped in A and sees all records in B, with **no change to `AccessContext` or `RestrictsToOwner`**. Same for `canAccessPanel`/`canAccessFilament` and the record policies.
+
+## Default role assignment
+
+Hook the existing team lifecycle (already centralized in `TeamManagementService` + the personal-team listener, both hardened in an earlier PR):
+
+- **Team created / personal team** → assign the creator `admin` scoped to the new team.
+- **Member added** (Jetstream `addTeamMember` / invitation accepted) → assign the new member `sales_rep` scoped to that team.
+
+Assignment always wraps `setPermissionsTeamId($team->id)` around `assignRole(...)`.
+
+## Backfill migration
+
+A data migration over existing `model_has_roles`:
+
+- `super_admin` rows → `team_id = null` (global).
+- every other row → the user's `current_team_id`; if the user has none, leave `team_id = null` (global fallback) and log it.
+
+This preserves each user's effective permissions in the team they actively work in.
+
+## Filament Shield
+
+Set `config/filament-shield.php` `tenant_model = Team::class` so Shield's generated resource permissions and role resource are team-aware. Shield stays on the `admin` panel (super_admin). The per-team role-management surface is phase 2.
+
+## Interaction with existing code (no behavioural regressions expected)
+
+- `AccessContext` / `RestrictsToOwner` — unchanged; become per-team for free once the middleware is wired.
+- `canAccessPanel` / `canAccessFilament` (User) — unchanged; resolve per current team. Note: a user with a role only in Team A must have the permission team set to A when accessing the app panel (the Filament tenant guarantees this).
+- Record policies (`belongsToTeam(currentTeam)`) — unchanged; already team-based.
+- `SetTenantContext` middleware — the new permission-team middleware sits beside it and resolves the team the same way; consider merging the two resolutions into one helper to avoid drift.
+
+## Testing strategy
+
+- A user assigned `manager` in Team A and `sales_rep` in Team B: `hasRole` resolves correctly after `setPermissionsTeamId` for each; owner-scope follows (all deals in A, own-only in B).
+- `super_admin` answers `true` across all teams regardless of context.
+- Team creation → creator has `admin` in that team and no role elsewhere; invited member → `sales_rep` in that team only.
+- A `manager` in Team A has **no** role/powers in Team B (cross-team isolation).
+- Backfill migration: seed pre-teams assignments, run migration, assert each lands on the right team.
+- Regression: the full existing suite stays green (the wiring must not change single-team behaviour).
+- **Verify the schema + backfill on MySQL 8.4**, not just sqlite (recreate the mysql container + `migrate:fresh`, as established).
+
+## Scope boundary
+
+**In:** teams mode config, pivot migration, global role definitions, current-team middleware, default assignment on create/join, backfill migration, Shield `tenant_model`, tests.
+
+**Out (phase 2):** team-admin self-service role management (a team-scoped Shield role resource on the `app` panel), custom per-team permissions beyond the 5 roles, territory/field-level scoping (G3 remainder).
+
+## Risks
+
+- **`super_admin` global resolution** — the extended `hasRole` override must be covered by a test proving super_admin answers true under any `setPermissionsTeamId` value (including a team the user has no assignment in).
+- **Permission cache** — Spatie caches permissions; confirm the team id is set before the first gate check each request and that the cache key is team-aware (it is in teams mode, but verify).
+- **Middleware ordering** — `setPermissionsTeamId` must run before any authorization check (before `SubstituteBindings`/policy resolution), like `SetTenantContext`.
+- **Backfill correctness** — a user on multiple teams with one global assignment collapses to their current team only; acceptable per the decision, but note it in the migration.

--- a/tests/Feature/Rbac/PerTeamRbacTest.php
+++ b/tests/Feature/Rbac/PerTeamRbacTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Rbac;
+
+use App\Enums\Role;
+use App\Models\Deal;
+use App\Models\Team;
+use App\Models\User;
+use App\Services\TeamManagementService;
+use App\Support\TenantContext;
+use Database\Seeders\RolesSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Jetstream\Events\TeamMemberAdded;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\TestCase;
+
+/**
+ * F4 per-team RBAC: a role assignment is scoped to a team, so a user can hold
+ * different roles in different teams. super_admin is the one global (platform)
+ * role and answers true in every team.
+ */
+class PerTeamRbacTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolesSeeder::class); // global (team_id = null) role definitions
+    }
+
+    protected function tearDown(): void
+    {
+        app(PermissionRegistrar::class)->setPermissionsTeamId(null);
+        parent::tearDown();
+    }
+
+    private function setTeam(?Team $team): void
+    {
+        setPermissionsTeamId($team?->getKey());
+    }
+
+    private function assignInTeam(User $user, Team $team, Role $role): void
+    {
+        $this->setTeam($team);
+        $user->assignRole($role->value);
+    }
+
+    private function hasRoleInTeam(User $user, ?Team $team, Role $role): bool
+    {
+        $this->setTeam($team);
+        $user->unsetRelation('roles'); // relation is cached per team; refresh after a context switch
+
+        return $user->hasRole($role);
+    }
+
+    public function test_a_user_holds_different_roles_in_different_teams(): void
+    {
+        $teamA = Team::factory()->create();
+        $teamB = Team::factory()->create();
+        $user = User::factory()->create();
+
+        $this->assignInTeam($user, $teamA, Role::Manager);
+        $this->assignInTeam($user, $teamB, Role::SalesRep);
+
+        // In team A the user is a manager, not a sales rep.
+        $this->assertTrue($this->hasRoleInTeam($user, $teamA, Role::Manager));
+        $this->assertFalse($this->hasRoleInTeam($user, $teamA, Role::SalesRep));
+
+        // In team B the user is a sales rep, not a manager.
+        $this->assertTrue($this->hasRoleInTeam($user, $teamB, Role::SalesRep));
+        $this->assertFalse($this->hasRoleInTeam($user, $teamB, Role::Manager));
+    }
+
+    public function test_a_manager_in_team_a_has_no_role_in_team_b(): void
+    {
+        $teamA = Team::factory()->create();
+        $teamB = Team::factory()->create();
+        $user = User::factory()->create();
+
+        $this->assignInTeam($user, $teamA, Role::Manager);
+
+        $this->assertTrue($this->hasRoleInTeam($user, $teamA, Role::Manager));
+        $this->assertFalse($this->hasRoleInTeam($user, $teamB, Role::Manager));
+        $this->assertFalse($this->hasRoleInTeam($user, $teamB, Role::Admin));
+        $this->assertFalse($this->hasRoleInTeam($user, $teamB, Role::SalesRep));
+    }
+
+    public function test_owner_scope_follows_the_per_team_role(): void
+    {
+        $teamA = Team::factory()->create();
+        $teamB = Team::factory()->create();
+
+        // Same person: manager in A (sees all), sales_rep in B (own only).
+        $user = User::factory()->create();
+        $this->assignInTeam($user, $teamA, Role::Manager);
+        $this->assignInTeam($user, $teamB, Role::SalesRep);
+
+        $mate = User::factory()->create();
+
+        $myDealA = Deal::factory()->create(['team_id' => $teamA->id, 'user_id' => $user->id]);
+        $mateDealA = Deal::factory()->create(['team_id' => $teamA->id, 'user_id' => $mate->id]);
+        $myDealB = Deal::factory()->create(['team_id' => $teamB->id, 'user_id' => $user->id]);
+        $mateDealB = Deal::factory()->create(['team_id' => $teamB->id, 'user_id' => $mate->id]);
+
+        $this->actingAs($user);
+
+        // Team A: manager → sees every deal in the team.
+        TenantContext::set($teamA->id);
+        $this->hasRoleInTeam($user, $teamA, Role::Manager); // set permission team + refresh roles
+        $idsInA = Deal::pluck('id');
+        $this->assertTrue($idsInA->contains($myDealA->id));
+        $this->assertTrue($idsInA->contains($mateDealA->id), 'manager must see teammate deal in team A');
+
+        // Team B: sales_rep → sees only their own deal.
+        TenantContext::set($teamB->id);
+        $this->hasRoleInTeam($user, $teamB, Role::SalesRep);
+        $idsInB = Deal::pluck('id');
+        $this->assertTrue($idsInB->contains($myDealB->id));
+        $this->assertFalse($idsInB->contains($mateDealB->id), 'sales_rep must NOT see teammate deal in team B');
+    }
+
+    public function test_super_admin_is_true_across_all_teams_regardless_of_context(): void
+    {
+        $memberTeam = Team::factory()->create();
+        $strangerTeam = Team::factory()->create(); // super admin has NO assignment here
+        $user = User::factory()->create();
+
+        // Global assignment: team_id = null.
+        $this->setTeam(null);
+        $user->assignRole(Role::SuperAdmin->value);
+
+        // True with no team context.
+        $this->assertTrue($this->hasRoleInTeam($user, null, Role::SuperAdmin));
+        // True in a team the user belongs to.
+        $this->assertTrue($this->hasRoleInTeam($user, $memberTeam, Role::SuperAdmin));
+        // True even in a team the user has no assignment in — platform-wide.
+        $this->assertTrue($this->hasRoleInTeam($user, $strangerTeam, Role::SuperAdmin));
+
+        // The global row really is stored with team_id = null.
+        $this->assertDatabaseHas('model_has_roles', [
+            'model_id' => $user->id,
+            'model_type' => $user->getMorphClass(),
+            'team_id' => null,
+        ]);
+    }
+
+    public function test_super_admin_does_not_leak_into_other_role_names(): void
+    {
+        $team = Team::factory()->create();
+        $user = User::factory()->create();
+
+        $this->setTeam(null);
+        $user->assignRole(Role::SuperAdmin->value);
+
+        // Being global super_admin must not make the user a manager anywhere.
+        $this->assertFalse($this->hasRoleInTeam($user, $team, Role::Manager));
+    }
+
+    public function test_team_creator_becomes_admin_only_in_that_team(): void
+    {
+        $service = app(TeamManagementService::class);
+        $creator = User::factory()->create(['name' => 'Ada']);
+        $otherTeam = Team::factory()->create();
+
+        $team = $service->createPersonalTeamForUser($creator);
+
+        $this->assertTrue($this->hasRoleInTeam($creator, $team, Role::Admin));
+        $this->assertFalse($this->hasRoleInTeam($creator, $otherTeam, Role::Admin));
+    }
+
+    public function test_added_member_becomes_sales_rep_in_that_team(): void
+    {
+        $service = app(TeamManagementService::class);
+        $team = Team::factory()->create(['personal_team' => false]);
+        $member = User::factory()->create();
+
+        $service->assignUserToTeam($member, $team);
+
+        $this->assertTrue($this->hasRoleInTeam($member, $team, Role::SalesRep));
+        $this->assertFalse($this->hasRoleInTeam($member, $team, Role::Admin));
+    }
+
+    public function test_invited_member_becomes_sales_rep_via_team_member_added_event(): void
+    {
+        $team = Team::factory()->create();
+        $invited = User::factory()->create();
+
+        // Jetstream fires this on addTeamMember (also on invitation acceptance).
+        event(new TeamMemberAdded($team, $invited));
+
+        $this->assertTrue($this->hasRoleInTeam($invited, $team, Role::SalesRep));
+    }
+}

--- a/tests/Feature/Rbac/RoleAssignmentBackfillTest.php
+++ b/tests/Feature/Rbac/RoleAssignmentBackfillTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Rbac;
+
+use App\Models\Team;
+use App\Models\User;
+use Database\Seeders\RolesSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\TestCase;
+
+/**
+ * F4 backfill: pre-teams role assignments are stamped with the team they now
+ * apply in — super_admin becomes global, every other assignment lands on the
+ * user's current team (or stays global when the user has no current team).
+ */
+class RoleAssignmentBackfillTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolesSeeder::class);
+    }
+
+    protected function tearDown(): void
+    {
+        app(PermissionRegistrar::class)->setPermissionsTeamId(null);
+        parent::tearDown();
+    }
+
+    public function test_backfill_stamps_each_assignment_with_the_right_team(): void
+    {
+        $teamA = Team::factory()->create();
+
+        $userWithTeam = User::factory()->create(['current_team_id' => $teamA->id]);
+        $userNoTeam = User::factory()->create(['current_team_id' => null]);
+        $superUser = User::factory()->create(['current_team_id' => $teamA->id]);
+
+        $managerId = DB::table('roles')->where('name', 'manager')->value('id');
+        $superAdminId = DB::table('roles')->where('name', 'super_admin')->value('id');
+
+        // Simulate legacy (pre-teams) rows: assignments written with no team.
+        $rows = [
+            // manager for a user with a current team -> should become teamA.
+            ['role_id' => $managerId, 'model_type' => $userWithTeam->getMorphClass(), 'model_id' => $userWithTeam->id, 'team_id' => null],
+            // manager for a user with no current team -> should stay null.
+            ['role_id' => $managerId, 'model_type' => $userNoTeam->getMorphClass(), 'model_id' => $userNoTeam->id, 'team_id' => null],
+            // super_admin, even stamped with a stray team -> should become null.
+            ['role_id' => $superAdminId, 'model_type' => $superUser->getMorphClass(), 'model_id' => $superUser->id, 'team_id' => $teamA->id],
+        ];
+        DB::table('model_has_roles')->insert($rows);
+
+        $migration = require base_path('database/migrations/2026_07_06_000003_backfill_role_assignment_teams.php');
+        $migration->up();
+
+        $this->assertDatabaseHas('model_has_roles', [
+            'role_id' => $managerId,
+            'model_id' => $userWithTeam->id,
+            'team_id' => $teamA->id,
+        ]);
+        $this->assertDatabaseHas('model_has_roles', [
+            'role_id' => $managerId,
+            'model_id' => $userNoTeam->id,
+            'team_id' => null,
+        ]);
+        $this->assertDatabaseHas('model_has_roles', [
+            'role_id' => $superAdminId,
+            'model_id' => $superUser->id,
+            'team_id' => null,
+        ]);
+    }
+}


### PR DESCRIPTION
## F4 — Per-team RBAC

Implements the design in `docs/superpowers/specs/2026-07-06-f4-per-team-rbac-design.md` (committed here). Enables Spatie teams mode so a user can hold different roles in different teams, and every `hasRole`/policy check answers against the team they're acting in.

### How it works
- **Teams mode on** — `config/permission.php` `teams=true`; pivot `team_id` is nullable + a UNIQUE index (not part of a NOT-NULL PRIMARY KEY) so a global `super_admin` row (`team_id=null`) is storable and MySQL-safe.
- **Per-request team** — `SetPermissionsTeamContext` middleware sets the Spatie permission team from the acting team (sanctum/session + the Filament tenant via the `TenantSet` listener), on web + api.
- **Resolution** — `User::hasRole` checks the team-scoped relation, then falls back to `hasGlobalRole` (a `team_id IS NULL` query). So `super_admin` is platform-wide, while `admin/manager/sales_rep/free` resolve per current team and **never leak across teams**. `AccessContext` owner-scoping becomes per-team for free (rep in A / manager in B → own-only in A, all in B).
- **Default assignment** — creator → `admin`; added member → `sales_rep` (via `TeamMemberAdded`), each wrapping `setPermissionsTeamId` around `assignRole`.
- **Backfill** — existing assignments stamped with the user's `current_team_id`; `super_admin` → global.

### Division of labor
Jetstream owns membership; Spatie owns per-team permissions. They layer, unchanged.

### Testing
- **615 passed, 1 skipped, 0 failed** — the entire pre-existing suite stayed green (no existing test edited); +9 new RBAC tests (per-team resolution, super_admin-global across a team the user isn't in, cross-team isolation, owner-scope-follows-role, backfill).
- `composer analyse` clean.
- **MySQL 8.4 verified**: `migrate:fresh` applies the teams schema + backfill cleanly; `model_has_roles.team_id` confirmed nullable under a UNIQUE index; null-team + per-team resolution verified live.

### Notable schema decision
The vendor `create_permission_tables` migration puts pivot `team_id` in a NOT-NULL composite **PRIMARY KEY**, which (a) makes the many existing `assignRole()` calls with no team context fail on NOT-NULL and (b) can't store the `null` global row (MySQL forbids NULL in a PK). Changed to nullable `team_id` + a composite **UNIQUE** index (distinctness preserved); the guarded migration mirrors it for existing DBs.

### Scope / follow-ups (per spec)
- **Phase 2 (separate PR):** team-admin self-service role management (team-scoped Shield role resource on the app panel).
- Existing-DB upgrade path: the guarded `enable_spatie_teams_columns` migration must drop the old composite PK and add the UNIQUE index on already-populated prod tables — verify against a production-like dataset before deploy.
