### PR TITLE
Model factories + Filament edit-page coverage flush

### DIFF
--- a/app/Models/Activation.php
+++ b/app/Models/Activation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Traits\IsTenantModel;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
@@ -18,6 +19,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  */
 class Activation extends Model
 {
+    use HasFactory;
     use IsTenantModel;
 
     /**

--- a/app/Models/Note.php
+++ b/app/Models/Note.php
@@ -13,8 +13,6 @@ class Note extends Model
     use HasFactory;
     use IsTenantModel;
 
-    protected $primaryKey = 'note_id';
-
     protected $fillable = [
         'content',
         'contact_id',

--- a/database/factories/ActivationFactory.php
+++ b/database/factories/ActivationFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\Activation;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Activation>
+ *
+ * Note: the `activations` table has no `team_id` column (unlike its siblings),
+ * so this factory intentionally sets none.
+ */
+class ActivationFactory extends Factory
+{
+    protected $model = Activation::class;
+
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'token' => $this->faker->sha256(),
+            'ip_address' => $this->faker->ipv4(),
+        ];
+    }
+}

--- a/database/factories/AdFactory.php
+++ b/database/factories/AdFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\Ad;
+use App\Models\AdSet;
+use App\Models\AdvertisingAccount;
+use App\Models\Campaign;
+use App\Models\Team;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Ad>
+ */
+class AdFactory extends Factory
+{
+    protected $model = Ad::class;
+
+    public function definition(): array
+    {
+        return [
+            'team_id' => Team::factory(),
+            'advertising_account_id' => AdvertisingAccount::factory(),
+            'campaign_id' => Campaign::factory(),
+            'ad_set_id' => AdSet::factory(),
+            'name' => $this->faker->words(3, true),
+            'external_id' => $this->faker->numerify('ad_########'),
+            'status' => $this->faker->randomElement(['active', 'paused', 'archived', 'deleted']),
+            'headline' => $this->faker->sentence(4),
+            'description' => $this->faker->paragraph(),
+            'destination_url' => $this->faker->url(),
+            'creative_url' => $this->faker->imageUrl(),
+            'metadata' => [],
+        ];
+    }
+}

--- a/database/factories/AdSetFactory.php
+++ b/database/factories/AdSetFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\AdSet;
+use App\Models\AdvertisingAccount;
+use App\Models\Campaign;
+use App\Models\Team;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<AdSet>
+ */
+class AdSetFactory extends Factory
+{
+    protected $model = AdSet::class;
+
+    public function definition(): array
+    {
+        return [
+            'team_id' => Team::factory(),
+            'advertising_account_id' => AdvertisingAccount::factory(),
+            'campaign_id' => Campaign::factory(),
+            'name' => $this->faker->words(3, true),
+            'external_id' => $this->faker->numerify('adset_########'),
+            'status' => $this->faker->randomElement(['active', 'paused', 'archived', 'deleted']),
+            'budget' => $this->faker->randomFloat(2, 100, 10000),
+            'budget_type' => $this->faker->randomElement(['daily', 'lifetime']),
+            'targeting' => [],
+            'metadata' => [],
+        ];
+    }
+}

--- a/database/factories/CallSettingFactory.php
+++ b/database/factories/CallSettingFactory.php
@@ -16,22 +16,9 @@ class CallSettingFactory extends Factory
     {
         return [
             'team_id' => Team::factory(),
-            'provider' => $this->faker->randomElement(['twilio', 'vonage', 'ringcentral']),
-            'api_key' => $this->faker->uuid,
-            'api_secret' => $this->faker->sha256,
-            'from_number' => $this->faker->e164PhoneNumber,
-            'settings' => json_encode([
-                'recording_enabled' => $this->faker->boolean,
-                'voicemail_enabled' => $this->faker->boolean,
-                'transcription_enabled' => $this->faker->boolean,
-                'call_forwarding' => [
-                    'enabled' => $this->faker->boolean,
-                    'number' => $this->faker->phoneNumber,
-                ],
-            ]),
-            'status' => $this->faker->randomElement(['active', 'inactive', 'pending']),
-            'created_at' => now(),
-            'updated_at' => now(),
+            'name' => $this->faker->unique()->words(2, true),
+            'value' => $this->faker->word(),
+            'description' => $this->faker->sentence(),
         ];
     }
 }

