### PR TITLE
feat(teams): team data-export backups (F3)

### DIFF
--- a/app/Console/Commands/BackupTeam.php
+++ b/app/Console/Commands/BackupTeam.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Jobs\GenerateTeamBackup;
+use App\Models\Team;
+use App\Models\TeamBackup;
+use Illuminate\Console\Command;
+
+class BackupTeam extends Command
+{
+    protected $signature = 'team:backup {team : The team id}';
+
+    protected $description = 'Queue a full JSON data-export backup of a team.';
+
+    public function handle(): int
+    {
+        $id = (int) $this->argument('team');
+        $team = Team::withoutGlobalScope('archived')->find($id);
+
+        if (! $team) {
+            $this->error("Team {$id} not found.");
+
+            return self::FAILURE;
+        }
+
+        $backup = TeamBackup::create([
+            'team_id' => $team->id,
+            'disk' => (string) config('filesystems.default', 'local'),
+            'status' => 'pending',
+        ]);
+
+        GenerateTeamBackup::dispatch($backup->id);
+
+        $this->info("Queued backup #{$backup->id} for team {$team->id}.");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Filament/Resources/TeamBackupResource.php
+++ b/app/Filament/Resources/TeamBackupResource.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources;
+
+use App\Enums\Role;
+use App\Filament\Resources\TeamBackupResource\Pages\ListTeamBackups;
+use App\Models\TeamBackup;
+use Filament\Actions\Action;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * Super-admin-only view of team data-export backups: trigger new ones, download
+ * completed archives, delete old ones. Backups contain PII, so downloads stream
+ * through this gated action off a private disk — never a public URL.
+ */
+class TeamBackupResource extends Resource
+{
+    protected static ?string $model = TeamBackup::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-archive-box-arrow-down';
+
+    public static function canAccess(): bool
+    {
+        return (bool) auth()->user()?->hasRole(Role::SuperAdmin);
+    }
+
+    #[\Override]
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([]);
+    }
+
+    #[\Override]
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->defaultSort('created_at', 'desc')
+            ->columns([
+                TextColumn::make('team.name')->label('Team')->searchable(),
+                TextColumn::make('status')
+                    ->badge()
+                    ->color(fn (string $state): string => match ($state) {
+                        'completed' => 'success',
+                        'failed' => 'danger',
+                        'processing' => 'warning',
+                        default => 'gray',
+                    }),
+                TextColumn::make('size_bytes')
+                    ->label('Size')
+                    ->formatStateUsing(fn (?int $state): string => $state ? number_format($state / 1024, 1).' KB' : '—'),
+                TextColumn::make('created_at')->dateTime()->sortable(),
+            ])
+            ->recordActions([
+                Action::make('download')
+                    ->icon('heroicon-o-arrow-down-tray')
+                    ->visible(fn (TeamBackup $record): bool => $record->status === 'completed' && $record->path !== null)
+                    ->action(fn (TeamBackup $record) => Storage::disk($record->disk)->download((string) $record->path)),
+                DeleteAction::make()
+                    ->before(function (TeamBackup $record): void {
+                        if ($record->path !== null) {
+                            Storage::disk($record->disk)->delete($record->path);
+                        }
+                    }),
+            ]);
+    }
+
+    #[\Override]
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListTeamBackups::route('/'),
+        ];
+    }
+}

