### PR TITLE
Auth: wire the teams-aware registration + account-deletion actions

### DIFF
--- a/app/Actions/Fortify/CreateNewUserWithTeams.php
+++ b/app/Actions/Fortify/CreateNewUserWithTeams.php
@@ -42,8 +42,11 @@ class CreateNewUserWithTeams implements CreatesNewUsers
      */
     protected function createTeam(User $user): void
     {
-        $teamManagementService = app(TeamManagementService::class);
-        $teamManagementService->assignUserToDefaultTeam($user);
-        $teamManagementService->createPersonalTeamForUser($user);
+        // A new registrant owns a single personal team (creator = admin) and
+        // acts in it. Previously this called assignUserToDefaultTeam() AND
+        // createPersonalTeamForUser(), producing two teams in the no-default
+        // fallback.
+        $team = app(TeamManagementService::class)->createPersonalTeamForUser($user);
+        $user->forceFill(['current_team_id' => $team->id])->save();
     }
 }

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace App\Providers;
 
-use App\Actions\Fortify\CreateNewUser;
+use App\Actions\Fortify\CreateNewUserWithTeams;
 use App\Actions\Fortify\ResetUserPassword;
 use App\Actions\Fortify\UpdateUserPassword;
 use App\Actions\Fortify\UpdateUserProfileInformation;
@@ -32,7 +32,7 @@ class FortifyServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        Fortify::createUsersUsing(CreateNewUser::class);
+        Fortify::createUsersUsing(CreateNewUserWithTeams::class);
         Fortify::updateUserProfileInformationUsing(UpdateUserProfileInformation::class);
         Fortify::updateUserPasswordsUsing(UpdateUserPassword::class);
         Fortify::resetUserPasswordsUsing(ResetUserPassword::class);

--- a/app/Providers/JetstreamServiceProvider.php
+++ b/app/Providers/JetstreamServiceProvider.php
@@ -7,7 +7,7 @@ namespace App\Providers;
 use App\Actions\Jetstream\AddTeamMember;
 use App\Actions\Jetstream\CreateTeam;
 use App\Actions\Jetstream\DeleteTeam;
-use App\Actions\Jetstream\DeleteUser;
+use App\Actions\Jetstream\DeleteUserWithTeams;
 use App\Actions\Jetstream\InviteTeamMember;
 use App\Actions\Jetstream\RemoveTeamMember;
 use App\Actions\Jetstream\UpdateTeamName;
@@ -41,7 +41,7 @@ class JetstreamServiceProvider extends ServiceProvider
         Jetstream::inviteTeamMembersUsing(InviteTeamMember::class);
         Jetstream::removeTeamMembersUsing(RemoveTeamMember::class);
         Jetstream::deleteTeamsUsing(DeleteTeam::class);
