### PR TITLE
CRM event notifications (+team-scoped), Socialstream model wiring, ticket email_id nullable

### DIFF
--- a/app/Events/DealClosed.php
+++ b/app/Events/DealClosed.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Deal;
+use App\Models\Team;
+use Illuminate\Foundation\Events\Dispatchable;
+
+class DealClosed
+{
+    use Dispatchable;
+
+    public function __construct(public Deal $deal)
+    {
+    }
+
+    /** Team this event belongs to — used to scope notifications (anti cross-tenant leak). */
+    public function team(): ?Team
+    {
+        return $this->deal->team;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->deal->id,
+            'name' => $this->deal->name,
+            'value' => $this->deal->value,
+            'stage' => $this->deal->stage,
+            'close_date' => $this->deal->close_date?->toDateString(),
+            'team_id' => $this->deal->team_id,
+        ];
+    }
+}

--- a/app/Events/MeetingScheduled.php
+++ b/app/Events/MeetingScheduled.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Activity;
+use App\Models\Team;
+use Illuminate\Foundation\Events\Dispatchable;
+
+// ponytail: FLAG — ambiguous trigger, no dispatch wired. There is no Meeting model.
+// Activity is a generic timeline log (type is created/updated/deleted/commented, no
+// "meeting"), so auto-dispatching on Activity created would over-notify on every
+// logged action. Wire this only once a real meeting model/type exists (e.g. dispatch
+// when an Activity is created with type === 'meeting'), which is a product decision.
+class MeetingScheduled
+{
+    use Dispatchable;
+
+    public function __construct(public Activity $activity)
+    {
+    }
+
+    /** Team this event belongs to — used to scope notifications (anti cross-tenant leak). */
+    public function team(): ?Team
+    {
+        return $this->activity->team;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->activity->id,
+            'type' => $this->activity->type,
+            'date' => $this->activity->date?->toDateTimeString(),
+            'description' => $this->activity->description,
+            'team_id' => $this->activity->getAttribute('team_id'),
+        ];
+    }
+}

--- a/app/Events/NewComment.php
+++ b/app/Events/NewComment.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Note;
+use App\Models\Team;
+use Illuminate\Foundation\Events\Dispatchable;
+
+// Note is this app's comment model (a `content` body attached to a contact/company/
+// opportunity), so NewComment fires on Note created.
+class NewComment
+{
+    use Dispatchable;
+
+    public function __construct(public Note $note)
+    {
+    }
+
+    /** Team this event belongs to — used to scope notifications (anti cross-tenant leak). */
+    public function team(): ?Team
+    {
+        return $this->note->team;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->note->id,
+            'content' => $this->note->content,
+            'contact_id' => $this->note->contact_id,
+            'company_id' => $this->note->company_id,
+            'opportunity_id' => $this->note->opportunity_id,
+            'team_id' => $this->note->getAttribute('team_id'),
+        ];
+    }
+}

--- a/app/Events/NewLead.php
+++ b/app/Events/NewLead.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Lead;
+use App\Models\Team;
+use Illuminate\Foundation\Events\Dispatchable;
+
+class NewLead
+{
+    use Dispatchable;
+
+    public function __construct(public Lead $lead)
+    {
+    }
+
+    /** Team this event belongs to — used to scope notifications (anti cross-tenant leak). */
+    public function team(): ?Team
+    {
+        return $this->lead->team;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->lead->id,
+            'status' => $this->lead->status,
+            'source' => $this->lead->source,
+            'potential_value' => $this->lead->potential_value,
+            'lifecycle_stage' => $this->lead->lifecycle_stage,
+            'team_id' => $this->lead->getAttribute('team_id'),
+        ];
+    }
+}