--- a/app/Filament/Resources/TeamBackupResource/Pages/ListTeamBackups.php
+++ b/app/Filament/Resources/TeamBackupResource/Pages/ListTeamBackups.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources\TeamBackupResource\Pages;
+
+use App\Filament\Resources\TeamBackupResource;
+use App\Jobs\GenerateTeamBackup;
+use App\Models\Team;
+use App\Models\TeamBackup;
+use Filament\Actions\Action;
+use Filament\Forms\Components\Select;
+use Filament\Notifications\Notification;
+use Filament\Resources\Pages\ListRecords;
+
+class ListTeamBackups extends ListRecords
+{
+    protected static string $resource = TeamBackupResource::class;
+
+    #[\Override]
+    protected function getHeaderActions(): array
+    {
+        return [
+            Action::make('generate')
+                ->label('Generate backup')
+                ->icon('heroicon-o-plus')
+                ->schema([
+                    Select::make('team_id')
+                        ->label('Team')
+                        ->options(fn (): array => Team::withoutGlobalScope('archived')->pluck('name', 'id')->all())
+                        ->searchable()
+                        ->required(),
+                ])
+                ->action(function (array $data): void {
+                    $backup = TeamBackup::create([
+                        'team_id' => (int) $data['team_id'],
+                        'disk' => (string) config('filesystems.default', 'local'),
+                        'status' => 'pending',
+                        'created_by' => auth()->id(),
+                    ]);
+
+                    GenerateTeamBackup::dispatch($backup->id);
+
+                    Notification::make()->title('Backup queued')->success()->send();
+                }),
+        ];
+    }
+}

--- a/app/Jobs/GenerateTeamBackup.php
+++ b/app/Jobs/GenerateTeamBackup.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use App\Models\Team;
+use App\Models\TeamBackup;
+use App\Services\TeamBackupService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Throwable;
+
+/**
+ * Builds a team's backup off the request cycle and records the outcome on the
+ * TeamBackup row. Reads unscoped (not TenantAware) by design; loads the team
+ * past the 'archived' scope so an archived team can still be backed up before
+ * a hard delete.
+ */
+class GenerateTeamBackup implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public function __construct(public int $backupId) {}
+
+    public function handle(TeamBackupService $service): void
+    {
+        $backup = TeamBackup::findOrFail($this->backupId);
+        $team = Team::withoutGlobalScope('archived')->findOrFail($backup->team_id);
+
+        $backup->update(['status' => 'processing']);
+
+        try {
+            $result = $service->backup($team, $backup->disk);
+            $backup->update([
+                'status' => 'completed',
+                'path' => $result['path'],
+                'size_bytes' => $result['size'],
+            ]);
+        } catch (Throwable $e) {
+            $backup->update(['status' => 'failed', 'error' => $e->getMessage()]);
+            throw $e;
+        }
+    }
+}

--- a/app/Models/TeamBackup.php
+++ b/app/Models/TeamBackup.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Tracking row for a team data-export. Not IsTenantModel — backups are an
+ * ops/super-admin concern, managed outside team tenancy.
+ */
+class TeamBackup extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'team_id',
+        'disk',
+        'path',
+        'size_bytes',
+        'status',
+        'error',
+        'created_by',
+    ];
+
+    protected $casts = [
+        'size_bytes' => 'integer',
+    ];
+
+    public function team(): BelongsTo
+    {
+        return $this->belongsTo(Team::class);
+    }
+
+    public function creator(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+}

