### PR TITLE
Bulk-assign authz + marketing-job leak fix + scheduled command coverage

### DIFF
--- a/app/Console/Commands/UpdatePostAnalytics.php
+++ b/app/Console/Commands/UpdatePostAnalytics.php
@@ -53,7 +53,9 @@ class UpdatePostAnalytics extends Command
         switch ($platform) {
             case 'facebook':
                 if (isset($postIds['facebook'])) {
-                    $service = new FacebookService;
+                    // Resolve via the container (not `new`) so the client is swappable
+                    // and matches PublishScheduledPosts; the ctor builds a live SDK client.
+                    $service = app(FacebookService::class);
                     $insights = $service->getPostInsights($postIds['facebook']);
 
                     return [

--- a/app/Http/Controllers/Api/ContactController.php
+++ b/app/Http/Controllers/Api/ContactController.php
@@ -132,6 +132,12 @@ class ContactController extends Controller
             'user_id' => 'required|integer|exists:users,id',
         ]);
 
+        // Assignee must be a member of the caller's current team, else this
+        // leaks records across tenants. Refuse before touching any record.
+        $team = $request->user()?->currentTeam;
+        $assignee = \App\Models\User::find($request->input('user_id'));
+        abort_unless($team && $assignee?->belongsToTeam($team), 403);
+
         $query = Contact::whereIn('id', $request->input('ids'));
         $query->byTeam($request->user()?->currentTeam?->id);
         $count = $query->update(['user_id' => $request->input('user_id')]);

--- a/app/Http/Controllers/Api/DealController.php
+++ b/app/Http/Controllers/Api/DealController.php
@@ -133,6 +133,12 @@ class DealController extends Controller
             'user_id' => 'required|integer|exists:users,id',
         ]);
 
+        // Assignee must be a member of the caller's current team, else this
+        // leaks records across tenants. Refuse before touching any record.
+        $team = $request->user()?->currentTeam;
+        $assignee = \App\Models\User::find($request->input('user_id'));
+        abort_unless($team && $assignee?->belongsToTeam($team), 403);
+
         $query = Deal::whereIn('id', $request->input('ids'));
         $query->byTeam($request->user()?->currentTeam?->id);
         $count = $query->update(['user_id' => $request->input('user_id')]);

--- a/app/Http/Controllers/Api/TaskController.php
+++ b/app/Http/Controllers/Api/TaskController.php
@@ -131,9 +131,16 @@ class TaskController extends Controller
             'user_id' => 'required|integer|exists:users,id',
         ]);
 
+        // Assignee must be a member of the caller's current team, else this
+        // leaks records across tenants. Refuse before touching any record.
+        $team = $request->user()?->currentTeam;
+        $assignee = \App\Models\User::find($request->input('user_id'));
+        abort_unless($team && $assignee?->belongsToTeam($team), 403);
+
         $query = Task::whereIn('id', $request->input('ids'));
         $query->byTeam($request->user()?->currentTeam?->id);
-        $count = $query->update(['user_id' => $request->input('user_id')]);
+        // Tasks store the assignee in `assigned_to` (there is no user_id column).
+        $count = $query->update(['assigned_to' => $request->input('user_id')]);
 
         return response()->json(['assigned' => $count]);
     }

--- a/app/Jobs/ExecuteWorkflowAction.php
+++ b/app/Jobs/ExecuteWorkflowAction.php
@@ -2,7 +2,7 @@
 
 namespace App\Jobs;
 
-use App\Models\Lead;
+use App\Jobs\Concerns\TenantAware;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -11,10 +11,13 @@ use Illuminate\Queue\SerializesModels;
 
 class ExecuteWorkflowAction implements ShouldQueue
 {
-    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels, TenantAware;
 
     public function __construct(protected array $action, protected \App\Models\Lead $lead)
     {
+        // Lead/Contact are tenant-scoped; remember the dispatching team so the
+        // relation read below stays scoped inside the worker.
+        $this->captureTenant();
     }
 
     public function handle(): void
@@ -40,6 +43,7 @@ class ExecuteWorkflowAction implements ShouldQueue
     {
         $allowed = ['name', 'last_name', 'email', 'phone_number', 'status', 'industry', 'company_size', 'annual_revenue', 'lifecycle_stage', 'custom_fields'];
         $data = array_intersect_key($this->action['data'] ?? [], array_flip($allowed));
-        $this->lead->contact->update($data);
+        // A lead may have no contact yet — no-op instead of fataling on null.
+        $this->lead->contact?->update($data);
     }
 }

