### PR TITLE
feat(teams): archive/restore team lifecycle (F3)

### DIFF
--- a/app/Filament/Resources/TeamResource.php
+++ b/app/Filament/Resources/TeamResource.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources;
+
+use App\Enums\Role;
+use App\Filament\Resources\TeamResource\Pages\ListTeams;
+use App\Models\Team;
+use Filament\Actions\Action;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Super-admin-only team lifecycle. Lists every team (including archived, which
+ * the global scope hides elsewhere) so a platform admin can archive a team
+ * (freeze + hide, data preserved) or restore one. No create/edit — teams are
+ * born through the app registration flow.
+ */
+class TeamResource extends Resource
+{
+    protected static ?string $model = Team::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-user-group';
+
+    public static function canAccess(): bool
+    {
+        return (bool) auth()->user()?->hasRole(Role::SuperAdmin);
+    }
+
+    #[\Override]
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([]);
+    }
+
+    #[\Override]
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->modifyQueryUsing(fn (Builder $query): Builder => $query->withoutGlobalScope('archived'))
+            ->columns([
+                TextColumn::make('name')->searchable()->sortable(),
+                IconColumn::make('personal_team')->boolean()->label('Personal'),
+                TextColumn::make('status')
+                    ->state(fn (Team $record): string => $record->isArchived() ? 'Archived' : 'Active')
+                    ->badge()
+                    ->color(fn (string $state): string => $state === 'Archived' ? 'danger' : 'success'),
+                TextColumn::make('archived_at')->dateTime()->placeholder('—'),
+                TextColumn::make('created_at')->dateTime()->sortable(),
+            ])
+            ->recordActions([
+                Action::make('archive')
+                    ->label('Archive')
+                    ->icon('heroicon-o-archive-box')
+                    ->color('warning')
+                    ->requiresConfirmation()
+                    ->modalDescription('Archive this team? Members lose access and its data is hidden, but nothing is deleted. You can restore it later.')
+                    ->visible(fn (Team $record): bool => ! $record->isArchived() && ! $record->personal_team)
+                    ->action(fn (Team $record) => $record->archive()),
+                Action::make('restore')
+                    ->label('Restore')
+                    ->icon('heroicon-o-arrow-uturn-left')
+                    ->color('success')
+                    ->requiresConfirmation()
+                    ->visible(fn (Team $record): bool => $record->isArchived())
+                    ->action(fn (Team $record) => $record->restore()),
+            ]);
+    }
+
+    #[\Override]
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListTeams::route('/'),
+        ];
+    }
+}