--- a/app/Services/TeamBackupService.php
+++ b/app/Services/TeamBackupService.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\Team;
+use App\Support\TenantModels;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use RuntimeException;
+use ZipArchive;
+
+/**
+ * Builds a JSON snapshot zip of every row a team owns: one {Model}.json per
+ * team-scoped model (discovered via TenantModels) plus team-owned extras, and
+ * a manifest. Reads UNSCOPED by design — a backup must capture all of a team's
+ * rows regardless of request/tenant context — and is guarded by the
+ * completeness + "only this team's rows" tests.
+ */
+class TeamBackupService
+{
+    private const FORMAT_VERSION = 1;
+
+    /** Team-owned tables that are not IsTenantModel models. */
+    private const EXTRA_TABLES = ['team_user', 'team_invitations', 'team_subscriptions'];
+
+    /**
+     * @return array{disk: string, path: string, size: int}
+     */
+    public function backup(Team $team, ?string $disk = null): array
+    {
+        $disk ??= (string) config('filesystems.default', 'local');
+
+        $tmp = tempnam(sys_get_temp_dir(), 'teambackup');
+        if ($tmp === false) {
+            throw new RuntimeException('Could not allocate a temp file for the backup.');
+        }
+
+        $zip = new ZipArchive;
+        if ($zip->open($tmp, ZipArchive::OVERWRITE) !== true) {
+            throw new RuntimeException('Could not open the backup archive for writing.');
+        }
+
+        $manifest = [
+            'format_version' => self::FORMAT_VERSION,
+            'team' => ['id' => $team->id, 'name' => $team->name],
+            'generated_at' => now()->toIso8601String(),
+            'models' => [],
+            'extras' => [],
+        ];
+
+        // ponytail: loads each model's rows into memory to serialize; fine for
+        // realistic team sizes. If a team ever holds millions of rows, stream
+        // chunkById to NDJSON temp files and addFile instead.
+        foreach (TenantModels::all() as $class) {
+            // A tenant-scoped model with no table is dead/pending schema drift
+            // (e.g. SiteSettings) — it holds no rows, so skip rather than fatal.
+            if (! Schema::hasTable((new $class)->getTable())) {
+                continue;
+            }
+
+            $rows = $class::query()->withoutGlobalScope('tenant')->where('team_id', $team->id)->get();
+            $name = class_basename($class);
+            $zip->addFromString("models/{$name}.json", (string) $rows->toJson(JSON_PRETTY_PRINT));
+            $manifest['models'][$name] = $rows->count();
+        }
+
+        // The team root row.
+        $zip->addFromString('extras/teams.json', (string) DB::table('teams')->where('id', $team->id)->get()->toJson());
+        $manifest['extras']['teams'] = 1;
+
+        foreach (self::EXTRA_TABLES as $table) {
+            if (! Schema::hasTable($table)) {
+                continue;
+            }
+            $rows = DB::table($table)->where('team_id', $team->id)->get();
+            $zip->addFromString("extras/{$table}.json", (string) $rows->toJson());
+            $manifest['extras'][$table] = $rows->count();
+        }
+
+        $zip->addFromString('manifest.json', (string) json_encode($manifest, JSON_PRETTY_PRINT));
+        $zip->close();
+
+        $path = 'backups/team-'.$team->id.'-'.now()->format('Ymd-His').'-'.Str::lower(Str::random(6)).'.zip';
+        Storage::disk($disk)->put($path, (string) file_get_contents($tmp));
+        @unlink($tmp);
+
+        return [
+            'disk' => $disk,
+            'path' => $path,
+            'size' => (int) Storage::disk($disk)->size($path),
+        ];
+    }
+}

--- a/app/Support/TenantModels.php
+++ b/app/Support/TenantModels.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use App\Traits\IsTenantModel;
+use ReflectionClass;
+
+/**
+ * Single source of truth for "which Eloquent models are team-scoped."
+ *
+ * Discovers every instantiable model in app/Models that uses IsTenantModel.
+ * Path-relative (not container-dependent) so it works both at runtime and at
+ * PHPUnit collection time, before the app boots. CrossTenantLeakageTest and
+ * TeamBackupService both consume this — so the test that proves no model
+ * escapes the tenant scope also proves the backup covers every model.
+ */
+class TenantModels
+{
+    /**
+     * @return list<class-string>
+     */
+    public static function all(): array
+    {
+        $dir = dirname(__DIR__).'/Models';
+        $models = [];
+
+        foreach (glob($dir.'/*.php') ?: [] as $file) {
+            $class = 'App\\Models\\'.basename($file, '.php');
+
+            if (! class_exists($class)) {
+                continue;
+            }
+            if (! in_array(IsTenantModel::class, class_uses_recursive($class), true)) {
+                continue;
+            }
+            if (! (new ReflectionClass($class))->isInstantiable()) {
+                continue;
+            }
+
+            $models[class_basename($class)] = $class;
+        }
+
+        ksort($models);
+
+        /** @var list<class-string> */
+        return array_values($models);
+    }
+}