--- a/app/Jobs/SendMarketingCampaign.php
+++ b/app/Jobs/SendMarketingCampaign.php
@@ -2,7 +2,7 @@
 
 namespace App\Jobs;
 
-use App\Models\MarketingCampaign;
+use App\Jobs\Concerns\TenantAware;
 use App\Services\MailChimpService;
 use App\Services\TwilioService;
 use App\Services\WhatsAppBusinessService;
@@ -16,10 +16,13 @@ use Illuminate\Support\Facades\Log;
 
 class SendMarketingCampaign implements ShouldQueue
 {
-    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels, TenantAware;
 
     public function __construct(protected \App\Models\MarketingCampaign $campaign)
     {
+        // Campaign + recipients are tenant-scoped; remember the dispatching team
+        // so the recipient update below can't leak across teams in the worker.
+        $this->captureTenant();
     }
 
     public function handle(MailChimpService $mailchimp, TwilioService $twilio, WhatsAppBusinessService $whatsapp): void
@@ -37,6 +40,8 @@ class SendMarketingCampaign implements ShouldQueue
                     break;
             }
 
+            // Mark this campaign's recipients as sent (tenant-scoped bulk update).
+            $this->campaign->recipients()->update(['status' => 'sent']);
             $this->campaign->update(['status' => 'sent']);
         } catch (Exception $e) {
             Log::error('Failed to send marketing campaign: '.$e->getMessage());

--- a/tests/Feature/Api/BulkAssignAuthzTest.php
+++ b/tests/Feature/Api/BulkAssignAuthzTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Contact;
+use App\Models\Deal;
+use App\Models\Task;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+/**
+ * Bulk-assign must only accept an assignee who is a member of the caller's
+ * current team. Assigning your team's records to a user in another team (or a
+ * teamless user) is a cross-tenant data-integrity hole; the endpoint must
+ * reject it and leave the records untouched.
+ */
+class BulkAssignAuthzTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function actingUser(): User
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        Sanctum::actingAs($user);
+
+        return $user;
+    }
+
+    /** A real member of $team (not its owner). */
+    private function teammate(User $owner): User
+    {
+        $mate = User::factory()->create();
+        $mate->teams()->attach($owner->currentTeam, ['role' => 'member']);
+
+        return $mate;
+    }
+
+    /** Owns their own team; not a member of the caller's team. */
+    private function outsider(): User
+    {
+        return User::factory()->withPersonalTeam()->create();
+    }
+
+    // --------------------------------------------------------------- deals
+
+    public function test_deals_assign_to_same_team_member_succeeds(): void
+    {
+        $user = $this->actingUser();
+        $mate = $this->teammate($user);
+        $deal = Deal::factory()->create(['team_id' => $user->currentTeam->id, 'user_id' => null]);
+
+        $this->postJson('/api/v1/deals/bulk/assign', [
+            'ids' => [$deal->id],
+            'user_id' => $mate->id,
+        ])
+            ->assertOk()
+            ->assertJson(['assigned' => 1]);
+
+        $this->assertDatabaseHas('deals', ['id' => $deal->id, 'user_id' => $mate->id]);
+    }
+
+    public function test_deals_assign_to_other_team_user_is_rejected(): void
+    {
+        $user = $this->actingUser();
+        $outsider = $this->outsider();
+        $deal = Deal::factory()->create(['team_id' => $user->currentTeam->id, 'user_id' => null]);
+
+        $this->postJson('/api/v1/deals/bulk/assign', [
+            'ids' => [$deal->id],
+            'user_id' => $outsider->id,
+        ])->assertForbidden();
+
+        $this->assertDatabaseMissing('deals', ['id' => $deal->id, 'user_id' => $outsider->id]);
+    }
+
+    // --------------------------------------------------------------- tasks
+
+    public function test_tasks_assign_to_same_team_member_succeeds(): void
+    {
+        $user = $this->actingUser();
+        $mate = $this->teammate($user);
+        $task = Task::factory()->create(['team_id' => $user->currentTeam->id, 'assigned_to' => null]);
+
+        $this->postJson('/api/v1/tasks/bulk/assign', [
+            'ids' => [$task->id],
+            'user_id' => $mate->id,
+        ])
+            ->assertOk()
+            ->assertJson(['assigned' => 1]);
+
+        $this->assertDatabaseHas('tasks', ['id' => $task->id, 'assigned_to' => $mate->id]);
+    }
+
+    public function test_tasks_assign_to_other_team_user_is_rejected(): void
+    {
+        $user = $this->actingUser();
+        $outsider = $this->outsider();
+        $task = Task::factory()->create(['team_id' => $user->currentTeam->id, 'assigned_to' => null]);
+
+        $this->postJson('/api/v1/tasks/bulk/assign', [
+            'ids' => [$task->id],
+            'user_id' => $outsider->id,
+        ])->assertForbidden();
+
+        $this->assertDatabaseMissing('tasks', ['id' => $task->id, 'assigned_to' => $outsider->id]);
+    }
+
+    // ------------------------------------------------------------ contacts
+
+    // Contacts have no assignee column (see summary — needs a migration), so
+    // only the security property is asserted: a cross-team assignee is refused
+    // before any write runs, and the record is left intact.
+    public function test_contacts_assign_to_other_team_user_is_rejected(): void
+    {
+        $user = $this->actingUser();
+        $outsider = $this->outsider();
+        $contact = Contact::factory()->create(['team_id' => $user->currentTeam->id]);
+
+        $this->postJson('/api/v1/contacts/bulk/assign', [
+            'ids' => [$contact->id],
+            'user_id' => $outsider->id,
+        ])->assertForbidden();
+
+        $this->assertDatabaseHas('contacts', ['id' => $contact->id]);
+    }
+}