--- a/app/Events/TaskOverdue.php
+++ b/app/Events/TaskOverdue.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Task;
+use App\Models\Team;
+use Illuminate\Foundation\Events\Dispatchable;
+
+// ponytail: FLAG — no dispatch wired. "Overdue" is a state-over-time condition
+// (Task::isOverdue(): due_date past & not completed), not a model lifecycle event,
+// so it needs a scheduled scan. The existing ReminderService keys off reminder_date
+// (a different concept) and is out of the allowed edit set. Add a scheduled command
+// that dispatches TaskOverdue for Task::isOverdue() rows when the product wants it.
+class TaskOverdue
+{
+    use Dispatchable;
+
+    public function __construct(public Task $task)
+    {
+    }
+
+    /** Team this event belongs to — used to scope notifications (anti cross-tenant leak). */
+    public function team(): ?Team
+    {
+        return $this->task->team;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->task->id,
+            'name' => $this->task->name,
+            'due_date' => $this->task->due_date?->toDateTimeString(),
+            'status' => $this->task->status,
+            'assigned_to' => $this->task->assigned_to,
+            'team_id' => $this->task->team_id,
+        ];
+    }
+}

--- a/app/Listeners/SendCRMEventNotification.php
+++ b/app/Listeners/SendCRMEventNotification.php
@@ -2,7 +2,6 @@
 
 namespace App\Listeners;
 
-use App\Models\User;
 use App\Notifications\CRMEventNotification;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Queue\InteractsWithQueue;
@@ -29,9 +28,11 @@ class SendCRMEventNotification implements ShouldQueue
 
     protected function getUsersToNotify($event)
     {
-        // Implement logic to determine which users should be notified
-        // This could be based on user roles, team membership, or other criteria
-        // For now, we'll just notify all users (you should refine this)
-        return User::all();
+        // Anti-leak: notify only the team that owns the event's model, never
+        // every user (User::all() was a cross-tenant notification leak). Each
+        // CRM event exposes its team via team().
+        $team = method_exists($event, 'team') ? $event->team() : null;
+
+        return $team ? $team->allUsers() : collect();
     }
 }

--- a/app/Models/Deal.php
+++ b/app/Models/Deal.php
@@ -35,6 +35,16 @@ class Deal extends Model implements OwnsRecords
         'probability' => 'integer',
     ];
 
+    /** Fire DealClosed when the stage transitions into a closed-won/closed state. */
+    protected static function booted(): void
+    {
+        static::updated(function (self $deal): void {
+            if ($deal->wasChanged('stage') && in_array($deal->stage, ['won', 'closed'], true)) {
+                \App\Events\DealClosed::dispatch($deal);
+            }
+        });
+    }
+
     public function contact(): BelongsTo
     {
         return $this->belongsTo(Contact::class);

--- a/app/Models/Lead.php
+++ b/app/Models/Lead.php
@@ -39,6 +39,11 @@ class Lead extends Model implements OwnsRecords
         'score' => 'integer',
     ];
 
+    /** Fire NewLead on create so the CRM notification listener runs. */
+    protected $dispatchesEvents = [
+        'created' => \App\Events\NewLead::class,
+    ];
+
     const LIFECYCLE_STAGES = [
         'subscriber',
         'lead',

--- a/app/Models/Note.php
+++ b/app/Models/Note.php
@@ -20,6 +20,11 @@ class Note extends Model
         'opportunity_id',
     ];
 