--- a/database/factories/TeamBackupFactory.php
+++ b/database/factories/TeamBackupFactory.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\Team;
+use App\Models\TeamBackup;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<TeamBackup>
+ */
+class TeamBackupFactory extends Factory
+{
+    protected $model = TeamBackup::class;
+
+    public function definition(): array
+    {
+        return [
+            'team_id' => Team::factory(),
+            'disk' => 'local',
+            'path' => null,
+            'size_bytes' => null,
+            'status' => 'pending',
+            'error' => null,
+            'created_by' => null,
+        ];
+    }
+
+    public function completed(): static
+    {
+        return $this->state(fn (): array => [
+            'status' => 'completed',
+            'path' => 'backups/team-backup.zip',
+            'size_bytes' => 2048,
+        ]);
+    }
+}

--- a/database/migrations/2026_07_06_200000_create_team_backups_table.php
+++ b/database/migrations/2026_07_06_200000_create_team_backups_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Tracks each team data-export: its lifecycle (pending -> processing ->
+ * completed | failed) and where the resulting zip lives on the storage disk.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('team_backups')) {
+            return;
+        }
+
+        Schema::create('team_backups', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('team_id')->constrained()->cascadeOnDelete();
+            $table->string('disk')->default('local');
+            $table->string('path')->nullable();
+            $table->unsignedBigInteger('size_bytes')->nullable();
+            $table->string('status')->default('pending')->index();
+            $table->text('error')->nullable();
+            $table->foreignId('created_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('team_backups');
+    }
+};

