### PR TITLE
Helpdesk ticket + module dev-mode fixes; policy coverage

### DIFF
--- a/app/Actions/Helpdesk/CreateTicketFromEmail.php
+++ b/app/Actions/Helpdesk/CreateTicketFromEmail.php
@@ -24,7 +24,12 @@ class CreateTicketFromEmail
             $emailId = $message->getId();
         }
 
-        $user = User::firstOrCreate(['email' => $headers['From']]);
+        // users.name is NOT NULL with no default; a new sender needs one or the
+        // insert fails. Fall back to the From value when we have nothing better.
+        $user = User::firstOrCreate(
+            ['email' => $headers['From']],
+            ['name' => $headers['From']]
+        );
 
         return Ticket::create([
             'subject' => $headers['Subject'],

--- a/app/Modules/BaseModule.php
+++ b/app/Modules/BaseModule.php
@@ -52,7 +52,10 @@ abstract class BaseModule implements ModuleInterface
     public function isEnabled(): bool
     {
         if ($this->isDevelopmentMode()) {
-            return Cache::get("module.{$this->name}.enabled", true);
+            // Skip the cache layer entirely so state changes reflect immediately.
+            // (enable()/disable() forget this key, so reading it here always
+            // returned the default and never reflected the persisted state.)
+            return $this->resolveEnabledState();
         }
 
         $ttl = config('modules.cache_ttl', 3600);

--- a/tests/Feature/Actions/HelpdeskActionsTest.php
+++ b/tests/Feature/Actions/HelpdeskActionsTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Actions;
+
+use App\Actions\Helpdesk\CreateTicketFromEmail;
+use App\Actions\Helpdesk\CreateTicketFromWhatsApp;
+use App\Models\Ticket;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class HelpdeskActionsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_creates_a_ticket_from_an_incoming_email(): void
+    {
+        $ticket = app(CreateTicketFromEmail::class)->execute([
+            'from' => 'jane@example.com',
+            'subject' => 'Cannot log in',
+            'content' => 'I keep getting an error on login.',
+            'id' => 'email-abc-123',
+        ], 'gmail');
+
+        $this->assertInstanceOf(Ticket::class, $ticket);
+
+        // A user is provisioned for the sender and linked to the ticket.
+        $sender = User::where('email', 'jane@example.com')->firstOrFail();
+        $this->assertSame($sender->id, $ticket->user_id);
+
+        $this->assertDatabaseHas('tickets', [
+            'id' => $ticket->id,
+            'subject' => 'Cannot log in',
+            'body' => 'I keep getting an error on login.',
+            'status' => 'open',
+            'priority' => 'medium',
+            'source' => 'gmail',
+            'source_id' => 'email-abc-123',
+            'email_id' => 'email-abc-123',
+            'user_id' => $sender->id,
+        ]);
+    }
+
+    public function test_it_creates_a_ticket_from_an_incoming_whatsapp_message(): void
+    {
+        $ticket = app(CreateTicketFromWhatsApp::class)->execute([
+            'from' => '1234567890',
+            'message' => 'Hello, I need help',
+            'id' => 'wa-msg-1',
+        ]);
+
+        $this->assertInstanceOf(Ticket::class, $ticket);
+
+        // WhatsApp senders get a synthetic user keyed off their number.
+        $sender = User::where('email', 'whatsapp+1234567890@whatsapp.invalid')->firstOrFail();
+        $this->assertSame('1234567890', $sender->name);
+        $this->assertSame($sender->id, $ticket->user_id);
+
+        $this->assertDatabaseHas('tickets', [
+            'id' => $ticket->id,
+            'subject' => 'WhatsApp message from 1234567890',
+            'body' => 'Hello, I need help',
+            'status' => 'open',
+            'priority' => 'medium',
+            'source' => 'whatsapp',
+            'source_id' => '1234567890',
+            'email_id' => 'wa-msg-1',
+            'user_id' => $sender->id,
+        ]);
+    }
+}

--- a/tests/Feature/Modules/BaseModuleTest.php
+++ b/tests/Feature/Modules/BaseModuleTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Modules;
+
+use App\Events\Module\ModuleDisabled;
+use App\Events\Module\ModuleEnabled;
+use App\Models\Module;
+use App\Modules\BaseModule;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Event;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * BaseModule is abstract; this named stub gives class_basename() a stable
+ * module name ('BaseModuleFake') which BaseModule uses as the DB/cache key.
+ */
+class BaseModuleFake extends BaseModule {}
+
+class BaseModuleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected BaseModuleFake $module;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->module = new BaseModuleFake;
+    }
+
+    #[Test]
+    public function enable_persists_state_forgets_cache_and_fires_event(): void
+    {
+        Event::fake();
+        Cache::put('module.BaseModuleFake.enabled', false); // stale value must be dropped
+
+        $this->module->enable();
+
+        $this->assertDatabaseHas('modules', ['name' => 'BaseModuleFake', 'is_enabled' => 1]);
+        $this->assertFalse(Cache::has('module.BaseModuleFake.enabled'));
+        Event::assertDispatched(ModuleEnabled::class, fn ($e): bool => $e->module === $this->module);
+    }
+
+    #[Test]
+    public function disable_persists_state_forgets_cache_and_fires_event(): void
+    {
+        Event::fake();
+        Cache::put('module.BaseModuleFake.enabled', true);
+
+        $this->module->disable();
+
+        $this->assertDatabaseHas('modules', ['name' => 'BaseModuleFake', 'is_enabled' => 0]);
+        $this->assertFalse(Cache::has('module.BaseModuleFake.enabled'));
+        Event::assertDispatched(ModuleDisabled::class, fn ($e): bool => $e->module === $this->module);
+    }
+
+    #[Test]
+    public function is_enabled_resolves_from_the_module_row(): void
+    {
+        config(['modules.development' => false]); // exercise the cached DB-resolve path
+
+        Module::create(['name' => 'BaseModuleFake', 'is_enabled' => false]);
+        Cache::forget('module.BaseModuleFake.enabled');
+        $this->assertFalse($this->module->isEnabled());
+
+        Module::query()->where('name', 'BaseModuleFake')->update(['is_enabled' => true]);
+        Cache::forget('module.BaseModuleFake.enabled'); // bust remember() cache
+        $this->assertTrue($this->module->isEnabled());
+    }
+
+    #[Test]
+    public function is_enabled_reflects_db_immediately_in_development_mode(): void
+    {
+        config(['modules.development' => true]);
+
+        $this->module->disable(); // persists is_enabled=false and forgets the cache key
+        $this->assertFalse($this->module->isEnabled());
+
+        $this->module->enable();
+        $this->assertTrue($this->module->isEnabled());
+    }
+
+    #[Test]
+    public function check_health_returns_status_and_checks_shape(): void
+    {
+        config(['modules.development' => true]);
+        $this->module->enable();
+
+        $health = $this->module->checkHealth();
+
+        $this->assertArrayHasKey('status', $health);
+        $this->assertArrayHasKey('checks', $health);
+        $this->assertContains($health['status'], ['healthy', 'degraded']);
+        $this->assertTrue($health['checks']['is_enabled']);
+        $this->assertSame('1.0.0', $health['checks']['version']);
+        $this->assertArrayHasKey('module_json_exists', $health['checks']);
+    }
+}