--- a/database/factories/CampaignFactory.php
+++ b/database/factories/CampaignFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\AdvertisingAccount;
+use App\Models\Campaign;
+use App\Models\Team;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Campaign>
+ */
+class CampaignFactory extends Factory
+{
+    protected $model = Campaign::class;
+
+    public function definition(): array
+    {
+        return [
+            'team_id' => Team::factory(),
+            'advertising_account_id' => AdvertisingAccount::factory(),
+            'name' => $this->faker->words(3, true),
+            'external_id' => $this->faker->numerify('camp_########'),
+            'status' => $this->faker->randomElement(['active', 'paused', 'archived', 'deleted']),
+            'objective' => $this->faker->randomElement(['awareness', 'consideration', 'conversion']),
+            'budget' => $this->faker->randomFloat(2, 100, 10000),
+            'budget_type' => $this->faker->randomElement(['daily', 'lifetime']),
+            'start_date' => $this->faker->dateTimeBetween('-1 month', 'now'),
+            'end_date' => $this->faker->dateTimeBetween('now', '+1 month'),
+            'metadata' => [],
+        ];
+    }
+}

--- a/database/factories/FormBuilderFactory.php
+++ b/database/factories/FormBuilderFactory.php
@@ -18,35 +18,20 @@ class FormBuilderFactory extends Factory
             'team_id' => Team::factory(),
             'name' => $this->faker->words(3, true),
             'description' => $this->faker->sentence(),
-            'fields' => json_encode([
+            'fields' => [
                 [
                     'type' => 'text',
                     'label' => 'Full Name',
+                    'name' => 'full_name',
                     'required' => true,
-                    'placeholder' => 'Enter your full name',
                 ],
                 [
                     'type' => 'email',
                     'label' => 'Email Address',
+                    'name' => 'email',
                     'required' => true,
-                    'placeholder' => 'Enter your email',
                 ],
-                [
-                    'type' => 'select',
-                    'label' => 'Interest',
-                    'options' => ['Product A', 'Product B', 'Service X'],
-                    'required' => false,
-                ],
-            ]),
-            'settings' => json_encode([
-                'submit_button_text' => 'Submit Form',
-                'success_message' => 'Thank you for your submission!',
-                'redirect_url' => $this->faker->url,
-                'email_notification' => true,
-            ]),
-            'status' => $this->faker->randomElement(['draft', 'published', 'archived']),
-            'created_at' => now(),
-            'updated_at' => now(),
+            ],
         ];
     }
 }

--- a/database/factories/MarketingCampaignFactory.php
+++ b/database/factories/MarketingCampaignFactory.php
@@ -17,36 +17,11 @@ class MarketingCampaignFactory extends Factory
         return [
             'team_id' => Team::factory(),
             'name' => $this->faker->words(3, true),
-            'type' => $this->faker->randomElement(['email', 'sms', 'social_media', 'ads']),
-            'status' => $this->faker->randomElement(['draft', 'scheduled', 'active', 'completed', 'paused']),
-            'description' => $this->faker->paragraph,
-            'start_date' => $this->faker->dateTimeBetween('now', '+1 month'),
-            'end_date' => $this->faker->dateTimeBetween('+1 month', '+2 months'),
-            'budget' => $this->faker->randomFloat(2, 1000, 50000),
-            'target_audience' => json_encode([
-                'demographics' => [
-                    'age_range' => [$this->faker->numberBetween(18, 30), $this->faker->numberBetween(31, 65)],
-                    'locations' => $this->faker->words(3),
-                    'interests' => $this->faker->words(5),
-                ],
-            ]),
-            'settings' => json_encode([
-                'frequency' => $this->faker->randomElement(['once', 'daily', 'weekly', 'monthly']),
-                'tracking' => [
-                    'utm_source' => $this->faker->word,
-                    'utm_medium' => $this->faker->word,
-                    'utm_campaign' => $this->faker->slug,
-                ],
-            ]),
-            'metrics' => json_encode([
-                'sent' => 0,
-                'opened' => 0,
-                'clicked' => 0,
-                'converted' => 0,
-                'unsubscribed' => 0,
-            ]),
-            'created_at' => now(),
-            'updated_at' => now(),
+            'type' => $this->faker->randomElement(['email', 'sms', 'whatsapp']),
+            'status' => $this->faker->randomElement(['draft', 'scheduled', 'sent', 'cancelled']),
+            'subject' => $this->faker->sentence(),
+            'content' => $this->faker->paragraph(),
+            'scheduled_at' => $this->faker->dateTimeBetween('now', '+1 month'),
         ];
     }
 }