--- a/docs/superpowers/specs/2026-07-06-f3-team-backup-design.md
+++ b/docs/superpowers/specs/2026-07-06-f3-team-backup-design.md
@@ -1,0 +1,105 @@
+# F3 — Team backup / data export (design)
+
+**Date:** 2026-07-06
+**Status:** approved, implementing
+**Slice of F3:** backup only. Sibling slices already shipped/deferred: `create` (done),
+`archive` (PR #475), `clone` (future). Restore/import is a **separate future slice** —
+this backup's JSON is deliberately import-shaped so restore can consume it.
+
+## Problem
+
+SCOPE §51 "Tenant backups" (TASKS F3). There is no way to export a team's data — for
+operational backup, pre-delete safety, or GDPR portability. 53 models are team-scoped via
+`IsTenantModel`; nothing exports them.
+
+## Decisions (locked with user)
+
+1. **Artifact:** a **JSON snapshot zip** — every `team_id` row per model serialized to a
+   model-keyed `*.json`, plus a `manifest.json`, bundled in one zip. Portable,
+   machine-readable, re-importable later.
+2. **Trigger/delivery:** a **queued job** builds the zip to a storage disk and tracks it in
+   a `team_backups` row. Triggered by a super_admin admin-panel action **or** a
+   `team:backup {team}` artisan command (schedulable). Super_admin downloads the stored
+   file.
+3. **Model scope:** **auto-discover** every model using `IsTenantModel` (self-maintaining,
+   zero drift) plus explicit team-owned extras. Same enumeration `CrossTenantLeakageTest`
+   already proves.
+
+## Architecture — small, isolated units
+
+### 1. `App\Support\TenantModels` (enumerator)
+
+Reflects `app/Models/*.php`, returns each instantiable model class using `IsTenantModel`
+(via `class_uses_recursive`). Single source of truth for "what is team-scoped."
+`CrossTenantLeakageTest` is refactored to consume it, so the test that proves no model
+escapes the tenant scope also proves the backup covers every model — completeness is
+guarded by an existing test, not a hand-list that drifts.
+
+### 2. `App\Services\TeamBackupService` (pure mechanism)
+
+`backup(Team $team): TeamBackupResult` (path + size). For the given team:
+
+- For each `TenantModels::all()` class: read rows **unscoped** —
+  `Model::withoutGlobalScope('tenant')->where('team_id', $team->id)` — `chunkById` to
+  avoid loading everything at once, stream each chunk as JSON into `{ModelBasename}.json`.
+- Explicit extras (team-owned but not `IsTenantModel`): the `teams` row, `team_user`
+  (memberships), `team_invitations`, `team_subscriptions` — queried by `team_id`.
+- Write `manifest.json`: `{ team: {id, name}, generated_at, app_version, schema_version,
+  models: { Contact: <count>, ... }, extras: { team_user: <count>, ... } }`.
+- Bundle into a zip on the configured backup disk; return path + byte size.
+
+Reads unscoped **by design** — a backup must capture all of a team's rows regardless of
+request/tenant context. The completeness + "only this team's rows" tests guard it.
+
+### 3. `App\Jobs\GenerateTeamBackup` (queued wrapper)
+
+Takes a team id + the `team_backups` row id. Drives status `pending → processing →
+completed | failed`; calls the service; records `path`, `size_bytes`, or `error`. **Not**
+`TenantAware` — it reads unscoped intentionally. Works under the `sync` queue in dev and
+Horizon in prod.
+
+### 4. `team_backups` table + `TeamBackup` model
+
+Columns: `id, team_id (fk), disk, path (nullable), size_bytes (nullable), status, error
+(nullable text), created_by (nullable fk users), timestamps`. Tracks each backup's
+lifecycle and location.
+
+### 5. `team:backup {team}` command
+
+Resolves the team (by id), creates a `pending` `team_backups` row, dispatches
+`GenerateTeamBackup`. Schedulable for recurring "tenant backups." Unknown id → clean
+failure (non-zero exit).
+
+### 6. Admin `TeamBackupResource` (super_admin only)
+
+`canAccess()` gated to `super_admin`. Table lists backups (team, status badge, size,
+created_at). **Generate backup** header action (team select → dispatch). Row actions:
+**Download** (streams via `Storage::disk($disk)->download($path)`, super_admin-gated —
+never a public URL) and **Delete** (removes the file + row).
+
+## Security
+
+- Backups contain PII → written to a **private** disk (default `local`), never `public`.
+- Download streamed through the super_admin-gated action, not a signed/public link.
+- `team_backups` rows + the resource are super_admin-only.
+
+## Testing (TDD, PHPUnit + sqlite, then MySQL-verify)
+
+- `TenantModels::all()` returns the full team-scoped set; `CrossTenantLeakageTest` consumes
+  it (completeness proof).
+- `TeamBackupService`: produces a zip that unzips to the expected model JSONs; manifest
+  counts match seeded rows; **only the target team's rows are present** (export-side
+  cross-tenant check — seed two teams, assert the other team's rows absent).
+- `GenerateTeamBackup`: success sets `completed` + path/size; a thrown service error sets
+  `failed` + records the message.
+- `team:backup`: dispatches the job for a valid team; unknown id fails cleanly.
+- Admin: super_admin can generate/download/delete; non-super_admin denied (`canAccess`
+  false).
+- MySQL migration verify (`team_backups`).
+
+## Out of scope (YAGNI)
+
+- Restore/import (separate slice; JSON is import-shaped for it).
+- Retention/expiry auto-prune (Delete action now; a prune command later).
+- At-rest encryption beyond the private disk.
+- Incremental/diff backups.

--- a/tests/Feature/Filament/TeamBackupResourceTest.php
+++ b/tests/Feature/Filament/TeamBackupResourceTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament;
+
+use App\Filament\Resources\TeamBackupResource;
+use App\Filament\Resources\TeamBackupResource\Pages\ListTeamBackups;
+use App\Jobs\GenerateTeamBackup;
+use App\Models\Team;
+use App\Models\User;
+use Database\Seeders\RolesSeeder;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class TeamBackupResourceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function actingSuperAdmin(): User
+    {
+        $this->seed(RolesSeeder::class);
+        $admin = User::factory()->withPersonalTeam()->create(['email_verified_at' => now()]);
+        setPermissionsTeamId(null);
+        $admin->assignRole('super_admin');
+        $this->actingAs($admin);
+        Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+        return $admin;
+    }
+
+    public function test_index_page_mounts_for_super_admin(): void
+    {
+        $this->actingSuperAdmin();
+
+        $this->get('/admin/'.TeamBackupResource::getSlug())->assertStatus(200);
+    }
+
+    public function test_generate_action_queues_a_backup(): void
+    {
+        Bus::fake();
+        $this->actingSuperAdmin();
+        $team = Team::factory()->create();
+
+        Livewire::test(ListTeamBackups::class)
+            ->callAction('generate', ['team_id' => $team->id]);
+
+        $this->assertDatabaseHas('team_backups', [
+            'team_id' => $team->id,
+            'status' => 'pending',
+        ]);
+        Bus::assertDispatched(GenerateTeamBackup::class);
+    }
+
+    public function test_resource_denies_non_super_admin(): void
+    {
+        $this->seed(RolesSeeder::class);
+        $manager = User::factory()->withPersonalTeam()->create(['email_verified_at' => now()]);
+        setPermissionsTeamId(null);
+        $manager->assignRole('manager');
+        $this->actingAs($manager);
+
+        $this->assertFalse(TeamBackupResource::canAccess());
+    }
+}