+    /** Note is the app's comment model; fire NewComment on create. */
+    protected $dispatchesEvents = [
+        'created' => \App\Events\NewComment::class,
+    ];
+
     public function contact()
     {
         return $this->belongsTo(Contact::class);

--- a/app/Providers/SocialstreamServiceProvider.php
+++ b/app/Providers/SocialstreamServiceProvider.php
@@ -90,6 +90,12 @@ class SocialstreamServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        // The package provider boots first and resets the resolver to its base
+        // ConnectedAccount model; override it so sign-up gets the app model
+        // (IsTenantModel, account_type/is_primary, its event map). userModel is
+        // already App\Models\User by default and not reset, so no override needed.
+        Socialstream::useConnectedAccountModel(\App\Models\ConnectedAccount::class);
+
         Socialstream::resolvesSocialiteUsersUsing(ResolveSocialiteUser::class);
         Socialstream::createUsersFromProviderUsing(CreateUserWithTeamsFromProvider::class);
         Socialstream::createConnectedAccountsUsing(CreateConnectedAccount::class);

--- a/database/migrations/2026_07_06_000000_make_tickets_email_id_nullable.php
+++ b/database/migrations/2026_07_06_000000_make_tickets_email_id_nullable.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $column = collect(Schema::getColumns('tickets'))->firstWhere('name', 'email_id');
+
+        // Only alter when the column is still NOT NULL (idempotent / re-runs safe).
+        // The unique index is left untouched: both sqlite and MySQL permit
+        // multiple NULLs under a unique index, so id-less tickets can coexist.
+        if ($column && $column['nullable'] === false) {
+            Schema::table('tickets', function (Blueprint $table): void {
+                $table->string('email_id')->nullable()->change();
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        // ponytail: no-op — reverting to NOT NULL would fail on existing NULL rows.
+    }
+};

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -24,6 +24,8 @@
         <env name="DB_CONNECTION" value="sqlite"/>
         <env name="DB_DATABASE" value=":memory:"/>
         <env name="MAIL_MAILER" value="array"/>
+        <env name="MAIL_FROM_ADDRESS" value="test@example.com"/>
+        <env name="MAIL_FROM_NAME" value="CRM Test"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>

--- a/tests/Feature/Actions/HelpdeskNullIdTest.php
+++ b/tests/Feature/Actions/HelpdeskNullIdTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Actions;
+
+use App\Actions\Helpdesk\CreateTicketFromEmail;
+use App\Actions\Helpdesk\CreateTicketFromWhatsApp;
+use App\Models\Ticket;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class HelpdeskNullIdTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_creates_a_ticket_from_an_email_with_no_id(): void
+    {
+        $ticket = app(CreateTicketFromEmail::class)->execute([
+            'from' => 'noid@example.com',
+            'subject' => 'No id here',
+            'content' => 'This inbound email carries no id.',
+        ], 'gmail');
+
+        $this->assertInstanceOf(Ticket::class, $ticket);
+        $this->assertNull($ticket->email_id);
+        $this->assertDatabaseHas('tickets', [
+            'id' => $ticket->id,
+            'email_id' => null,
+        ]);
+    }
+
+    public function test_it_creates_a_ticket_from_a_whatsapp_message_with_no_id(): void
+    {
+        $ticket = app(CreateTicketFromWhatsApp::class)->execute([
+            'from' => '5550001111',
+            'message' => 'This inbound WhatsApp message carries no id.',
+        ]);
+
+        $this->assertInstanceOf(Ticket::class, $ticket);
+        $this->assertNull($ticket->email_id);
+        $this->assertDatabaseHas('tickets', [
+            'id' => $ticket->id,
+            'email_id' => null,
+        ]);
+    }
+
+    public function test_two_id_less_tickets_can_coexist(): void
+    {
+        // The unique index on email_id must tolerate multiple NULLs.
+        $first = app(CreateTicketFromEmail::class)->execute([
+            'from' => 'a@example.com',
+            'subject' => 'first',
+            'content' => 'first',
+        ], 'gmail');
+
+        $second = app(CreateTicketFromWhatsApp::class)->execute([
+            'from' => '5550002222',
+            'message' => 'second',
+        ]);
+
+        $this->assertNull($first->email_id);
+        $this->assertNull($second->email_id);
+        $this->assertCount(2, Ticket::whereNull('email_id')->get());
+    }
+}

--- a/tests/Feature/Actions/SocialstreamActionsTest.php
+++ b/tests/Feature/Actions/SocialstreamActionsTest.php
@@ -8,11 +8,15 @@ use App\Actions\Socialstream\CreateConnectedAccount;
 use App\Actions\Socialstream\CreateUserWithTeamsFromProvider;
 use App\Actions\Socialstream\HandleInvalidState;
 use App\Actions\Socialstream\SetUserPassword;
+use App\Models\ConnectedAccount;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
+use JoelButcher\Socialstream\Events\ConnectedAccountCreated;
+use JoelButcher\Socialstream\Socialstream;
 use Laravel\Socialite\Contracts\User as ProviderUser;
 use Laravel\Socialite\Two\InvalidStateException;
 use Mockery;
@@ -148,6 +152,35 @@ class SocialstreamActionsTest extends TestCase
         ]);
 
         $this->assertTrue(Hash::check('S3cret-Passw0rd', $user->fresh()->password));