--- a/tests/Feature/Api/DealApiTest.php
+++ b/tests/Feature/Api/DealApiTest.php
@@ -249,6 +249,9 @@ class DealApiTest extends TestCase
         // Distinct assignee so the foreign deal's pre-stamped creator (this
         // caller) can't masquerade as a successful cross-team assignment.
         $assignee = User::factory()->create();
+        // Bulk-assign now rejects cross-team/teamless assignees, so the
+        // assignee must be a member of the caller's team.
+        $assignee->teams()->attach($user->currentTeam, ['role' => 'member']);
         $own = Deal::factory()->create(['team_id' => $user->currentTeam->id]);
         $foreign = Deal::factory()->create(['team_id' => $this->foreignTeamId()]);
 

--- a/tests/Feature/Console/CommandsTest.php
+++ b/tests/Feature/Console/CommandsTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\SocialMediaPost;
+use App\Models\Task;
+use App\Models\User;
+use App\Notifications\TaskReminderNotification;
+use App\Services\FacebookService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Notification;
+use Tests\TestCase;
+
+class CommandsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_publish_scheduled_posts_flips_due_post_to_published(): void
+    {
+        // Mock the Facebook client so no real Graph call fires.
+        $this->mock(FacebookService::class)
+            ->shouldReceive('publishPost')
+            ->once()
+            ->andReturn(['id' => 'fb-post-123']);
+
+        $post = SocialMediaPost::factory()->create([
+            'status' => SocialMediaPost::STATUS_SCHEDULED,
+            'scheduled_at' => now()->subMinutes(10),
+            'platforms' => ['facebook'],
+            'content' => 'Hello world',
+        ]);
+
+        $this->artisan('social-media:publish-scheduled')->assertSuccessful();
+
+        $post->refresh();
+        $this->assertSame(SocialMediaPost::STATUS_PUBLISHED, $post->status);
+        $this->assertSame('fb-post-123', $post->platform_post_ids['facebook']);
+    }
+
+    public function test_send_reminders_notifies_assignee_and_flags_task(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create();
+        // reminderDue() = reminder_date in the past + reminder_sent false.
+        $task = Task::factory()->reminderDue()->create([
+            'assigned_to' => $user->id,
+        ]);
+
+        $this->artisan('reminders:send')->assertSuccessful();
+
+        Notification::assertSentTo($user, TaskReminderNotification::class);
+        $this->assertTrue($task->fresh()->reminder_sent);
+    }
+
+    public function test_update_post_analytics_writes_metrics_for_published_post(): void
+    {
+        // Mock the Facebook client so getPostInsights returns canned data.
+        $this->mock(FacebookService::class)
+            ->shouldReceive('getPostInsights')
+            ->once()
+            ->andReturn(['post_impressions' => 42]);
+
+        $post = SocialMediaPost::factory()->create([
+            'status' => SocialMediaPost::STATUS_PUBLISHED,
+            'platforms' => ['facebook'],
+            'platform_post_ids' => ['facebook' => 'fb-post-123'],
+            'impressions' => 0,
+        ]);
+
+        // The command only touches posts untouched for >1h; age the row past that gate.
+        DB::table('social_media_posts')
+            ->where('id', $post->id)
+            ->update(['updated_at' => now()->subHours(2)]);
+
+        $this->artisan('social-media:update-analytics')->assertSuccessful();
+
+        $this->assertSame(42, $post->fresh()->impressions);
+    }
+}

