### PR TITLE
DealResource + deeper Filament coverage + MessageFactory fix

### DIFF
--- a/app/Filament/App/Resources/DealResource.php
+++ b/app/Filament/App/Resources/DealResource.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace App\Filament\App\Resources;
+
+use App\Filament\App\Resources\DealResource\Pages\CreateDeal;
+use App\Filament\App\Resources\DealResource\Pages\EditDeal;
+use App\Filament\App\Resources\DealResource\Pages\ListDeals;
+use App\Models\Deal;
+use App\Models\Stage;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class DealResource extends Resource
+{
+    protected static ?string $model = Deal::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-banknotes';
+
+    protected static ?string $navigationLabel = 'Deals';
+
+    #[\Override]
+    public static function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                TextInput::make('name')
+                    ->required()
+                    ->maxLength(255),
+                TextInput::make('value')
+                    ->numeric()
+                    ->prefix('$'),
+                TextInput::make('stage')
+                    ->maxLength(255),
+                DatePicker::make('close_date')
+                    ->label('Close Date'),
+                TextInput::make('probability')
+                    ->numeric()
+                    ->suffix('%'),
+                Select::make('contact_id')
+                    ->relationship('contact', 'name')
+                    ->searchable()
+                    ->nullable(),
+                Select::make('user_id')
+                    ->label('Owner')
+                    ->relationship('user', 'name')
+                    ->searchable()
+                    ->nullable(),
+                Select::make('pipeline_id')
+                    ->relationship('pipeline', 'name')
+                    ->searchable()
+                    ->nullable(),
+                // `stage` is also a plain string column, so the `stage()` relation
+                // name collides — use options() instead of ->relationship() here.
+                Select::make('stage_id')
+                    ->label('Pipeline Stage')
+                    ->options(Stage::pluck('name', 'id'))
+                    ->searchable()
+                    ->nullable(),
+            ]);
+    }
+
+    #[\Override]
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('name')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('value')
+                    ->money('usd')
+                    ->sortable(),
+                TextColumn::make('stage')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('close_date')
+                    ->date()
+                    ->sortable(),
+                TextColumn::make('probability')
+                    ->suffix('%')
+                    ->sortable(),
+                TextColumn::make('contact.name')
+                    ->label('Contact')
+                    ->sortable(),
+                TextColumn::make('user.name')
+                    ->label('Owner')
+                    ->sortable(),
+                TextColumn::make('pipeline.name')
+                    ->label('Pipeline')
+                    ->sortable(),
+                TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                //
+            ])
+            ->recordActions([
+                EditAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    #[\Override]
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListDeals::route('/'),
+            'create' => CreateDeal::route('/create'),
+            'edit' => EditDeal::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/App/Resources/DealResource/Pages/CreateDeal.php
+++ b/app/Filament/App/Resources/DealResource/Pages/CreateDeal.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\App\Resources\DealResource\Pages;
+
+use App\Filament\App\Resources\DealResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateDeal extends CreateRecord
+{
+    protected static string $resource = DealResource::class;
+}

--- a/app/Filament/App/Resources/DealResource/Pages/EditDeal.php
+++ b/app/Filament/App/Resources/DealResource/Pages/EditDeal.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\App\Resources\DealResource\Pages;
+
+use App\Filament\App\Resources\DealResource;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditDeal extends EditRecord
+{
+    protected static string $resource = DealResource::class;
+
+    #[\Override]
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/App/Resources/DealResource/Pages/ListDeals.php
+++ b/app/Filament/App/Resources/DealResource/Pages/ListDeals.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\App\Resources\DealResource\Pages;
+
+use App\Filament\App\Resources\DealResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListDeals extends ListRecords
+{
+    protected static string $resource = DealResource::class;
+
+    #[\Override]
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/App/Resources/LandingPageResource.php
+++ b/app/Filament/App/Resources/LandingPageResource.php
@@ -11,8 +11,8 @@ use App\Models\LandingPage;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Forms\Components\DateTimePicker;
-use Filament\Forms\Components\RichEditor;
 use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
@@ -34,7 +34,11 @@ class LandingPageResource extends Resource
                 TextInput::make('title')
                     ->required()
                     ->maxLength(255),
-                RichEditor::make('content')
+                // ponytail: content is an uncast longText (may hold HTML or JSON
+                // page data); RichEditor fatals on non-tiptap content, so Textarea
+                // tolerates any stored string. Restore RichEditor only if content
+                // is guaranteed HTML.
+                Textarea::make('content')
                     ->required(),
                 Select::make('campaign_id')
                     ->relationship('campaign', 'name')

--- a/database/factories/MessageFactory.php
+++ b/database/factories/MessageFactory.php
@@ -6,32 +6,25 @@ namespace Database\Factories;
 
 use App\Models\Message;
 use App\Models\Team;
-use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 class MessageFactory extends Factory
 {
     protected $model = Message::class;
 
-    public function definition()
+    public function definition(): array
     {
         return [
             'team_id' => Team::factory(),
-            'sender_id' => User::factory(),
-            'receiver_id' => User::factory(),
-            'subject' => $this->faker->sentence(),
+            'channel' => $this->faker->randomElement(['email', 'sms', 'whatsapp', 'facebook', 'chat']),
+            'sender' => $this->faker->safeEmail(),
             'content' => $this->faker->paragraph(),
-            'type' => $this->faker->randomElement(['direct', 'group', 'system']),
-            'status' => $this->faker->randomElement(['unread', 'read', 'archived']),
+            'timestamp' => now(),
             'priority' => $this->faker->randomElement(['low', 'normal', 'high']),
-            'metadata' => json_encode([
-                'attachments' => [],
-                'mentions' => [],
-                'thread_id' => $this->faker->optional()->uuid,
-            ]),
-            'read_at' => $this->faker->optional()->dateTimeThisMonth(),
-            'created_at' => now(),
-            'updated_at' => now(),
+            'status' => $this->faker->randomElement(['unread', 'read', 'archived']),
+            'account_id' => $this->faker->numberBetween(1, 1000),
+            'thread_id' => null,
+            'metadata' => ['attachments' => [], 'mentions' => []],
         ];
     }
 }

--- a/tests/Feature/Filament/DealResourceTest.php
+++ b/tests/Feature/Filament/DealResourceTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament;
+
+use App\Filament\App\Resources\DealResource;
+use App\Models\Deal;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class DealResourceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function actingManagerWithTeam(): Team
+    {
+        Role::findOrCreate('manager', 'web');
+        $user = User::factory()->withPersonalTeam()->create(['email_verified_at' => now()]);
+        $team = $user->ownedTeams->first();
+        $user->current_team_id = $team->id;
+        $user->save();
+        $user->assignRole('manager');
+        $this->actingAs($user);
+
+        return $team;
+    }
+
+    public function test_index_page_mounts(): void
+    {
+        $team = $this->actingManagerWithTeam();
+        $this->get('/app/'.$team->id.'/'.DealResource::getSlug())
+            ->assertStatus(200);
+    }
+
+    public function test_create_page_mounts(): void
+    {
+        $team = $this->actingManagerWithTeam();
+        $this->get('/app/'.$team->id.'/'.DealResource::getSlug().'/create')
+            ->assertStatus(200);
+    }
+
+    public function test_edit_page_mounts(): void
+    {
+        $team = $this->actingManagerWithTeam();
+        $deal = Deal::factory()->create(['team_id' => $team->id]);
+
+        $this->get('/app/'.$team->id.'/'.DealResource::getSlug().'/'.$deal->id.'/edit')
+            ->assertStatus(200);
+    }
+}

--- a/tests/Feature/Filament/ResourceEditPageMountTest.php
+++ b/tests/Feature/Filament/ResourceEditPageMountTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament;
+
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+/**
+ * Mounts every App-panel resource's EDIT page against a real seeded row, plus
+ * the INDEX with that row present. An empty index masks column drift: a table
+ * column or form field bound to a nonexistent DB column only fatals when a row
+ * renders or the edit form hydrates. This exercises those deeper paths.
+ *
+ * DealResource is skipped (built by a concurrent task). Resources whose model
+ * has no factory are skipped and reported.
+ */
+class ResourceEditPageMountTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function actingManagerWithTeam(): Team
+    {
+        Role::findOrCreate('manager', 'web');
+        $user = User::factory()->withPersonalTeam()->create(['email_verified_at' => now()]);
+        $team = $user->ownedTeams->first();
+        $user->current_team_id = $team->id;
+        $user->save();
+        $user->assignRole('manager');
+        $this->actingAs($user);
+
+        return $team;
+    }
+
+    public function test_all_resource_edit_and_populated_index_pages_mount(): void
+    {
+        $team = $this->actingManagerWithTeam();
+
+        $failures = [];   // HTTP 500 on edit or index -> resource form/column drift
+        $covered = [];    // mounted 200
+        $skipped = [];    // model has no factory
+        $flagged = [];    // factory cannot seed a row -> model/migration drift
+
+        foreach (glob(app_path('Filament/App/Resources/*Resource.php')) as $file) {
+            $basename = basename($file, '.php');
+
+            // Concurrent task owns DealResource — do not touch it here.
+            if ($basename === 'DealResource') {
+                continue;
+            }
+
+            $class = 'App\\Filament\\App\\Resources\\'.$basename;
+
+            if (! class_exists($class) || ! isset($class::getPages()['edit'])) {
+                continue;
+            }
+
+            $model = $class::getModel();
+
+            if (! $this->modelHasFactory($model)) {
+                $skipped[] = class_basename($class);
+
+                continue;
+            }
+
+            $attrs = [];
+            if (Schema::hasColumn((new $model)->getTable(), 'team_id')) {
+                $attrs['team_id'] = $team->id;
+            }
+
+            try {
+                $record = $model::factory()->create($attrs);
+            } catch (\Throwable $e) {
+                $flagged[] = class_basename($class).' [seed]: '.$this->oneLine($e);
+
+                continue;
+            }
+
+            $slug = $class::getSlug();
+            $editStatus = $this->get('/app/'.$team->id.'/'.$slug.'/'.$record->getKey().'/edit')->status();
+            $indexStatus = $this->get('/app/'.$team->id.'/'.$slug)->status();
+
+            if ($editStatus === 500 || $indexStatus === 500) {
+                $failures[] = class_basename($class)." (edit={$editStatus}, index={$indexStatus})";
+            } else {
+                $covered[] = class_basename($class);
+            }
+        }
+
+        $this->assertNotEmpty($covered, 'no edit pages were exercised');
+        $this->assertSame([], $failures, implode("\n", [
+            'Edit/index pages that fatal (500): '.implode(', ', $failures),
+            'skipped (no factory): '.implode(', ', $skipped),
+            'flagged (seed failed, needs model/migration): '.implode(' || ', $flagged),
+        ]));
+    }
+
+    /** True only when the model exposes a usable factory class. */
+    private function modelHasFactory(string $model): bool
+    {
+        if (! method_exists($model, 'factory')) {
+            return false;
+        }
+
+        try {
+            return $model::factory() instanceof Factory;
+        } catch (\Throwable) {
+            return false;
+        }
+    }
+
+    private function oneLine(\Throwable $e): string
+    {
+        return class_basename($e).': '.strtok($e->getMessage(), "\n");
+    }
+}

--- a/tests/Feature/MessageFactoryTest.php
+++ b/tests/Feature/MessageFactoryTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Message;
+use App\Models\Team;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+class MessageFactoryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_factory_persists_a_row_using_real_columns(): void
+    {
+        $message = Message::factory()->create();
+
+        $this->assertDatabaseHas('messages', [
+            'id' => $message->id,
+            'channel' => $message->channel,
+            'sender' => $message->sender,
+            'content' => $message->content,
+            'priority' => $message->priority,
+            'status' => $message->status,
+            'account_id' => $message->account_id,
+            'team_id' => $message->team_id,
+        ]);
+    }
+
+    public function test_casts_and_relations_resolve(): void
+    {
+        $message = Message::factory()->create();
+
+        $this->assertIsArray($message->metadata);
+        $this->assertInstanceOf(Carbon::class, $message->timestamp);
+        $this->assertInstanceOf(Team::class, $message->team);
+    }
+}


### PR DESCRIPTION
## DealResource + deeper Filament coverage + MessageFactory fix

| Commit | What |
|--------|------|
| `f18ce20` | **feat(filament)** — Deals had a model/policy/factory/API but **no app-panel UI**. Added `DealResource` (index/create/edit) modeled on `ContactResource`. Handles the `Deal.stage` column-vs-`stage()`-relation name collision with `->options(Stage::pluck())`. |
| `1d089cc` | **fix(factory)** — `MessageFactory` wrote phantom columns (`receiver_id`/`subject`/`type`) → hard error (factories run unguarded). Rewrote to the real messages schema; dropped a `metadata` double-encode. |
| `e0f9fe3` | **test(filament)** — edit-page + populated-index mounts (seed a row per resource) to catch the column/form drift that empty-index mounts mask. Found + fixed `LandingPageResource` (RichEditor on `content` fatals on non-tiptap stored values → Textarea). |

### Testing
- **621 passed, 1 skipped, 0 failed**.
- `composer analyse` clean.

### Coverage found (via the edit-page probe)
- **10 resources** pass edit + populated-index mount cleanly.
- **1 fixed** (LandingPage).
- **8 skipped** — model has no factory (no edit-page coverage possible): Activation, Ad, AdSet, Campaign, Note, OAuthConfiguration, SocialMediaPost, WhatsAppNumber.

### Follow-ups (flagged, not fixed here — factory↔schema drift)
Three resources have factories that write columns their table lacks, so seeding fails (edit pages not yet covered). Each needs either a column-adding migration or a factory trim + a check that the resource form doesn't also bind the missing column:
- `CallSettingResource` — `call_settings` has no `provider` (factory also writes api_key/api_secret/from_number/settings/status).
- `FormBuilderResource` — `form_builders` has no `settings`.
- `MarketingCampaignResource` — `marketing_campaigns` has no `description`.

Plus: 8 models still lack factories (blocks edit-page coverage for those resources).