-        Jetstream::deleteUsersUsing(DeleteUser::class);
+        Jetstream::deleteUsersUsing(DeleteUserWithTeams::class);
 
         // Use our modified CreatePersonalTeam listener
         Event::listen(

--- a/tests/Feature/Actions/FortifyActionsTest.php
+++ b/tests/Feature/Actions/FortifyActionsTest.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Actions;
+
+use App\Actions\Fortify\CreateNewUserWithTeams;
+use App\Actions\Fortify\ResetUserPassword;
+use App\Actions\Fortify\UpdateUserPassword;
+use App\Actions\Fortify\UpdateUserProfileInformation;
+use App\Enums\Role;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\ValidationException;
+use Tests\TestCase;
+
+class FortifyActionsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // --- CreateNewUserWithTeams (registration) --------------------------------
+
+    public function test_register_creates_user_with_hashed_password_personal_team_and_admin_role(): void
+    {
+        $user = app(CreateNewUserWithTeams::class)->create([
+            'name' => 'Ada Lovelace',
+            'email' => 'ada@example.com',
+            'password' => 'password123',
+            'password_confirmation' => 'password123',
+            'terms' => true,
+        ]);
+
+        $this->assertDatabaseHas('users', [
+            'email' => 'ada@example.com',
+            'name' => 'Ada Lovelace',
+        ]);
+
+        // Password is stored hashed (not plaintext, not double-hashed) and verifies.
+        $this->assertNotSame('password123', $user->password);
+        $this->assertTrue(Hash::check('password123', $user->fresh()->password));
+
+        // Registration gives the creator an owned personal team + a current team.
+        $this->assertNotNull($user->current_team_id);
+        $personalTeam = $user->ownedTeams()->where('personal_team', true)->first();
+        $this->assertNotNull($personalTeam, 'Registration should create a personal team.');
+        // Exactly one team — guards the fixed double-team-creation bug.
+        $this->assertCount(1, $user->ownedTeams);
+        $this->assertSame($personalTeam->id, $user->current_team_id);
+
+        // The creator holds the admin role in the team they are acting in.
+        setPermissionsTeamId($user->current_team_id);
+        $this->assertTrue($user->fresh()->hasRole(Role::Admin));
+    }
+
+    public function test_register_rejects_duplicate_email(): void
+    {
+        User::factory()->create(['email' => 'dupe@example.com']);
+
+        $this->assertRegistrationFails([
+            'name' => 'Grace',
+            'email' => 'dupe@example.com',
+            'password' => 'password123',
+            'password_confirmation' => 'password123',
+        ], 'email');
+
+        // Only the pre-existing user exists; registration did not add a second.
+        $this->assertSame(1, User::query()->where('email', 'dupe@example.com')->count());
+    }
+
+    public function test_register_rejects_mismatched_password_confirmation(): void
+    {
+        $this->assertRegistrationFails([
+            'name' => 'Grace',
+            'email' => 'mismatch@example.com',
+            'password' => 'password123',
+            'password_confirmation' => 'different123',
+        ], 'password');
+
+        $this->assertDatabaseMissing('users', ['email' => 'mismatch@example.com']);
+    }
+
+    public function test_register_rejects_weak_password(): void
+    {
+        $this->assertRegistrationFails([
+            'name' => 'Grace',
+            'email' => 'weak@example.com',
+            'password' => 'short',
+            'password_confirmation' => 'short',
+        ], 'password');
+
+        $this->assertDatabaseMissing('users', ['email' => 'weak@example.com']);
+    }
+
+    private function assertRegistrationFails(array $input, string $field): void
+    {
+        try {
+            app(CreateNewUserWithTeams::class)->create($input);
+            $this->fail("Expected registration to fail validation for [{$field}].");
+        } catch (ValidationException $e) {
+            $this->assertArrayHasKey($field, $e->errors());
+        }
+    }
+
+    // --- ResetUserPassword ----------------------------------------------------
+
+    public function test_reset_password_sets_new_hashed_password(): void
+    {
+        $user = User::factory()->create();
+
+        app(ResetUserPassword::class)->reset($user, [
+            'password' => 'new-password-1',
+            'password_confirmation' => 'new-password-1',
+        ]);
+
+        $this->assertTrue(Hash::check('new-password-1', $user->fresh()->password));
+    }
+
+    // --- UpdateUserPassword ---------------------------------------------------
+
+    public function test_update_password_changes_password_when_current_matches(): void
+    {
+        // UserFactory seeds password = 'password'.
+        $user = User::factory()->create();
+        $this->actingAs($user); // current_password:web validates against the logged-in user
+
+        app(UpdateUserPassword::class)->update($user, [
+            'current_password' => 'password',
+            'password' => 'brand-new-1',
+            'password_confirmation' => 'brand-new-1',
+        ]);
+
+        $this->assertTrue(Hash::check('brand-new-1', $user->fresh()->password));
+    }
+
+    public function test_update_password_rejects_wrong_current_password(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        try {
+            app(UpdateUserPassword::class)->update($user, [
+                'current_password' => 'not-the-password',
+                'password' => 'brand-new-1',
+                'password_confirmation' => 'brand-new-1',
+            ]);
+            $this->fail('Expected validation to fail for a wrong current password.');
+        } catch (ValidationException $e) {
+            $this->assertArrayHasKey('current_password', $e->errors());
+        }
+
+        // Password is unchanged.
+        $this->assertTrue(Hash::check('password', $user->fresh()->password));
+    }
+
+    // --- UpdateUserProfileInformation -----------------------------------------
+
+    public function test_update_profile_information_updates_name_and_email(): void
+    {
+        $user = User::factory()->create(['name' => 'Old', 'email' => 'old@example.com']);
+
+        app(UpdateUserProfileInformation::class)->update($user, [
+            'name' => 'New Name',
+            'email' => 'new@example.com',
+        ]);
+
+        $user->refresh();
+        $this->assertSame('New Name', $user->name);
+        $this->assertSame('new@example.com', $user->email);
+    }
+
+    public function test_update_profile_information_rejects_duplicate_email(): void
+    {
+        User::factory()->create(['email' => 'taken@example.com']);
+        $user = User::factory()->create(['email' => 'me@example.com']);
+
+        try {
+            app(UpdateUserProfileInformation::class)->update($user, [
+                'name' => 'Me',
+                'email' => 'taken@example.com',
+            ]);
+            $this->fail('Expected validation to fail for a duplicate email.');
+        } catch (ValidationException $e) {
+            $this->assertArrayHasKey('email', $e->errors());
+        }
+
+        $this->assertSame('me@example.com', $user->fresh()->email);
+    }
+}