--- a/tests/Feature/Policies/PolicyCoverageTest.php
+++ b/tests/Feature/Policies/PolicyCoverageTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Policies;
+
+use App\Models\ConnectedAccount;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Coverage for two previously untested policies:
+ *
+ * - ConnectedAccountPolicy: a ConnectedAccount belongs to a User via user_id;
+ *   only that user may view/update/delete it.
+ * - TeamPolicy: Jetstream authorization — view is gated by belongsToTeam,
+ *   the mutating actions by ownsTeam.
+ */
+class PolicyCoverageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_connected_account_owner_may_view_update_delete(): void
+    {
+        $owner = User::factory()->create();
+        $account = ConnectedAccount::factory()->create(['user_id' => $owner->id]);
+
+        $this->assertTrue($owner->can('view', $account));
+        $this->assertTrue($owner->can('update', $account));
+        $this->assertTrue($owner->can('delete', $account));
+    }
+
+    public function test_connected_account_non_owner_is_denied(): void
+    {
+        $owner = User::factory()->create();
+        $other = User::factory()->create();
+        $account = ConnectedAccount::factory()->create(['user_id' => $owner->id]);
+
+        $this->assertFalse($other->can('view', $account));
+        $this->assertFalse($other->can('update', $account));
+        $this->assertFalse($other->can('delete', $account));
+    }
+
+    public function test_team_owner_may_view_and_manage(): void
+    {
+        $owner = User::factory()->create();
+        $team = Team::factory()->create(['user_id' => $owner->id]);
+
+        $this->assertTrue($owner->can('view', $team));
+        $this->assertTrue($owner->can('update', $team));
+        $this->assertTrue($owner->can('delete', $team));
+        $this->assertTrue($owner->can('addTeamMember', $team));
+        $this->assertTrue($owner->can('updateTeamMember', $team));
+        $this->assertTrue($owner->can('removeTeamMember', $team));
+    }
+
+    public function test_team_member_may_view_but_not_manage(): void
+    {
+        $owner = User::factory()->create();
+        $member = User::factory()->create();
+        $team = Team::factory()->create(['user_id' => $owner->id]);
+        $team->users()->attach($member, ['role' => 'editor']);
+
+        $this->assertTrue($member->can('view', $team));
+
+        $this->assertFalse($member->can('update', $team));
+        $this->assertFalse($member->can('delete', $team));
+        $this->assertFalse($member->can('addTeamMember', $team));
+        $this->assertFalse($member->can('removeTeamMember', $team));
+    }
+
+    public function test_team_stranger_is_denied(): void
+    {
+        $owner = User::factory()->create();
+        $stranger = User::factory()->create();
+        $team = Team::factory()->create(['user_id' => $owner->id]);
+
+        $this->assertFalse($stranger->can('view', $team));
+        $this->assertFalse($stranger->can('update', $team));
+        $this->assertFalse($stranger->can('delete', $team));
+        $this->assertFalse($stranger->can('addTeamMember', $team));
+        $this->assertFalse($stranger->can('removeTeamMember', $team));
+    }
+}