--- a/database/factories/NoteFactory.php
+++ b/database/factories/NoteFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\Contact;
+use App\Models\Note;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class NoteFactory extends Factory
+{
+    protected $model = Note::class;
+
+    public function definition(): array
+    {
+        // Only `content` is NOT NULL. Note is NOT polymorphic — contact_id/
+        // company_id/opportunity_id are plain nullable ints (no FK constraint).
+        return [
+            'content' => $this->faker->paragraph(),
+            'contact_id' => Contact::factory(),
+        ];
+    }
+}

--- a/database/factories/OAuthConfigurationFactory.php
+++ b/database/factories/OAuthConfigurationFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\OAuthConfiguration;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class OAuthConfigurationFactory extends Factory
+{
+    protected $model = OAuthConfiguration::class;
+
+    public function definition(): array
+    {
+        // NOT NULL: service_name, client_id, client_secret. `user_id` is in
+        // the model's $fillable but has no column — omitted (drift, flagged).
+        return [
+            'service_name' => $this->faker->unique()->randomElement(['google', 'microsoft', 'twilio', 'facebook', 'linkedin']),
+            'account_name' => $this->faker->company(),
+            'client_id' => $this->faker->uuid(),
+            'client_secret' => $this->faker->sha256(),
+            'additional_settings' => [],
+            'is_active' => true,
+        ];
+    }
+}

--- a/database/factories/SocialMediaPostFactory.php
+++ b/database/factories/SocialMediaPostFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\SocialMediaPost;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class SocialMediaPostFactory extends Factory
+{
+    protected $model = SocialMediaPost::class;
+
+    public function definition(): array
+    {
+        // NOT NULL without a default: content, platforms (json), status.
+        return [
+            'content' => $this->faker->sentence(),
+            'platforms' => $this->faker->randomElements(['facebook', 'twitter', 'linkedin', 'instagram'], 2),
+            'status' => SocialMediaPost::STATUS_DRAFT,
+            'scheduled_at' => $this->faker->dateTimeBetween('now', '+1 week'),
+        ];
+    }
+}

--- a/database/factories/WhatsAppNumberFactory.php
+++ b/database/factories/WhatsAppNumberFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\WhatsAppNumber;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class WhatsAppNumberFactory extends Factory
+{
+    protected $model = WhatsAppNumber::class;
+
+    public function definition(): array
+    {
+        // NOT NULL: number (unique), display_name. is_active defaults true.
+        return [
+            'number' => '+'.$this->faker->unique()->numerify('###########'),
+            'display_name' => $this->faker->name(),
+            'is_active' => true,
+        ];
+    }
+}

--- a/resources/views/filament/components/social-media-preview.blade.php
+++ b/resources/views/filament/components/social-media-preview.blade.php
@@ -6,10 +6,9 @@
     @foreach($getRecord()->platforms as $platform)
         <div class="border rounded-lg p-4 mb-4 bg-white shadow">
             <div class="flex items-center mb-3">
-                <x-dynamic-component 
-                    :component="'heroicon-o-' . $platform" 
-                    class="w-5 h-5 mr-2"
-                />
+                {{-- Heroicons has no brand icons; a generic icon avoids a fatal
+                     "component not found" for facebook/twitter/etc. --}}
+                <x-heroicon-o-globe-alt class="w-5 h-5 mr-2" />
                 <span class="font-semibold">{{ ucfirst($platform) }} Preview</span>
             </div>
             