--- a/tests/Feature/Actions/JetstreamActionsTest.php
+++ b/tests/Feature/Actions/JetstreamActionsTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Actions;
+
+use App\Actions\Jetstream\AddTeamMember;
+use App\Actions\Jetstream\DeleteUserWithTeams;
+use App\Actions\Jetstream\InviteTeamMember;
+use App\Actions\Jetstream\RemoveTeamMember;
+use App\Enums\Role;
+use App\Models\Team;
+use App\Models\User;
+use Database\Seeders\RolesSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
+use Laravel\Jetstream\Mail\TeamInvitation as TeamInvitationMail;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\TestCase;
+
+/**
+ * Real behaviour of the wired Jetstream team-lifecycle actions. This app runs
+ * Spatie teams mode: adding a member fires TeamMemberAdded, whose listener
+ * (AssignDefaultTeamRole) grants the member sales_rep scoped to that team.
+ */
+class JetstreamActionsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolesSeeder::class); // global (team_id = null) role definitions
+    }
+
+    protected function tearDown(): void
+    {
+        app(PermissionRegistrar::class)->setPermissionsTeamId(null);
+        parent::tearDown();
+    }
+
+    /** Owner + a non-personal team they own. */
+    private function ownedTeam(): array
+    {
+        $owner = User::factory()->create();
+        $team = Team::factory()->create(['user_id' => $owner->id, 'personal_team' => false]);
+
+        return [$owner, $team];
+    }
+
+    private function hasRoleInTeam(User $user, Team $team, Role $role): bool
+    {
+        setPermissionsTeamId($team->getKey());
+        $user->unsetRelation('roles'); // relation is cached per team; refresh after a context switch
+
+        return $user->hasRole($role);
+    }
+
+    public function test_add_team_member_attaches_user_and_grants_sales_rep(): void
+    {
+        [$owner, $team] = $this->ownedTeam();
+        $member = User::factory()->create();
+
+        app(AddTeamMember::class)->add($owner, $team, $member->email, 'admin');
+
+        // Pivot membership carries the Jetstream role passed in.
+        $this->assertDatabaseHas('team_user', [
+            'team_id' => $team->id,
+            'user_id' => $member->id,
+            'role' => 'admin',
+        ]);
+
+        // TeamMemberAdded → AssignDefaultTeamRole granted sales_rep in this team.
+        $this->assertTrue($this->hasRoleInTeam($member, $team, Role::SalesRep));
+    }
+
+    public function test_add_team_member_consumes_a_matching_invitation(): void
+    {
+        [$owner, $team] = $this->ownedTeam();
+        $member = User::factory()->create();
+        $team->teamInvitations()->create([
+            'email' => $member->email,
+            'role' => 'editor',
+            'token' => 'tok-'.uniqid(),
+        ]);
+
+        app(AddTeamMember::class)->add($owner, $team, $member->email, 'admin');
+
+        // Invitation role wins over the passed role, and the invite is deleted.
+        $this->assertDatabaseHas('team_user', [
+            'team_id' => $team->id,
+            'user_id' => $member->id,
+            'role' => 'editor',
+        ]);
+        $this->assertDatabaseMissing('team_invitations', [
+            'team_id' => $team->id,
+            'email' => $member->email,
+        ]);
+    }
+
+    public function test_invite_team_member_creates_invitation_and_sends_mail(): void
+    {
+        Mail::fake();
+        [$owner, $team] = $this->ownedTeam();
+
+        app(InviteTeamMember::class)->invite($owner, $team, 'invitee@example.com', 'editor');
+
+        $this->assertDatabaseHas('team_invitations', [
+            'team_id' => $team->id,
+            'email' => 'invitee@example.com',
+            'role' => 'editor',
+        ]);
+        Mail::assertSent(TeamInvitationMail::class, fn (TeamInvitationMail $mail): bool => $mail->hasTo('invitee@example.com'));
+    }
+
+    public function test_remove_team_member_detaches_the_membership(): void
+    {
+        [$owner, $team] = $this->ownedTeam();
+        $member = User::factory()->create();
+        $team->users()->attach($member, ['role' => 'admin']);
+
+        app(RemoveTeamMember::class)->remove($owner, $team, $member);
+
+        $this->assertDatabaseMissing('team_user', [
+            'team_id' => $team->id,
+            'user_id' => $member->id,
+        ]);
+    }
+
+    public function test_delete_user_with_teams_purges_owned_teams_and_the_user(): void
+    {
+        [$owner, $ownedTeam] = $this->ownedTeam();
+        $member = User::factory()->create();
+        $ownedTeam->users()->attach($member, ['role' => 'admin']);
+
+        // A team the user only belongs to must survive (only the membership goes).
+        [, $otherTeam] = $this->ownedTeam();
+        $owner->teams()->attach($otherTeam, ['role' => 'admin']);
+
+        app(DeleteUserWithTeams::class)->delete($owner);
+
+        $this->assertModelMissing($owner);
+        $this->assertModelMissing($ownedTeam);
+        $this->assertDatabaseMissing('team_user', ['team_id' => $ownedTeam->id]);
+        $this->assertDatabaseMissing('team_user', ['user_id' => $owner->id]);
+
+        // Foreign team itself is untouched.
+        $this->assertModelExists($otherTeam);
+    }
+}