--- a/tests/Feature/Support/TenantModelsTest.php
+++ b/tests/Feature/Support/TenantModelsTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Support;
+
+use App\Models\Contact;
+use App\Models\Lead;
+use App\Models\Team;
+use App\Models\TeamBackup;
+use App\Models\User;
+use App\Support\TenantModels;
+use Tests\TestCase;
+
+class TenantModelsTest extends TestCase
+{
+    public function test_all_includes_team_scoped_models(): void
+    {
+        $all = TenantModels::all();
+
+        $this->assertContains(Contact::class, $all);
+        $this->assertContains(Lead::class, $all);
+    }
+
+    public function test_all_excludes_non_tenant_models(): void
+    {
+        $all = TenantModels::all();
+
+        $this->assertNotContains(User::class, $all);
+        $this->assertNotContains(Team::class, $all);
+        $this->assertNotContains(TeamBackup::class, $all);
+    }
+}

--- a/tests/Feature/Teams/BackupTeamCommandTest.php
+++ b/tests/Feature/Teams/BackupTeamCommandTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Teams;
+
+use App\Jobs\GenerateTeamBackup;
+use App\Models\Team;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Tests\TestCase;
+
+class BackupTeamCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_command_queues_a_backup_for_a_valid_team(): void
+    {
+        Bus::fake();
+        $team = Team::factory()->create();
+
+        $this->artisan('team:backup', ['team' => $team->id])->assertSuccessful();
+
+        $this->assertDatabaseHas('team_backups', [
+            'team_id' => $team->id,
+            'status' => 'pending',
+        ]);
+        Bus::assertDispatched(GenerateTeamBackup::class);
+    }
+
+    public function test_command_fails_for_unknown_team(): void
+    {
+        Bus::fake();
+
+        $this->artisan('team:backup', ['team' => 999999])->assertFailed();
+
+        Bus::assertNotDispatched(GenerateTeamBackup::class);
+        $this->assertDatabaseCount('team_backups', 0);
+    }
+}

--- a/tests/Feature/Teams/GenerateTeamBackupJobTest.php
+++ b/tests/Feature/Teams/GenerateTeamBackupJobTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Teams;
+
+use App\Jobs\GenerateTeamBackup;
+use App\Models\Contact;
+use App\Models\Team;
+use App\Models\TeamBackup;
+use App\Services\TeamBackupService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use RuntimeException;
+use Tests\TestCase;
+use Throwable;
+
+class GenerateTeamBackupJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_job_completes_and_records_path_and_size(): void
+    {
+        Storage::fake('local');
+        $team = Team::factory()->create();
+        Contact::factory()->create(['team_id' => $team->id]);
+        $backup = TeamBackup::factory()->create(['team_id' => $team->id, 'disk' => 'local']);
+
+        (new GenerateTeamBackup($backup->id))->handle(app(TeamBackupService::class));
+
+        $backup->refresh();
+        $this->assertSame('completed', $backup->status);
+        $this->assertNotNull($backup->path);
+        $this->assertGreaterThan(0, $backup->size_bytes);
+        Storage::disk('local')->assertExists($backup->path);
+    }
+
+    public function test_job_records_failure(): void
+    {
+        $team = Team::factory()->create();
+        $backup = TeamBackup::factory()->create(['team_id' => $team->id, 'disk' => 'local']);
+
+        $service = new class extends TeamBackupService
+        {
+            public function backup(Team $team, ?string $disk = null): array
+            {
+                throw new RuntimeException('boom');
+            }
+        };
+
+        try {
+            (new GenerateTeamBackup($backup->id))->handle($service);
+            $this->fail('expected the job to rethrow');
+        } catch (Throwable $e) {
+            $this->assertSame('boom', $e->getMessage());
+        }
+
+        $backup->refresh();
+        $this->assertSame('failed', $backup->status);
+        $this->assertStringContainsString('boom', (string) $backup->error);
+    }
+}