--- a/tests/Feature/Jobs/JobsTest.php
+++ b/tests/Feature/Jobs/JobsTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Tests\Feature\Jobs;
+
+use App\Jobs\ExecuteWorkflowAction;
+use App\Jobs\SendMarketingCampaign;
+use App\Models\CampaignRecipient;
+use App\Models\Contact;
+use App\Models\Lead;
+use App\Models\MarketingCampaign;
+use App\Models\Team;
+use App\Services\MailChimpService;
+use App\Services\TwilioService;
+use App\Services\WhatsAppBusinessService;
+use App\Support\TenantContext;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Tests\TestCase;
+
+class JobsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Run the job's handle() the way the worker would: with the dispatching
+     * team restored by the TenantAware middleware around it.
+     */
+    private function runInWorker(object $job, callable $handle): void
+    {
+        // The worker process is un-scoped; the middleware must restore context.
+        TenantContext::clear();
+        $job->middleware()[0]->handle($job, $handle);
+    }
+
+    public function test_execute_workflow_action_updates_the_leads_contact(): void
+    {
+        $team = Team::factory()->create();
+        TenantContext::set($team->id);
+
+        $contact = Contact::factory()->create([
+            'team_id' => $team->id,
+            'status' => 'inactive',
+            'phone_number' => '000',
+        ]);
+        $lead = Lead::factory()->create([
+            'team_id' => $team->id,
+            'contact_id' => $contact->id,
+        ]);
+
+        $job = new ExecuteWorkflowAction(
+            ['type' => 'update_contact', 'data' => ['status' => 'active', 'phone_number' => '555-1234']],
+            $lead,
+        );
+        // TenantAware captured the dispatching team at construct time.
+        $this->assertSame($team->id, $job->tenantId);
+
+        $this->runInWorker($job, fn ($j) => $j->handle());
+
+        $contact->refresh();
+        $this->assertSame('active', $contact->status);
+        $this->assertSame('555-1234', $contact->phone_number);
+    }
+
+    public function test_execute_workflow_action_is_safe_when_lead_has_no_contact(): void
+    {
+        $team = Team::factory()->create();
+        TenantContext::set($team->id);
+
+        // contact_id is nullable and unset — the null-safe update must no-op.
+        $lead = Lead::factory()->create(['team_id' => $team->id]);
+
+        $job = new ExecuteWorkflowAction(
+            ['type' => 'update_contact', 'data' => ['status' => 'active']],
+            $lead,
+        );
+
+        $this->runInWorker($job, fn ($j) => $j->handle());
+
+        $this->assertNull($lead->fresh()->contact_id);
+    }
+
+    public function test_send_marketing_campaign_marks_its_recipients_and_campaign_sent(): void
+    {
+        $team = Team::factory()->create();
+        $otherTeam = Team::factory()->create();
+
+        // team_id is not fillable on these models — IsTenantModel auto-stamps it
+        // from the active context on create, so set the context per row.
+        TenantContext::set($team->id);
+        $campaign = MarketingCampaign::factory()->create([
+            'type' => 'email',
+            'status' => 'draft',
+        ]);
+        $mine = CampaignRecipient::create([
+            'marketing_campaign_id' => $campaign->id,
+            'recipient_type' => Contact::class,
+            'recipient_id' => 1,
+            'email' => 'me@example.test',
+            'status' => 'pending',
+        ]);
+
+        // Same campaign id, different team: TenantAware must keep this untouched.
+        TenantContext::set($otherTeam->id);
+        $leaked = CampaignRecipient::create([
+            'marketing_campaign_id' => $campaign->id,
+            'recipient_type' => Contact::class,
+            'recipient_id' => 2,
+            'email' => 'other@example.test',
+            'status' => 'pending',
+        ]);
+
+        TenantContext::set($team->id);
+        $job = new SendMarketingCampaign($campaign);
+        $this->assertSame($team->id, $job->tenantId);
+
+        // External senders are stubbed no-ops; mock them so nothing hits the network.
+        $handle = fn ($j) => $j->handle(
+            Mockery::mock(MailChimpService::class),
+            Mockery::mock(TwilioService::class),
+            Mockery::mock(WhatsAppBusinessService::class),
+        );
+        $this->runInWorker($job, $handle);
+
+        $this->assertSame('sent', $campaign->fresh()->status);
+        $this->assertSame('sent', $mine->fresh()->status);
+        $this->assertSame('pending', $leaked->fresh()->status, 'cross-team recipient must not be marked sent');
+    }
+}