--- a/tests/Feature/Actions/SocialstreamActionsTest.php
+++ b/tests/Feature/Actions/SocialstreamActionsTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Actions;
+
+use App\Actions\Socialstream\CreateConnectedAccount;
+use App\Actions\Socialstream\CreateUserWithTeamsFromProvider;
+use App\Actions\Socialstream\HandleInvalidState;
+use App\Actions\Socialstream\SetUserPassword;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+use Laravel\Socialite\Contracts\User as ProviderUser;
+use Laravel\Socialite\Two\InvalidStateException;
+use Mockery;
+use Tests\TestCase;
+
+class SocialstreamActionsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Build a fake Socialite provider user. getId/getName/getEmail/getNickname/
+     * getAvatar come from the contract; token/refreshToken/expiresIn are public
+     * properties the actions read directly (as on the real Socialite\Two\User).
+     */
+    private function fakeProviderUser(array $o = []): ProviderUser
+    {
+        $user = Mockery::mock(ProviderUser::class);
+        $user->shouldReceive('getId')->andReturn($o['id'] ?? '1234567890');
+        $user->shouldReceive('getName')->andReturn($o['name'] ?? 'Ada Lovelace');
+        $user->shouldReceive('getEmail')->andReturn($o['email'] ?? 'ada@example.com');
+        $user->shouldReceive('getNickname')->andReturn($o['nickname'] ?? 'ada');
+        $user->shouldReceive('getAvatar')->andReturn($o['avatar'] ?? 'https://example.com/avatar.jpg');
+
+        $user->token = $o['token'] ?? 'access-token-abc';
+        $user->refreshToken = $o['refreshToken'] ?? 'refresh-token-def';
+        $user->expiresIn = $o['expiresIn'] ?? 3600;
+
+        return $user;
+    }
+
+    public function test_creates_user_connected_account_and_team_from_provider(): void
+    {
+        $providerUser = $this->fakeProviderUser();
+
+        $action = new CreateUserWithTeamsFromProvider(new CreateConnectedAccount());
+        $user = $action->create('google', $providerUser);
+
+        $this->assertInstanceOf(User::class, $user);
+        $this->assertDatabaseHas('users', [
+            'id' => $user->id,
+            'name' => 'Ada Lovelace',
+            'email' => 'ada@example.com',
+        ]);
+        $this->assertNotNull($user->fresh()->email_verified_at);
+
+        $this->assertDatabaseHas('connected_accounts', [
+            'user_id' => $user->id,
+            'provider' => 'google',
+            'provider_id' => '1234567890',
+        ]);
+
+        $this->assertDatabaseHas('teams', [
+            'user_id' => $user->id,
+            'personal_team' => true,
+        ]);
+    }
+
+    /**
+     * The static analysis baseline flags User::setProfilePhotoFromUrl() as
+     * nonexistent, and both provider-sign-up actions call it (guarded by the
+     * provider-avatars feature). It is actually provided by the
+     * SetsProfilePhotoFromUrl trait — this proves the call is not a fatal.
+     */
+    public function test_user_can_set_profile_photo_from_url(): void
+    {
+        Http::fake(['*' => Http::response('image-bytes', 200)]);
+        Storage::fake('public');
+
+        $user = User::factory()->create(['profile_photo_path' => null]);
+
+        $user->setProfilePhotoFromUrl('https://example.com/avatar.jpg');
+
+        Http::assertSent(fn ($request): bool => $request->url() === 'https://example.com/avatar.jpg');
+        $this->assertNotNull($user->fresh()->profile_photo_path);
+    }
+
+    public function test_create_connected_account_persists_provider_tokens(): void
+    {
+        $user = User::factory()->create();
+
+        $providerUser = $this->fakeProviderUser([
+            'token' => 'tok-1',
+            'refreshToken' => 'ref-1',
+            'expiresIn' => 7200,
+        ]);
+
+        $account = (new CreateConnectedAccount())->create($user, 'Google', $providerUser);
+
+        $this->assertTrue($account->exists);
+        $this->assertDatabaseHas('connected_accounts', [
+            'id' => $account->id,
+            'user_id' => $user->id,
+            'provider' => 'google', // lower-cased by the action
+            'provider_id' => '1234567890',
+            'token' => 'tok-1',
+            'refresh_token' => 'ref-1',
+        ]);
+        $this->assertNotNull($account->fresh()->expires_at);
+    }
+
+    public function test_update_connected_account_persists_new_tokens(): void
+    {
+        $user = User::factory()->create();
+
+        $account = (new CreateConnectedAccount())->create(
+            $user,
+            'google',
+            $this->fakeProviderUser(['token' => 'old-token', 'refreshToken' => 'old-refresh']),
+        );
+
+        $updated = app(\App\Actions\Socialstream\UpdateConnectedAccount::class)->update(
+            $user,
+            $account,
+            'google',
+            $this->fakeProviderUser(['token' => 'new-token', 'refreshToken' => 'new-refresh']),
+        );
+
+        $this->assertDatabaseHas('connected_accounts', [
+            'id' => $updated->id,
+            'user_id' => $user->id,
+            'token' => 'new-token',
+            'refresh_token' => 'new-refresh',
+        ]);
+    }
+
+    public function test_set_user_password_hashes_and_persists(): void
+    {
+        $user = User::factory()->create();
+
+        (new SetUserPassword())->set($user, [
+            'password' => 'S3cret-Passw0rd',
+            'password_confirmation' => 'S3cret-Passw0rd',
+        ]);
+
+        $this->assertTrue(Hash::check('S3cret-Passw0rd', $user->fresh()->password));
+    }
+
+    public function test_handle_invalid_state_rethrows(): void
+    {
+        $this->expectException(InvalidStateException::class);
+
+        (new HandleInvalidState())->handle(new InvalidStateException());
+    }
+}