### PR DESCRIPTION
## Helpdesk + module fixes + policy coverage

| Commit | What |
|--------|------|
| `c1667f7` | **fix(helpdesk)** — `CreateTicketFromEmail` did `User::firstOrCreate(['email'=>…])` with no name, but `users.name` is NOT NULL → **every ticket from a first-time email sender crashed**. Default the name from the From header. Covers both helpdesk actions (email + WhatsApp). |
| `34798c1` | **fix(modules)** — `BaseModule::isEnabled()` in dev mode read `Cache::get(key, true)`, but `enable()`/`disable()` **forget** that key → it always returned `true`, so **`disable()` was a no-op in development** (opposite of the documented "reflect state immediately"). Read live DB state. Adds lifecycle tests. |
| `00a9ccb` | **test(authz)** — covered `ConnectedAccountPolicy` + `TeamPolicy` (owner-allowed / member-view / non-owner-denied). No bugs (the `ownsConnectedAccount` phpstan flag is a false positive — it's a trait method). |

### Testing
- **735 passed, 1 skipped, 0 failed**. `composer analyse` clean. No migrations.

### Follow-ups (flagged, deferred)
- `tickets.email_id` is `unique()` + NOT NULL, but the actions write `id ?? null` — an inbound message without an id would 422/500. Make it nullable or guard.
- Helpdesk actions link an auto-provisioned `User`, not a `Contact`, and create no `Message` row — a feature gap (no Contact/Message linkage) worth closing for real helpdesk threading.