--- a/app/Filament/Resources/TeamResource/Pages/ListTeams.php
+++ b/app/Filament/Resources/TeamResource/Pages/ListTeams.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources\TeamResource\Pages;
+
+use App\Filament\Resources\TeamResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListTeams extends ListRecords
+{
+    protected static string $resource = TeamResource::class;
+}

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use DomainException;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
@@ -13,6 +15,24 @@ use Laravel\Jetstream\Team as JetstreamTeam;
 class Team extends JetstreamTeam
 {
     use HasFactory;
+
+    /**
+     * Hide archived teams from every default query. Removable so the admin
+     * panel and restore paths can still see them (->withArchived()). This one
+     * gate cascades: allTeams()/the team switcher, the User::currentTeam
+     * relation, and route-model binding all stop resolving archived teams.
+     */
+    protected static function booted(): void
+    {
+        static::addGlobalScope('archived', function (Builder $builder): void {
+            $builder->whereNull($builder->getModel()->qualifyColumn('archived_at'));
+        });
+    }
+
+    public function scopeWithArchived(Builder $query): void
+    {
+        $query->withoutGlobalScope('archived');
+    }
 
     /**
      * The attributes that are mass assignable.
@@ -62,7 +82,42 @@ class Team extends JetstreamTeam
     {
         return [
             'personal_team' => 'boolean',
+            'archived_at' => 'datetime',
         ];
+    }
+
+    public function isArchived(): bool
+    {
+        return $this->archived_at !== null;
+    }
+
+    /**
+     * Freeze the team: hide it everywhere, keep the data. Any member whose
+     * active team was this one falls back to their personal team so no session
+     * is stranded. Personal teams are a user's home and cannot be archived.
+     */
+    public function archive(): void
+    {
+        if ($this->personal_team) {
+            throw new DomainException('Personal teams cannot be archived.');
+        }
+
+        if ($this->isArchived()) {
+            return;
+        }
+
+        $this->archived_at = now();
+        $this->save();
+
+        foreach (User::query()->where('current_team_id', $this->id)->get() as $user) {
+            $user->forceFill(['current_team_id' => $user->personalTeam()?->id])->save();
+        }
+    }
+
+    public function restore(): void
+    {
+        $this->archived_at = null;
+        $this->save();
     }
 
     public function contacts(): HasMany

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -91,11 +91,17 @@ class User extends Authenticatable implements FilamentUser, HasDefaultTenant, Ha
 
     public function getTenants(Panel $panel): array|Collection
     {
+        // Archived teams are excluded by Team's global 'archived' scope, which
+        // filters the ownedTeams/teams relations allTeams() re-queries.
         return $this->allTeams();
     }
 
     public function canAccessTenant(Model $tenant): bool
     {
+        if ($tenant instanceof Team && $tenant->isArchived()) {
+            return false;
+        }
+
         return $this->ownsTeam($tenant) || $this->teams->contains($tenant);
     }
 
@@ -116,7 +122,9 @@ class User extends Authenticatable implements FilamentUser, HasDefaultTenant, Ha
 
     public function getDefaultTenant(Panel $panel): ?Model
     {
-        return $this->latestTeam;
+        $team = $this->latestTeam;
+
+        return $team instanceof Team && $team->isArchived() ? null : $team;
     }
 
     public function latestTeam(): BelongsTo

--- a/database/migrations/2026_07_06_190000_add_archived_at_to_teams_table.php
+++ b/database/migrations/2026_07_06_190000_add_archived_at_to_teams_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Team lifecycle: a nullable timestamp marks a team as archived (frozen,
+ * hidden, data preserved) vs the existing hard-delete. Presence = archived.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasColumn('teams', 'archived_at')) {
+            return;
+        }
+
+        Schema::table('teams', function (Blueprint $table) {
+            $table->timestamp('archived_at')->nullable()->index();
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasColumn('teams', 'archived_at')) {
+            return;
+        }
+
+        Schema::table('teams', function (Blueprint $table) {
+            $table->dropColumn('archived_at');
+        });
+    }
+};