+    }
+
+    /**
+     * The SocialstreamServiceProvider must wire the app's ConnectedAccount model
+     * so social sign-up gets the IsTenantModel/account_type/is_primary behaviour
+     * and the app's event map — not the base package model. The package provider
+     * boots first and resets the resolver to its own base model, so this only
+     * holds because the app provider overrides it in boot().
+     */
+    public function test_socialstream_resolves_the_app_connected_account_model(): void
+    {
+        $this->assertSame(ConnectedAccount::class, Socialstream::connectedAccountModel());
+    }
+
+    public function test_create_connected_account_returns_app_model_and_dispatches_created_event(): void
+    {
+        Event::fake([ConnectedAccountCreated::class]);
+
+        $user = User::factory()->create();
+
+        $account = (new CreateConnectedAccount())->create($user, 'google', $this->fakeProviderUser());
+
+        $this->assertInstanceOf(ConnectedAccount::class, $account);
+
+        Event::assertDispatched(
+            ConnectedAccountCreated::class,
+            fn (ConnectedAccountCreated $event): bool => $event->connectedAccount instanceof ConnectedAccount
+                && $event->connectedAccount->is($account),
+        );
     }
 
     public function test_handle_invalid_state_rethrows(): void

--- a/tests/Feature/Events/CrmEventTest.php
+++ b/tests/Feature/Events/CrmEventTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Events;
+
+use App\Events\DealClosed;
+use App\Events\NewLead;
+use App\Models\Deal;
+use App\Models\Lead;
+use App\Models\Team;
+use App\Models\User;
+use App\Notifications\CRMEventNotification;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Notification;
+use Tests\TestCase;
+
+class CrmEventTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @return array{0: Team, 1: User} */
+    private function teamWithOwner(): array
+    {
+        $owner = User::factory()->create();
+        $team = Team::factory()->create(['user_id' => $owner->id]);
+
+        return [$team, $owner];
+    }
+
+    public function test_new_lead_notifies_only_its_team_users(): void
+    {
+        Notification::fake();
+
+        [$teamA, $ownerA] = $this->teamWithOwner();
+        [, $ownerB] = $this->teamWithOwner();
+
+        $lead = Lead::factory()->create(['team_id' => $teamA->id]);
+
+        event(new NewLead($lead));
+
+        Notification::assertSentTo($ownerA, CRMEventNotification::class);
+        // Leak guard: a user from another team must NOT be notified.
+        Notification::assertNotSentTo($ownerB, CRMEventNotification::class);
+    }
+
+    public function test_deal_closed_notifies_only_its_team_users(): void
+    {
+        Notification::fake();
+
+        [$teamA, $ownerA] = $this->teamWithOwner();
+        [, $ownerB] = $this->teamWithOwner();
+
+        $deal = Deal::factory()->create(['team_id' => $teamA->id, 'stage' => 'won']);
+
+        event(new DealClosed($deal));
+
+        Notification::assertSentTo($ownerA, CRMEventNotification::class);
+        // Leak guard: a user from another team must NOT be notified.
+        Notification::assertNotSentTo($ownerB, CRMEventNotification::class);
+    }
+
+    public function test_new_lead_to_array_shape(): void
+    {
+        Notification::fake(); // creating the lead auto-fires NewLead → listener
+
+        [$team] = $this->teamWithOwner();
+        $lead = Lead::factory()->create(['team_id' => $team->id, 'status' => 'new']);
+
+        $payload = (new NewLead($lead))->toArray();
+
+        $this->assertSame($lead->id, $payload['id']);
+        $this->assertSame('new', $payload['status']);
+        $this->assertSame($team->id, $payload['team_id']);
+    }
+
+    public function test_creating_a_lead_dispatches_new_lead(): void
+    {
+        Event::fake([NewLead::class]);
+
+        [$team] = $this->teamWithOwner();
+        $lead = Lead::factory()->create(['team_id' => $team->id]);
+
+        Event::assertDispatched(NewLead::class, fn (NewLead $e): bool => $e->lead->is($lead));
+    }
+
+    public function test_updating_deal_stage_to_won_dispatches_deal_closed(): void
+    {
+        Event::fake([DealClosed::class]);
+
+        [$team] = $this->teamWithOwner();
+        $deal = Deal::factory()->create(['team_id' => $team->id, 'stage' => 'proposal']);
+
+        $deal->update(['stage' => 'won']);
+
+        Event::assertDispatched(DealClosed::class, fn (DealClosed $e): bool => $e->deal->is($deal));
+    }
+}