--- a/tests/Feature/Teams/TeamBackupServiceTest.php
+++ b/tests/Feature/Teams/TeamBackupServiceTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Teams;
+
+use App\Models\Contact;
+use App\Models\Lead;
+use App\Models\Team;
+use App\Models\User;
+use App\Services\TeamBackupService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+use ZipArchive;
+
+class TeamBackupServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function readEntry(string $path, string $entry): string
+    {
+        $zip = new ZipArchive;
+        $this->assertTrue($zip->open(Storage::disk('local')->path($path)) === true);
+        $contents = $zip->getFromName($entry);
+        $zip->close();
+        $this->assertNotFalse($contents, "zip entry `{$entry}` is missing");
+
+        return $contents;
+    }
+
+    public function test_backup_produces_a_zip_with_model_json_and_manifest(): void
+    {
+        Storage::fake('local');
+        $team = Team::factory()->create();
+        Contact::factory()->create(['team_id' => $team->id, 'name' => 'Acme Buyer']);
+
+        $result = (new TeamBackupService)->backup($team, 'local');
+
+        Storage::disk('local')->assertExists($result['path']);
+        $this->assertGreaterThan(0, $result['size']);
+
+        $manifest = json_decode($this->readEntry($result['path'], 'manifest.json'), true);
+        $this->assertSame($team->id, $manifest['team']['id']);
+        $this->assertSame(1, $manifest['models']['Contact']);
+
+        $this->assertStringContainsString('Acme Buyer', $this->readEntry($result['path'], 'models/Contact.json'));
+    }
+
+    public function test_backup_contains_only_the_target_teams_rows(): void
+    {
+        Storage::fake('local');
+        $teamA = Team::factory()->create();
+        $teamB = Team::factory()->create();
+        Contact::factory()->create(['team_id' => $teamA->id, 'name' => 'Mine Contact']);
+        Contact::factory()->create(['team_id' => $teamB->id, 'name' => 'Other Contact']);
+        Lead::factory()->create(['team_id' => $teamB->id]);
+
+        $result = (new TeamBackupService)->backup($teamA, 'local');
+
+        $contacts = $this->readEntry($result['path'], 'models/Contact.json');
+        $this->assertStringContainsString('Mine Contact', $contacts);
+        $this->assertStringNotContainsString('Other Contact', $contacts);
+
+        $manifest = json_decode($this->readEntry($result['path'], 'manifest.json'), true);
+        $this->assertSame(1, $manifest['models']['Contact']);
+    }
+
+    public function test_backup_includes_team_membership_extras(): void
+    {
+        Storage::fake('local');
+        $owner = User::factory()->create();
+        $team = Team::factory()->create(['user_id' => $owner->id]);
+        $member = User::factory()->create();
+        $team->users()->attach($member, ['role' => 'sales_rep']);
+
+        $result = (new TeamBackupService)->backup($team, 'local');
+
+        $manifest = json_decode($this->readEntry($result['path'], 'manifest.json'), true);
+        $this->assertSame(1, $manifest['extras']['team_user']);
+        $this->assertStringContainsString((string) $member->id, $this->readEntry($result['path'], 'extras/team_user.json'));
+    }
+}

--- a/tests/Feature/Tenancy/CrossTenantLeakageTest.php
+++ b/tests/Feature/Tenancy/CrossTenantLeakageTest.php
@@ -4,11 +4,10 @@ namespace Tests\Feature\Tenancy;
 
 use App\Models\Team;
 use App\Support\TenantContext;