### PR DESCRIPTION
## Bulk-assign authz, marketing-campaign job, scheduled commands

Sweep of the last untested surfaces (API bulk ops, jobs, console commands) — with a security fix and a cross-tenant leak fixed along the way.

| Commit | What |
|--------|------|
| `e6b1bb3` | **fix(api) — security**: `bulk/assign` accepted any `user_id`, so a caller could assign their records to a user in **another team**. Added a `belongsToTeam(currentTeam)` guard (403) to Contact/Deal/Task `bulkAssign`. Also fixed `TaskController::bulkAssign` writing a nonexistent `user_id` column (tasks uses `assigned_to`) → **500 every call**. Updated the now-insecure `DealApiTest`. |
| `9c78e20` | **fix(jobs)**: `SendMarketingCampaign` flipped `campaign.status='sent'` but **never touched recipients** (the send was a no-op). Added the recipient update — which **requires `TenantAware`**: in an un-scoped worker the bulk update would have marked **every team's** recipients of that campaign (cross-tenant leak). Both jobs now carry the dispatching team. Null-safed `ExecuteWorkflowAction`'s contact update. |
| `acf299c` | **test(console)**: `UpdatePostAnalytics` did `new FacebookService` (bypasses the container) → built a live Graph SDK client → would fire a **real API call from the scheduler** → `app(FacebookService::class)`. Adds tests for publish-scheduled / send-reminders / update-analytics (the other two were already correct). |

### Testing
- **682 passed, 1 skipped, 0 failed**.
- `composer analyse` clean. No migrations this round.

### Follow-ups (flagged, deferred)
- **`contacts` has no assignee column** — `ContactController::bulkAssign`'s happy path 500s (pre-existing; the security guard still correctly rejects cross-team). Needs a product decision: add `user_id` to `contacts` (make contacts assignable) or drop the endpoint.
- **`CampaignRecipientFactory` is badly drifted** (wrong FK name `campaign_id`, phantom `contact_id`/timestamp columns, enum values the DB rejects) — unusable; the job test builds recipients directly. Needs rewriting like the earlier factory fixes.
- `team_id` missing from `$fillable` on MarketingCampaign/CampaignRecipient/Lead (present on Contact) — minor test-setup ergonomics.
- The channel send methods (email/SMS/WhatsApp) remain empty stubs — genuine unimplemented features, not bugs.
