### PR TITLE
Filament pages + listeners coverage (fixes /app/new prod break + dead notification path)

### DIFF
--- a/app/Filament/App/Pages/EditTeam.php
+++ b/app/Filament/App/Pages/EditTeam.php
@@ -21,12 +21,6 @@ class EditTeam extends EditTenantProfile
     }
 
     #[\Override]
-    public function mount(): void
-    {
-        abort_unless($this->user()->canCreateTeams(), 403);
-    }
-
-    #[\Override]
     public function form(Schema $schema): Schema
     {
         return $schema
@@ -52,6 +46,16 @@ class EditTeam extends EditTenantProfile
         $this->user()->switchTeam($team);
 
         return redirect()->route('filament.app.tenant.profile', ['tenant' => $team]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    #[\Override]
+    public function getViewData(): array
+    {
+        // The blade view embeds Jetstream team Livewire components that expect $team.
+        return ['team' => $this->tenant];
     }
 
     #[\Override]

--- a/app/Listeners/SendCRMEventNotification.php
+++ b/app/Listeners/SendCRMEventNotification.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use App\Notifications\CRMEventNotification;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Str;
 
 class SendCRMEventNotification implements ShouldQueue
 {
@@ -13,7 +14,9 @@ class SendCRMEventNotification implements ShouldQueue
 
     public function handle($event): void
     {
-        $eventName = class_basename($event);
+        // config/crm.php keys are snake_case (new_lead); class_basename is StudlyCase
+        // (NewLead). Without snake() the lookup always missed and nothing notified.
+        $eventName = Str::snake(class_basename($event));
         $notificationConfig = config("crm.notifications.events.{$eventName}");
 
         if ($notificationConfig) {

--- a/app/Models/CampaignRecipient.php
+++ b/app/Models/CampaignRecipient.php
@@ -20,6 +20,7 @@ class CampaignRecipient extends Model
         'email',
         'phone',
         'status',
+        'team_id',
     ];
 
     public function campaign()

--- a/app/Models/Lead.php
+++ b/app/Models/Lead.php
@@ -29,6 +29,7 @@ class Lead extends Model implements OwnsRecords
         'lifecycle_stage',
         'custom_fields',
         'score',
+        'team_id',
     ];
 
     protected $casts = [

--- a/app/Models/MarketingCampaign.php
+++ b/app/Models/MarketingCampaign.php
@@ -20,6 +20,7 @@ class MarketingCampaign extends Model
         'subject',
         'content',
         'scheduled_at',
+        'team_id',
     ];
 
     protected $casts = [

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -146,6 +146,9 @@ class AppPanelProvider extends PanelProvider
 
     public function shouldRegisterMenuItem(): bool
     {
-        return true; // auth()->user()?->hasVerifiedEmail() && Filament::hasTenancy() && Filament::getTenant();
+        // Only register tenant-scoped menu items (Profile/Team Settings) when a
+        // tenant is set — otherwise their getUrl() throws on the tenant-less
+        // /app/new registration route (UrlGenerationException, missing {tenant}).
+        return (bool) (auth()->user()?->hasVerifiedEmail() && Filament::hasTenancy() && Filament::getTenant());
     }
 }

--- a/database/factories/CampaignRecipientFactory.php
+++ b/database/factories/CampaignRecipientFactory.php
@@ -17,22 +17,13 @@ class CampaignRecipientFactory extends Factory
     public function definition()
     {
         return [
+            'marketing_campaign_id' => MarketingCampaign::factory(),
+            'recipient_type' => Contact::class,
+            'recipient_id' => Contact::factory(),
+            'email' => $this->faker->safeEmail(),
+            'phone' => $this->faker->phoneNumber(),
+            'status' => $this->faker->randomElement(['pending', 'sent', 'failed']),
             'team_id' => Team::factory(),
-            'campaign_id' => MarketingCampaign::factory(),
-            'contact_id' => Contact::factory(),
-            'email' => $this->faker->email,
-            'status' => $this->faker->randomElement(['pending', 'sent', 'opened', 'clicked', 'bounced']),
-            'sent_at' => $this->faker->optional()->dateTimeThisMonth(),
-            'opened_at' => $this->faker->optional()->dateTimeThisMonth(),
-            'clicked_at' => $this->faker->optional()->dateTimeThisMonth(),
-            'bounced_at' => $this->faker->optional()->dateTimeThisMonth(),
-            'metadata' => json_encode([
-                'ip_address' => $this->faker->ipv4,
-                'user_agent' => $this->faker->userAgent,
-                'location' => $this->faker->city,
-            ]),
-            'created_at' => now(),
-            'updated_at' => now(),
         ];
     }
 }

--- a/tests/Feature/Factories/CampaignRecipientFactoryTest.php
+++ b/tests/Feature/Factories/CampaignRecipientFactoryTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Factories;
+
+use App\Models\CampaignRecipient;
+use App\Models\Contact;
+use App\Models\Lead;
+use App\Models\MarketingCampaign;
+use App\Models\Team;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CampaignRecipientFactoryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_factory_persists_a_valid_row_with_real_columns(): void
+    {
+        $recipient = CampaignRecipient::factory()->create();
+
+        $this->assertDatabaseHas('campaign_recipients', [
+            'id' => $recipient->id,
+            'marketing_campaign_id' => $recipient->marketing_campaign_id,
+            'recipient_type' => Contact::class,
+            'recipient_id' => $recipient->recipient_id,
+            'status' => $recipient->status,
+        ]);
+
+        $this->assertContains($recipient->status, ['pending', 'sent', 'failed']);
+        $this->assertInstanceOf(Contact::class, $recipient->recipient);
+    }
+
+    public function test_lead_mass_assigns_team_id(): void
+    {
+        // Mass-assign via Model::create so fillable is actually enforced (a
+        // factory build runs unguarded and would pass regardless). The column
+        // defaults to 1, so the target team must NOT be id 1 or a dropped
+        // team_id would coincidentally match.
+        Team::factory()->create();
+        $team = Team::factory()->create();
+        $this->assertNotSame(1, $team->id);
+
+        $lead = Lead::create(['team_id' => $team->id]);
+
+        $this->assertDatabaseHas('leads', [
+            'id' => $lead->id,
+            'team_id' => $team->id,
+        ]);
+    }
+
+    public function test_marketing_campaign_mass_assigns_team_id(): void
+    {
+        Team::factory()->create();
+        $team = Team::factory()->create();
+        $this->assertNotSame(1, $team->id);
+
+        $campaign = MarketingCampaign::create([
+            'name' => 'Test Campaign',
+            'type' => 'email',
+            'status' => 'draft',
+            'content' => 'Body',
+            'team_id' => $team->id,
+        ]);
+
+        $this->assertDatabaseHas('marketing_campaigns', [
+            'id' => $campaign->id,
+            'team_id' => $team->id,
+        ]);
+    }
+}

--- a/tests/Feature/Filament/PageMountTest.php
+++ b/tests/Feature/Filament/PageMountTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament;
+
+use App\Filament\App\Pages\EditProfile;
+use App\Filament\App\Pages\MailchimpIntegration;
+use App\Filament\App\Pages\PersonalAccessTokensPage;
+use App\Filament\App\Pages\ReportPage;
+use App\Filament\App\Pages\TwilioIntegration;
+use App\Filament\App\Pages\TwilioSettings;
+use App\Filament\App\Pages\UpdateProfileInformationPage;
+use App\Filament\App\Pages\VisualPipeline;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class PageMountTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function actingManagerWithTeam(): Team
+    {
+        Role::findOrCreate('manager', 'web');
+        $user = User::factory()->withPersonalTeam()->create(['email_verified_at' => now()]);
+        $team = $user->ownedTeams->first();
+        $user->current_team_id = $team->id;
+        $user->save();
+        $user->assignRole('manager');
+        $this->actingAs($user);
+
+        return $team;
+    }
+
+    /** Standard team-scoped page: /app/{tenant}/{slug} */
+    private function assertPageMounts(string $page): void
+    {
+        $team = $this->actingManagerWithTeam();
+        $url = '/app/'.$team->id.'/'.$page::getSlug();
+        $this->get($url)->assertStatus(200);
+    }
+
+    public function test_edit_profile_page_mounts(): void
+    {
+        $this->assertPageMounts(EditProfile::class);
+    }
+
+    public function test_mailchimp_integration_page_mounts(): void
+    {
+        $this->assertPageMounts(MailchimpIntegration::class);
+    }
+
+    public function test_personal_access_tokens_page_mounts(): void
+    {
+        $this->assertPageMounts(PersonalAccessTokensPage::class);
+    }
+
+    public function test_report_page_mounts(): void
+    {
+        $this->assertPageMounts(ReportPage::class);
+    }
+
+    public function test_twilio_integration_page_mounts(): void
+    {
+        $this->assertPageMounts(TwilioIntegration::class);
+    }
+
+    public function test_twilio_settings_page_mounts(): void
+    {
+        $this->assertPageMounts(TwilioSettings::class);
+    }
+
+    public function test_update_profile_information_page_mounts(): void
+    {
+        $this->assertPageMounts(UpdateProfileInformationPage::class);
+    }
+
+    public function test_visual_pipeline_page_mounts(): void
+    {
+        $this->assertPageMounts(VisualPipeline::class);
+    }
+
+    // Tenancy pages have their own (non-slug) routes.
+
+    public function test_create_team_page_mounts(): void
+    {
+        $this->actingManagerWithTeam();
+        // /app/new is the tenant-registration route (no tenant in context); the
+        // shouldRegisterMenuItem() guard now skips the tenant-scoped menu items
+        // there, so it no longer throws UrlGenerationException.
+        $this->get('/app/new')->assertStatus(200);
+    }
+
+    public function test_edit_team_page_mounts(): void
+    {
+        $team = $this->actingManagerWithTeam();
+        // EditTeam is the tenant profile page: /app/{tenant}/profile
+        $this->get('/app/'.$team->id.'/profile')->assertStatus(200);
+    }
+}