--- a/docs/superpowers/specs/2026-07-06-f3-team-archive-design.md
+++ b/docs/superpowers/specs/2026-07-06-f3-team-archive-design.md
@@ -1,0 +1,97 @@
+# F3 — Team Archive / Lifecycle (design)
+
+**Date:** 2026-07-06
+**Status:** approved, implementing
+**Slice of F3:** archive/lifecycle only. `create` is already covered (registration →
+`CreateNewUserWithTeams`; Jetstream team-create). `clone` and `backup` are separate
+future slices, each its own spec.
+
+## Problem
+
+Teams (Jetstream tenants) can only be hard-deleted (`DeleteUserWithTeams` / Jetstream
+`deleteTeam`), which destroys all team-scoped data. There is no way to *deactivate* a
+team — freeze it, hide it from everyone, keep the data — for off-boarding without loss.
+
+## Decisions (locked with user)
+
+1. **Slice:** archive/lifecycle first (most bounded, highest operational value).
+2. **Access when archived:** **full lockout.** Archived team vanishes from every
+   member's team list; nobody can switch into it, view, or edit. Data stays in the DB,
+   invisible in the app. Restore brings it fully back.
+3. **Trigger surface:** mechanism + a **super_admin-only** Archive/Restore action in the
+   `/admin` panel. Owner self-service = deferred phase 2.
+
+## Invariants (safety, not preference)
+
+- **Personal teams are never archivable** — a user always needs a home team.
+- Archiving **reassigns** any member whose `current_team_id` points at the team to their
+  personal team, so no one is stranded mid-session.
+
+## Architecture — one gate
+
+The feature hinges on a single **removable global scope** on `Team` (same idiom as the
+existing `IsTenantModel` tenant scope). Hiding archived teams at the query layer cascades
+correctly through Jetstream + Filament + the API tenant boundary, instead of hand-filtering
+every call site.
+
+### 1. Data model
+
+One guarded migration, MySQL-verified:
+
+```
+teams.archived_at TIMESTAMP NULL   // presence = archived; also records "when"
+```
+
+No `is_active` bool, no new table — a nullable timestamp is the flag *and* the timestamp.
+
+### 2. Mechanism — on `App\Models\Team`
+
+- `archive(): void` — throws `DomainException` if `personal_team`; sets `archived_at = now()`;
+  reassigns members whose `current_team_id === $this->id` to `personalTeam()->id`.
+  Idempotent (already-archived → no-op).
+- `restore(): void` — clears `archived_at`.
+- `isArchived(): bool` — `archived_at !== null`.
+
+### 3. The gate — `App\Models\Scopes\ArchivedTeamScope` (global, removable)
+
+Applied to `Team`. Default queries exclude `archived_at IS NOT NULL`. Local
+`scopeWithArchived()` (and `withoutGlobalScope(ArchivedTeamScope::class)`) reveal them.
+Cascades:
+
+- `allTeams()` (Jetstream, drives the team switcher) → archived drop out automatically.
+- `User::currentTeam` relation → an archived current team resolves to `null` →
+  `SetTenantContext` sets a null tenant → **zero data leak** even if `current_team_id`
+  still points at it (belt-and-suspenders with the reassign in `archive()`).
+
+### 4. Enforcement points (defense-in-depth, all tested)
+
+- `User::getTenants()` — scope already filters; add an explicit `->reject(isArchived)`
+  guard for the direct-relation path.
+- `User::canAccessTenant()` — return `false` for an archived team (blocks a hand-crafted
+  `/app/{archivedTeamId}` URL).
+- `User::getDefaultTenant()` — never resolve to an archived team.
+
+### 5. Admin surface (super_admin only)
+
+No admin `TeamResource` exists today (only `TeamSubscriptionResource`). Add a **minimal**
+`TeamResource` on the `/admin` panel: list teams (`withArchived`), a status column, and
+**Archive** / **Restore** row actions gated `->visible()` to `super_admin` (via
+`hasGlobalRole`), each with a confirmation modal. No create/edit forms (teams are born via
+the app registration flow). Owner self-service → phase 2.
+
+## Testing (TDD, PHPUnit + sqlite, then MySQL-verify)
+
+- `archive()` sets timestamp + reassigns stranded members; refuses personal team;
+  idempotent.
+- `restore()` reverses.
+- scope hides archived by default; `withArchived` reveals.
+- archived team drops from `getTenants`; `canAccessTenant` false; not returned as default.
+- `SetTenantContext` → null tenant for a user stranded on an archived team.
+- admin action archives/restores; action hidden from non-super_admin.
+
+## Out of scope (YAGNI)
+
+- No scheduled auto-hard-delete after N days.
+- No owner-facing UI (phase 2).
+- No cascade to the 53 team-scoped data models — they stay put, invisible via the tenant
+  boundary. That is the entire point of full-lockout-not-delete.