### PR DESCRIPTION
## Auth Action wiring — the broken defaults were wired, the correct ones weren't

Testing the untested Fortify/Jetstream/Socialstream Action classes surfaced a clear theme: **this app has correct, teams-aware Action implementations that the service providers never wired** — so the *default* (broken) actions run instead. Two are outright fatal/data-losing.

| Commit | What |
|--------|------|
| `ee39995` | **fix(auth) — registration**: `FortifyServiceProvider` wired `CreateNewUser`, whose `assignOrCreateTeam()` does `Team::first()->users()->attach()` → **fatals on a fresh DB** (first-ever registration) and otherwise joins new users to an *arbitrary existing team*. Wired the teams-aware `CreateNewUserWithTeams` (creator owns a personal team + gets the `admin` role) and fixed its `createTeam()`, which created **two** personal teams. Now exactly one, `current_team_id` set. |
| `8923e2c` | **fix(auth) — account deletion**: `JetstreamServiceProvider` wired `DeleteUser`, which deletes the user but **not their teams** → self-serve account deletion **orphaned owned teams** + left stale pivots. Wired the `DeleteUserWithTeams` action written for exactly this. + tests for the team-lifecycle actions. |
| `fc15db8` | **test(auth)**: covered the Socialstream provider actions (mocked Socialite user). The flagged `setProfilePhotoFromUrl` is a phpstan false positive (trait method). |

### Testing
- **723 passed, 1 skipped, 0 failed** (26 auth-focused tests among them); the double-team fix is locked by an "exactly one team" assertion.
- `composer analyse` clean. No migrations.

### Follow-up (flagged, deferred — a behavior change, not a fatal-fix)
- `SocialstreamServiceProvider` never calls `Socialstream::useConnectedAccountModel(App\Models\ConnectedAccount::class)`, so social sign-up writes *base* connected-account rows — bypassing the app model's `IsTenantModel` `team_id` stamping, its `account_type`/`is_primary` scopes, and its `ConnectedAccountCreated/Updated/Deleted` events. Deferred to its own change so the event/tenancy side effects can be verified deliberately.