--- a/tests/Feature/Listeners/ListenersTest.php
+++ b/tests/Feature/Listeners/ListenersTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Listeners;
+
+use App\Enums\Role;
+use App\Events\ContactUpdated;
+use App\Listeners\CreatePersonalTeam;
+use App\Listeners\EmailTracker;
+use App\Listeners\NotifyTeamMembers;
+use App\Listeners\SendCRMEventNotification;
+use App\Listeners\SwitchTeam;
+use App\Models\Contact;
+use App\Models\Team;
+use App\Models\User;
+use App\Notifications\CRMEventNotification;
+use App\Services\TeamManagementService;
+use Database\Seeders\RolesSeeder;
+use Filament\Events\TenantSet;
+use Illuminate\Auth\Events\Registered;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Mail\Events\MessageSent;
+use Illuminate\Mail\SentMessage;
+use Illuminate\Support\Facades\Notification;
+use Laravel\Jetstream\Events\TeamMemberAdded;
+use Spatie\Permission\PermissionRegistrar;
+use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\SentMessage as SymfonySentMessage;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
+use Tests\TestCase;
+
+class ListenersTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolesSeeder::class); // global (team_id = null) role definitions
+    }
+
+    protected function tearDown(): void
+    {
+        // Per-team permission context is a process static; reset so it can't leak.
+        app(PermissionRegistrar::class)->setPermissionsTeamId(null);
+        parent::tearDown();
+    }
+
+    /** Spatie roles are cached per team; refresh after switching the team context. */
+    private function hasRoleInTeam(User $user, ?Team $team, Role $role): bool
+    {
+        setPermissionsTeamId($team?->getKey());
+        $user->unsetRelation('roles');
+
+        return $user->hasRole($role);
+    }
+
+    // --- AssignDefaultTeamRole (TeamMemberAdded) ---------------------------------
+
+    public function test_assign_default_team_role_gives_added_member_sales_rep_in_that_team(): void
+    {
+        $team = Team::factory()->create();
+        $member = User::factory()->create();
+
+        // Dispatched → EventServiceProvider routes it to AssignDefaultTeamRole.
+        event(new TeamMemberAdded($team, $member));
+
+        $this->assertTrue($this->hasRoleInTeam($member, $team, Role::SalesRep));
+        // Scoped to that team only.
+        $this->assertFalse($this->hasRoleInTeam($member, Team::factory()->create(), Role::SalesRep));
+    }
+
+    // --- CreatePersonalTeam (Registered) ----------------------------------------
+
+    public function test_create_personal_team_assigns_registered_user_to_default_team(): void
+    {
+        $defaultTeam = Team::factory()->create(['personal_team' => false]);
+        $user = User::factory()->create();
+
+        app(CreatePersonalTeam::class)->handle(new Registered($user));
+
+        $this->assertTrue($user->fresh()->belongsToTeam($defaultTeam));
+        $this->assertSame($defaultTeam->id, $user->fresh()->current_team_id);
+    }
+
+    // --- SwitchTeam (Filament TenantSet) ----------------------------------------
+
+    public function test_switch_team_scopes_spatie_permissions_to_the_tenant(): void
+    {
+        $team = Team::factory()->create();
+        setPermissionsTeamId(null);
+
+        (new SwitchTeam())->handle(new TenantSet($team, User::factory()->make()));
+
+        $this->assertSame($team->getKey(), getPermissionsTeamId());
+    }
+
+    public function test_switch_team_ignores_non_tenant_set_events(): void
+    {
+        setPermissionsTeamId(null);
+
+        (new SwitchTeam())->handle(new \stdClass());
+
+        $this->assertNull(getPermissionsTeamId());
+    }
+
+    // --- SendCRMEventNotification (config-gated CRM events) ----------------------
+
+    public function test_send_crm_event_notification_notifies_users_for_configured_event(): void
+    {
+        Notification::fake();
+        $users = User::factory()->count(2)->create();
+
+        // class_basename(NewLead) → snake → "new_lead", a truthy config/crm.php key.
+        (new SendCRMEventNotification())->handle(new NewLead());
+
+        Notification::assertSentTo($users, CRMEventNotification::class);
+    }
+
+    public function test_send_crm_event_notification_skips_unconfigured_event(): void
+    {
+        Notification::fake();
+        User::factory()->create();
+
+        (new SendCRMEventNotification())->handle(new SomethingUnconfigured());
+
+        Notification::assertNothingSent();
+    }
+
+    // --- NotifyTeamMembers (ContactUpdated) -------------------------------------
+
+    public function test_notify_team_members_handles_event_without_error(): void
+    {
+        // ponytail: handle() is a comment-only stub (see flag in summary); the only
+        // guarantee it currently makes is that dispatching the event is safe.
+        (new NotifyTeamMembers())->handle(new ContactUpdated(new Contact()));
+
+        $this->assertTrue(true);
+    }
+
+    // --- EmailTracker (MessageSent) ---------------------------------------------
+
+    public function test_email_tracker_is_a_noop_when_campaign_headers_absent(): void
+    {
+        // A normal outbound mail carries no X-Campaign-ID/X-Lead-ID, so the guard
+        // short-circuits before the (broken) EmailCampaign path. See flag in summary.
+        $email = (new Email())
+            ->from('sender@example.com')
+            ->to('rcpt@example.com')
+            ->subject('Hello')
+            ->text('body');
+
+        $symfonySent = new SymfonySentMessage(
+            $email,
+            new Envelope(new Address('sender@example.com'), [new Address('rcpt@example.com')]),
+        );
+
+        (new EmailTracker())->handle(new MessageSent(new SentMessage($symfonySent)));
+
+        $this->assertTrue(true); // no exception on the header-absent path
+    }
+}
+
+/**
+ * Test double for SendCRMEventNotification: class_basename → "NewLead" →
+ * Str::snake → "new_lead", which config/crm.php marks true.
+ */
+final class NewLead
+{
+    public function toArray(): array
+    {
+        return ['lead_id' => 42];
+    }
+}
+
+/** Test double with no matching config/crm.php key. */
+final class SomethingUnconfigured
+{
+    public function toArray(): array
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
## Filament pages + listeners + factory drift

Swept the last untested UI/event surfaces; found a **production** tenant-registration break and a silently-dead notification path.

| Commit | What |
|--------|------|
| `2b7a29a` | **fix(filament)** — mount-testing the 10 custom app-panel pages found two fatals: `EditTeam::mount()` called a nonexistent `User::canCreateTeams()` and bypassed the parent mount (tenant never set) → 500; and `shouldRegisterMenuItem()` was hardcoded `true` (tenant guard commented out), so the Profile/Team-Settings menu items called `getUrl()` on the tenant-less `/app/new` route → `UrlGenerationException` — **broke tenant registration in production**. Restored the guard; added mount tests for all 10 pages. |
| `1ddb2db` | **fix(listeners)** — `SendCRMEventNotification` looked up snake_case config keys with a StudlyCase `class_basename()` → **always null → no one was ever notified**. Fixed with `Str::snake`. Adds tests for the 6 untested listeners. |
| `a01bcce` | **test(factories)** — rewrote the drifted, unusable `CampaignRecipientFactory` to the real schema (polymorphic recipient, DB-enum status, `marketing_campaign_id`); added `team_id` to `$fillable` on `MarketingCampaign`/`CampaignRecipient`/`Lead` (was silently dropped on mass-assign). |

### Testing
- **703 passed, 1 skipped, 0 failed** (only the pre-existing `SiteSettings` skip remains).
- `composer analyse` clean. No migrations this round.

### Follow-ups (flagged, deferred)
- **The CRM-event-notification feature can't fire**: `EventServiceProvider` wires 5 event classes (`NewLead`/`DealClosed`/`TaskOverdue`/`NewComment`/`MeetingScheduled`) that **don't exist**. Needs the event classes created (each with `toArray()`) or the wiring removed.
- `EmailTracker` listener is **dead code** — references a nonexistent `EmailCampaign` model + `email_stats` table, reads headers nothing sets, and isn't registered anywhere.
- `NotifyTeamMembers` listener is a comment-only stub.
- `TeamManagementService` still depends on a missing `App\Models\Branch` model (survives only via a `catch (\Throwable)` fallback).