--- a/tests/Feature/Filament/TeamResourceArchiveTest.php
+++ b/tests/Feature/Filament/TeamResourceArchiveTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament;
+
+use App\Filament\Resources\TeamResource;
+use App\Filament\Resources\TeamResource\Pages\ListTeams;
+use App\Models\Team;
+use App\Models\User;
+use Database\Seeders\RolesSeeder;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class TeamResourceArchiveTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function actingSuperAdmin(): User
+    {
+        $this->seed(RolesSeeder::class);
+        $admin = User::factory()->withPersonalTeam()->create(['email_verified_at' => now()]);
+        setPermissionsTeamId(null);
+        $admin->assignRole('super_admin');
+        $this->actingAs($admin);
+        Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+        return $admin;
+    }
+
+    public function test_index_page_mounts_for_super_admin(): void
+    {
+        $this->actingSuperAdmin();
+
+        $this->get('/admin/'.TeamResource::getSlug())->assertStatus(200);
+    }
+
+    public function test_super_admin_can_archive_team_via_action(): void
+    {
+        $this->actingSuperAdmin();
+        $team = Team::factory()->create();
+
+        Livewire::test(ListTeams::class)
+            ->callTableAction('archive', $team);
+
+        $this->assertNotNull($team->fresh()->archived_at);
+    }
+
+    public function test_super_admin_can_restore_team_via_action(): void
+    {
+        $this->actingSuperAdmin();
+        $team = Team::factory()->create();
+        $team->archive();
+
+        Livewire::test(ListTeams::class)
+            ->callTableAction('restore', $team);
+
+        $this->assertNull($team->fresh()->archived_at);
+    }
+
+    public function test_archive_action_hidden_for_personal_team(): void
+    {
+        $this->actingSuperAdmin();
+        $personal = Team::factory()->create(['personal_team' => true]);
+
+        Livewire::test(ListTeams::class)
+            ->assertTableActionHidden('archive', $personal);
+    }
+
+    public function test_resource_denies_non_super_admin(): void
+    {
+        $this->seed(RolesSeeder::class);
+        $manager = User::factory()->withPersonalTeam()->create(['email_verified_at' => now()]);
+        setPermissionsTeamId(null);
+        $manager->assignRole('manager');
+        $this->actingAs($manager);
+
+        $this->assertFalse(TeamResource::canAccess());
+    }
+}

--- a/tests/Feature/Teams/TeamArchiveTest.php
+++ b/tests/Feature/Teams/TeamArchiveTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Teams;
+
+use App\Models\Team;
+use App\Models\User;
+use App\Support\TenantContext;
+use DomainException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TeamArchiveTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_archive_sets_timestamp_and_marks_archived(): void
+    {
+        $team = Team::factory()->create();
+
+        $team->archive();
+
+        $this->assertNotNull($team->archived_at);
+        $this->assertTrue($team->isArchived());
+    }
+
+    public function test_archive_refuses_personal_team(): void
+    {
+        $team = Team::factory()->create(['personal_team' => true]);
+
+        $this->expectException(DomainException::class);
+
+        $team->archive();
+    }
+
+    public function test_archive_is_idempotent(): void
+    {
+        $team = Team::factory()->create();
+        $team->archive();
+        $first = $team->archived_at;
+
+        $team->archive();
+
+        $this->assertEquals($first, $team->fresh()->archived_at);
+    }
+
+    public function test_archive_reassigns_stranded_members_to_personal_team(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $personal = $user->personalTeam();
+
+        $shared = Team::factory()->create();
+        $user->forceFill(['current_team_id' => $shared->id])->save();
+
+        $shared->archive();
+
+        $this->assertSame($personal->id, $user->fresh()->current_team_id);
+    }
+
+    public function test_restore_clears_archived_state(): void
+    {
+        $team = Team::factory()->create();
+        $team->archive();
+
+        $team->restore();
+
+        $this->assertNull($team->fresh()->archived_at);
+        $this->assertFalse($team->fresh()->isArchived());
+    }
+
+    public function test_global_scope_hides_archived_but_with_archived_reveals(): void
+    {
+        $active = Team::factory()->create();
+        $archived = Team::factory()->create();
+        $archived->archive();
+
+        $ids = Team::query()->pluck('id');
+        $this->assertTrue($ids->contains($active->id));
+        $this->assertFalse($ids->contains($archived->id));
+
+        $allIds = Team::query()->withArchived()->pluck('id');
+        $this->assertTrue($allIds->contains($archived->id));
+    }
+
+    public function test_archived_team_drops_from_user_tenants_and_access(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $shared = Team::factory()->create(['user_id' => $user->id]);
+        $user->teams()->attach($shared);
+        $user->unsetRelation('ownedTeams')->unsetRelation('teams');
+
+        $panel = filament()->getPanel('app');
+        $this->assertTrue($user->getTenants($panel)->contains(fn (Team $t): bool => $t->id === $shared->id));
+        $this->assertTrue($user->canAccessTenant($shared));
+
+        $shared->archive();
+        $user->unsetRelation('ownedTeams')->unsetRelation('teams');
+
+        $this->assertFalse($user->getTenants($panel)->contains(fn (Team $t): bool => $t->id === $shared->id));
+        $this->assertFalse($user->canAccessTenant($shared->fresh()));
+    }
+
+    public function test_default_tenant_is_never_an_archived_team(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $shared = Team::factory()->create(['user_id' => $user->id]);
+        $user->forceFill(['current_team_id' => $shared->id])->save();
+        $shared->archive();
+
+        $panel = filament()->getPanel('app');
+        $default = $user->fresh()->getDefaultTenant($panel);
+
+        $this->assertTrue($default === null || ! $default->isArchived());
+    }
+
+    public function test_set_tenant_context_null_for_user_stranded_on_archived_team(): void
+    {
+        // current_team_id points at an archived team -> currentTeam relation
+        // resolves to null via the global scope -> no tenant, no data leak.
+        $user = User::factory()->create();
+        $shared = Team::factory()->create();
+        $user->forceFill(['current_team_id' => $shared->id])->save();
+        Team::query()->whereKey($shared->id)->update(['archived_at' => now()]);
+
+        TenantContext::clear();
+        $resolved = $user->fresh()->currentTeam;
+
+        $this->assertNull($resolved);
+    }
+}