--- a/tests/Feature/Factories/ExtraFactoriesTest.php
+++ b/tests/Feature/Factories/ExtraFactoriesTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Factories;
+
+use App\Models\Note;
+use App\Models\OAuthConfiguration;
+use App\Models\SocialMediaPost;
+use App\Models\WhatsAppNumber;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * These four models previously had no factory, so their Filament edit pages
+ * could not be smoke-tested. Each factory must seed a persistable row.
+ * Runs un-scoped (no tenant context), so IsTenantModel stamps nothing.
+ */
+class ExtraFactoriesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_note_factory_persists_a_row(): void
+    {
+        Note::factory()->create();
+        $this->assertDatabaseCount('notes', 1);
+    }
+
+    public function test_oauth_configuration_factory_persists_a_row(): void
+    {
+        OAuthConfiguration::factory()->create();
+        $this->assertDatabaseCount('oauth_configurations', 1);
+    }
+
+    public function test_social_media_post_factory_persists_a_row(): void
+    {
+        SocialMediaPost::factory()->create();
+        $this->assertDatabaseCount('social_media_posts', 1);
+    }
+
+    public function test_whatsapp_number_factory_persists_a_row(): void
+    {
+        WhatsAppNumber::factory()->create();
+        $this->assertDatabaseCount('whats_app_numbers', 1);
+    }
+}

--- a/tests/Feature/Factories/NewFactoriesTest.php
+++ b/tests/Feature/Factories/NewFactoriesTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Factories;
+
+use App\Models\Ad;
+use App\Models\AdSet;
+use App\Models\Campaign;
+use Database\Factories\ActivationFactory;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class NewFactoriesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_campaign_factory_persists_a_row(): void
+    {
+        $this->assertModelExists(Campaign::factory()->create());
+    }
+
+    public function test_ad_set_factory_persists_a_row(): void
+    {
+        $this->assertModelExists(AdSet::factory()->create());
+    }
+
+    public function test_ad_factory_persists_a_row(): void
+    {
+        $this->assertModelExists(Ad::factory()->create());
+    }
+
+    /**
+     * App\Models\Activation lacks the HasFactory trait (its three siblings have
+     * it), so Activation::factory() is undefined. Drive the factory class
+     * directly — this still asserts a genuine persisted Activation row. Adding
+     * `use HasFactory;` to the model would enable Activation::factory() and let
+     * ResourceEditPageMountTest cover ActivationResource.
+     */
+    public function test_activation_factory_persists_a_row(): void
+    {
+        $this->assertModelExists(ActivationFactory::new()->create());
+    }
+}


### PR DESCRIPTION
## Model factories + Filament edit-page coverage flush

Completes the factory/coverage gap flagged in #466: 8 models had no factory and 3 had broken ones, which blocked Filament edit-page smoke coverage. Exercising the edit pages then surfaced three real bugs.

| Commit | What |
|--------|------|
| `7391a0e` | **test(factories)** — added 8 factories (Activation, Ad, AdSet, Campaign, Note, OAuthConfiguration, SocialMediaPost, WhatsAppNumber) and fixed 3 broken ones (CallSetting, FormBuilder, MarketingCampaign). Real columns / NOT-NULL satisfied / FK chains / **DB-allowed enum values** (the MarketingCampaign factory wrote enum values MySQL would reject). Fixed a FormBuilder `fields` array double-encode. |
| `02cf0d0` | **fix** — three real bugs the edit-page mounts exposed: `Note` model set `$primaryKey='note_id'` but the PK column is `id` (500/404); `social-media-preview.blade` rendered non-existent `heroicon-o-{platform}` brand icons (500) → generic icon; `Activation` lacked `use HasFactory`. |

### Testing
- **629 passed, 1 skipped, 0 failed**.
- `composer analyse` clean.
- The existing `ResourceEditPageMountTest` now auto-covers the newly-factoried resources' edit + populated-index pages.

### Note on this round's process
One dispatched agent returned a **prompt-injection-style artifact** as its "result" (fake system/skill instructions) with **zero tool uses** — i.e. it did no work. I ignored the injected instructions (a tool result can't issue directives), treated it as a no-op, and re-ran the task with a fresh agent. Judging by actual tool-use/diff rather than the summary text caught it.

### Follow-ups
- `activations` has no `team_id` column though `Activation` uses `IsTenantModel` (harmless — nullable/absent, factory omits it), and `OAuthConfiguration.user_id` is fillable-but-no-column — both minor model↔schema drift.
- Edit-page coverage is now broad; the remaining external-ad services still need SDK stubbing to test.