--- a/tests/Feature/Listeners/ListenersTest.php
+++ b/tests/Feature/Listeners/ListenersTest.php
@@ -111,12 +111,14 @@ class ListenersTest extends TestCase
     public function test_send_crm_event_notification_notifies_users_for_configured_event(): void
     {
         Notification::fake();
-        $users = User::factory()->count(2)->create();
+        // getUsersToNotify is team-scoped: only the lead's team is notified,
+        // for the truthy config/crm.php key "new_lead" (snake of NewLead).
+        $team = Team::factory()->create();
+        $lead = \App\Models\Lead::factory()->create(['team_id' => $team->id]);
 
-        // class_basename(NewLead) → snake → "new_lead", a truthy config/crm.php key.
-        (new SendCRMEventNotification())->handle(new NewLead());
+        (new SendCRMEventNotification())->handle(new \App\Events\NewLead($lead));
 
-        Notification::assertSentTo($users, CRMEventNotification::class);
+        Notification::assertSentTo($team->owner, CRMEventNotification::class);
     }
 
     public function test_send_crm_event_notification_skips_unconfigured_event(): void


### PR DESCRIPTION
## Feature-completion round — build the wired-but-missing pieces

| Commit | What |
|--------|------|
| `f97db78` | **feat — CRM event notifications**: the feature was fully wired (config + listener + provider) but couldn't fire because the 5 `App\Events\*` classes didn't exist. Built them; dispatch `NewLead` (Lead created), `NewComment` (Note created), `DealClosed` (Deal stage→won). **Fixed a cross-tenant leak**: `getUsersToNotify()` returned `User::all()` → now `$event->team()->allUsers()` (leak-guard test asserts another team isn't notified). Set `MAIL_FROM` in phpunit.xml (the notification now fires on Lead/Note create). |
| `744861e` | **fix(social)** — `SocialstreamServiceProvider` never called `useConnectedAccountModel`, so social sign-up wrote *base* rows, bypassing the app model's tenant scoping + events. Wired it. |
| `9ee2b9e` | **fix(helpdesk)** — `tickets.email_id` was unique + NOT NULL, but the actions write `id ?? null` → any id-less message 500'd. Made it nullable (unique index kept). |

### Testing
- **745 passed, 1 skipped, 0 failed**. `composer analyse` clean. The `email_id` migration is MySQL-verified.
- Updated `ListenersTest` (asserted the old all-users behavior) to the team-scoped delivery.

### Follow-ups (flagged, deferred)
- **`TaskOverdue`** event exists but needs a scheduled scan to dispatch (overdue is a state-over-time, not a lifecycle event). **`MeetingScheduled`** exists but there's no Meeting model — needs a product decision on its trigger.
- **`connected_accounts` lacks `account_type`/`is_primary`** columns that the app model's `scopeOfType`/`scopePrimary` reference — add before those scopes are used. (`team_id` already exists via the F1 backfill.)
- **prod `.env` must set `MAIL_FROM_ADDRESS`** — the CRM notification now fires on Lead/Note creation and the mail channel requires a From.