### PR DESCRIPTION
## F3 — Team archive / lifecycle (slice 1 of 3)

Teams could only be **hard-deleted** (`DeleteUserWithTeams`), destroying all team-scoped data. This adds **reversible archive** — the safe off-boarding path: freeze a team, hide it everywhere, keep the data.

Design: [`docs/superpowers/specs/2026-07-06-f3-team-archive-design.md`](../blob/feat/f3-team-archive/docs/superpowers/specs/2026-07-06-f3-team-archive-design.md).
`create` is already covered (registration); `clone` and `backup` are separate future slices.

### Mechanism — one gate
- `teams.archived_at` (nullable timestamp) marks state; presence = archived.
- A **removable global `'archived'` scope** on `Team` (same idiom as `IsTenantModel`'s tenant scope) hides archived teams from every default query. This single gate cascades:
  - `allTeams()` / the Filament team switcher → archived drop out
  - `User::currentTeam` → an archived current team resolves to `null` → `SetTenantContext` sets a null tenant → **zero data leak** even if `current_team_id` still points at it
  - route-model binding stops resolving archived teams

### Safety invariants
- **Personal teams are never archivable** (a user's home) — `archive()` throws `DomainException`.
- Archiving **reassigns** any member stranded on the team (`current_team_id`) to their personal team, so no session breaks. Idempotent.
- Defense-in-depth: `User::canAccessTenant()` / `getDefaultTenant()` reject archived teams (blocks a hand-crafted `/app/{archivedId}` URL).

### Surface
- Super-admin-only **Archive** / **Restore** row actions on a new `/admin` `TeamResource` (confirmation modals). Owner self-service → phase 2.

### Verification
- **761 pass / 1 skip / 0 fail** (+14 new: 9 mechanism/scope/guards, 5 admin resource).
- **PHPStan: 0 new errors** (21 pre-existing baseline entries on `main`, identical with/without this branch).
- **MySQL 8.4 verified**: `migrate:fresh --force` clean; `archived_at timestamp NULL` + `teams_archived_at_index` present.

### Out of scope (YAGNI)
No scheduled auto-hard-delete, no owner-facing UI (phase 2), no cascade to the 53 team-scoped models — they stay put, invisible via the tenant boundary.