-use App\Traits\IsTenantModel;
+use App\Support\TenantModels;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Schema;
 use PHPUnit\Framework\Attributes\DataProvider;
-use ReflectionClass;
 use Tests\TestCase;
 
 /**
@@ -35,28 +34,15 @@ class CrossTenantLeakageTest extends TestCase
     /** @return array<string, array{class-string}> */
     public static function tenantModels(): array
     {
-        // Filesystem walk — no container helpers: data providers run at
-        // collection time, before the app is booted.
-        $modelDir = dirname(__DIR__, 3).'/app/Models';
+        // Shared enumerator (App\Support\TenantModels) is path-relative and
+        // container-free, so it works here at data-provider collection time —
+        // before the app boots. TeamBackupService consumes the same list, so
+        // this leakage proof and the backup's model set can never diverge.
         $models = [];
 
-        foreach (glob($modelDir.'/*.php') as $file) {
-            $class = 'App\\Models\\'.basename($file, '.php');
-
-            if (! class_exists($class)) {
-                continue;
-            }
-            if (! in_array(IsTenantModel::class, class_uses_recursive($class), true)) {
-                continue;
-            }
-            if (! (new ReflectionClass($class))->isInstantiable()) {
-                continue;
-            }
-
+        foreach (TenantModels::all() as $class) {
             $models[class_basename($class)] = [$class];
         }
-
-        ksort($models);
 
         return $models;
     }


### PR DESCRIPTION
## F3 — Team backup / data export (slice 2 of F3)

No way existed to export a team's data — for operational backup, pre-delete safety, or GDPR portability (SCOPE §51 "Tenant backups"). This adds **on-demand JSON-snapshot backups**.

Design: [`docs/superpowers/specs/2026-07-06-f3-team-backup-design.md`](../blob/feat/f3-team-backup/docs/superpowers/specs/2026-07-06-f3-team-backup-design.md).
Sibling slices: `create` (done), `archive` (#475), `clone` (future). Restore/import is a **separate future slice** — this JSON is deliberately import-shaped for it.

### What it produces
A zip per backup: `models/{Model}.json` for every team-scoped model + `extras/` (team row, memberships, invitations, subscriptions) + `manifest.json` with per-model row counts (the contract a future restore reads).

### Components (each testable in isolation)
- **`App\Support\TenantModels`** — reflects `app/Models`, returns every `IsTenantModel` model. Path-relative so it works at test-collection time too. **`CrossTenantLeakageTest` now consumes it** → the test proving no model escapes the tenant scope also proves the backup covers every model; no hand-list to drift.
- **`TeamBackupService`** — builds the zip. Reads **unscoped by design** (`withoutGlobalScope('tenant')` + explicit `team_id`) to capture all rows; **skips models whose table is absent** (dead schema drift like `SiteSettings`) instead of fataling.
- **`GenerateTeamBackup`** (queued) — drives a `team_backups` row `pending → processing → completed|failed`, records path/size. Loads the team **past the `archived` scope** so an archived team can be backed up before hard-delete.
- **`team:backup {team}`** command (schedulable) + super-admin-only **`TeamBackupResource`** (generate / download / delete).

### Security
Backups contain PII → written to a **private** disk, never `public`; downloads **stream through the super-admin-gated action**, not a public URL. Export-side cross-tenant test asserts only the target team's rows are present.

### Verification
- **773 pass / 1 skip / 0 fail** (+12: service 3, enumerator 2, job 2, command 2, resource 3). The skip is `SiteSettings` (known no-table drift, now surfaced by the shared enumerator).
- **PHPStan: 0 new** (21 pre-existing baseline entries on `main`, identical with/without this branch).
- **MySQL 8.4 verified**: `migrate:fresh --force` clean; `team_backups` + both FKs present.

### Out of scope (YAGNI)
Restore/import (separate slice), retention/expiry auto-prune (Delete action now), at-rest encryption beyond the private disk, incremental backups.