### PR TITLE
feat(tasks): scheduled overdue-task notifications (completes CRM events)

### DIFF
--- a/app/Console/Commands/NotifyOverdueTasks.php
+++ b/app/Console/Commands/NotifyOverdueTasks.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Events\TaskOverdue;
+use App\Models\Task;
+use Illuminate\Console\Command;
+
+class NotifyOverdueTasks extends Command
+{
+    protected $signature = 'tasks:notify-overdue';
+
+    protected $description = 'Dispatch TaskOverdue for past-due, incomplete tasks (once per task).';
+
+    public function handle(): int
+    {
+        $count = 0;
+
+        // Runs in console: IsTenantModel / RestrictsToOwner scopes are inert
+        // (no tenant/auth context), so this scans every team's tasks. Each
+        // TaskOverdue event is team-scoped by the notification listener.
+        Task::query()
+            ->whereNotNull('due_date')
+            ->where('due_date', '<', now())
+            ->where('status', '!=', 'completed')
+            ->where('overdue_notified', false)
+            ->chunkById(200, function ($tasks) use (&$count): void {
+                foreach ($tasks as $task) {
+                    TaskOverdue::dispatch($task);
+                    $task->update(['overdue_notified' => true]);
+                    $count++;
+                }
+            });
+
+        $this->info("Dispatched TaskOverdue for {$count} task(s).");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -36,12 +36,14 @@ class Task extends Model implements OwnsRecords
         'outlook_event_id',
         'calendar_type',
         'assigned_to',
+        'overdue_notified',
     ];
 
     protected $casts = [
         'reminder_date' => 'datetime',
         'reminder_sent' => 'boolean',
         'due_date' => 'datetime',
+        'overdue_notified' => 'boolean',
     ];
 
     public function contact(): BelongsTo

--- a/database/migrations/2026_07_06_180000_add_overdue_notified_to_tasks_table.php
+++ b/database/migrations/2026_07_06_180000_add_overdue_notified_to_tasks_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Dedup flag so tasks:notify-overdue fires the TaskOverdue event once per task
+ * rather than every scheduled run.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasColumn('tasks', 'overdue_notified')) {
+            return;
+        }
+
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->boolean('overdue_notified')->default(false);
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasColumn('tasks', 'overdue_notified')) {
+            return;
+        }
+
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->dropColumn('overdue_notified');
+        });
+    }
+};

--- a/routes/console.php
+++ b/routes/console.php
@@ -10,3 +10,4 @@ Artisan::command('inspire', function (): void {
 
 Schedule::command('social-media:publish-scheduled')->everyMinute();
 Schedule::command('social-media:update-analytics')->hourly();
+Schedule::command('tasks:notify-overdue')->dailyAt('07:00');

--- a/tests/Feature/Console/NotifyOverdueTasksTest.php
+++ b/tests/Feature/Console/NotifyOverdueTasksTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Events\TaskOverdue;
+use App\Models\Task;
+use App\Models\Team;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Tests\TestCase;
+
+class NotifyOverdueTasksTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_dispatches_task_overdue_once_for_past_due_incomplete_tasks(): void
+    {
+        Event::fake([TaskOverdue::class]);
+        $team = Team::factory()->create();
+
+        $overdue = Task::factory()->create([
+            'team_id' => $team->id, 'due_date' => now()->subDay(), 'status' => 'pending',
+        ]);
+        Task::factory()->create([ // not yet due
+            'team_id' => $team->id, 'due_date' => now()->addDay(), 'status' => 'pending',
+        ]);
+        Task::factory()->create([ // past due but completed
+            'team_id' => $team->id, 'due_date' => now()->subDay(), 'status' => 'completed',
+        ]);
+
+        $this->artisan('tasks:notify-overdue')->assertSuccessful();
+
+        Event::assertDispatchedTimes(TaskOverdue::class, 1);
+        Event::assertDispatched(TaskOverdue::class, fn (TaskOverdue $e): bool => $e->task->id === $overdue->id);
+        $this->assertTrue($overdue->fresh()->overdue_notified);
+    }
+
+    public function test_does_not_re_notify_an_already_notified_task(): void
+    {
+        Event::fake([TaskOverdue::class]);
+        $team = Team::factory()->create();
+        Task::factory()->create([
+            'team_id' => $team->id, 'due_date' => now()->subDay(),
+            'status' => 'pending', 'overdue_notified' => true,
+        ]);
+
+        $this->artisan('tasks:notify-overdue')->assertSuccessful();
+
+        Event::assertNotDispatched(TaskOverdue::class);
+    }
+}


### PR DESCRIPTION
## Scheduled overdue-task notifications

Completes the CRM-events feature from the prior PR: `TaskOverdue` had an event class but nothing dispatched it — "overdue" is a state-over-time condition, not a model lifecycle event, so it needs a scheduled scan.

- `tasks:notify-overdue` command dispatches `TaskOverdue` for tasks that are past `due_date` and not `completed`, **once each** (via a new `overdue_notified` dedup flag), and marks them notified.
- Scheduled `dailyAt('07:00')` in `routes/console.php`.
- Notifications are **team-scoped** by the existing `SendCRMEventNotification` listener (no cross-tenant leak) — the command scan is global (console = no tenant scope), each event scopes its own delivery.

### Testing
- **747 passed, 1 skipped, 0 failed**. `composer analyse` clean. The `overdue_notified` migration is MySQL-verified.
- Tests cover: dispatches once for a past-due incomplete task (not for future/completed ones) + sets the flag; and does not re-notify an already-notified task.

### Note
This is the last cleanly-completable CRM-event trigger. `MeetingScheduled` still has no dispatcher because there is **no Meeting model/concept** in the app — it needs a product decision (what "a meeting" is) before it can fire.