### PR TITLE
feat(teams): restore a team from its backup (F3)

### DIFF
--- a/app/Console/Commands/RestoreTeam.php
+++ b/app/Console/Commands/RestoreTeam.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Jobs\RestoreTeamBackup;
+use App\Models\TeamBackup;
+use Illuminate\Console\Command;
+
+class RestoreTeam extends Command
+{
+    protected $signature = 'team:restore {backup : The team_backups id}';
+
+    protected $description = 'Restore a team\'s data from one of its completed backups (same-team recovery).';
+
+    public function handle(): int
+    {
+        $id = (int) $this->argument('backup');
+        $backup = TeamBackup::find($id);
+
+        if (! $backup) {
+            $this->error("Backup {$id} not found.");
+
+            return self::FAILURE;
+        }
+
+        RestoreTeamBackup::dispatch($backup->id);
+
+        $this->info("Queued restore from backup #{$backup->id} into team {$backup->team_id}.");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Exceptions/TeamNotEmptyException.php
+++ b/app/Exceptions/TeamNotEmptyException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions;
+
+/**
+ * The restore target team already holds data. Restore is same-team disaster
+ * recovery and refuses to run against a populated team (would duplicate rows
+ * and collide on original PKs).
+ */
+class TeamNotEmptyException extends TeamRestoreException {}

--- a/app/Exceptions/TeamRestoreException.php
+++ b/app/Exceptions/TeamRestoreException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions;
+
+use RuntimeException;
+
+/**
+ * A team restore could not proceed (bad/incomplete source, missing team,
+ * unsupported format). Carries a message safe to surface to a super admin.
+ */
+class TeamRestoreException extends RuntimeException {}

--- a/app/Filament/Resources/TeamBackupResource.php
+++ b/app/Filament/Resources/TeamBackupResource.php
@@ -6,9 +6,13 @@ namespace App\Filament\Resources;
 
 use App\Enums\Role;
 use App\Filament\Resources\TeamBackupResource\Pages\ListTeamBackups;
+use App\Jobs\RestoreTeamBackup;
+use App\Models\Team;
 use App\Models\TeamBackup;
+use App\Services\TeamRestoreService;
 use Filament\Actions\Action;
 use Filament\Actions\DeleteAction;
+use Filament\Notifications\Notification;
 use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
@@ -62,6 +66,30 @@ class TeamBackupResource extends Resource
                     ->icon('heroicon-o-arrow-down-tray')
                     ->visible(fn (TeamBackup $record): bool => $record->status === 'completed' && $record->path !== null)
                     ->action(fn (TeamBackup $record) => Storage::disk($record->disk)->download((string) $record->path)),
+                Action::make('restore')
+                    ->icon('heroicon-o-arrow-uturn-left')
+                    ->color('warning')
+                    ->requiresConfirmation()
+                    ->modalHeading('Restore this backup?')
+                    ->modalDescription('Re-inserts this team\'s data from the backup. Only runs when the team currently has no data — nothing is overwritten.')
+                    ->visible(fn (TeamBackup $record): bool => $record->status === 'completed' && $record->path !== null)
+                    ->action(function (TeamBackup $record): void {
+                        $team = Team::withoutGlobalScope('archived')->find($record->team_id);
+
+                        if ($team && app(TeamRestoreService::class)->firstPopulatedTable($team) !== null) {
+                            Notification::make()
+                                ->title('Cannot restore')
+                                ->body('That team still has data — restore only runs into an empty team.')
+                                ->danger()
+                                ->send();
+
+                            return;
+                        }
+
+                        RestoreTeamBackup::dispatch($record->id, auth()->id());
+
+                        Notification::make()->title('Restore queued')->success()->send();
+                    }),
                 DeleteAction::make()
                     ->before(function (TeamBackup $record): void {
                         if ($record->path !== null) {

--- a/app/Jobs/RestoreTeamBackup.php
+++ b/app/Jobs/RestoreTeamBackup.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use App\Models\TeamBackup;
+use App\Models\User;
+use App\Services\TeamRestoreService;
+use Filament\Notifications\Notification;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Throwable;
+
+/**
+ * Restores a team's data off the request cycle and reports the outcome to the
+ * initiating super admin via a database notification. Not TenantAware — writes
+ * unscoped by design.
+ */
+class RestoreTeamBackup implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public function __construct(public int $backupId, public ?int $notifyUserId = null) {}
+
+    public function handle(TeamRestoreService $service): void
+    {
+        $backup = TeamBackup::findOrFail($this->backupId);
+
+        try {
+            $counts = $service->restore($backup);
+            $this->notify('Restore complete', true, 'Restored '.array_sum($counts)." rows into team {$backup->team_id}.");
+        } catch (Throwable $e) {
+            $this->notify('Restore failed', false, $e->getMessage());
+            throw $e;
+        }
+    }
+
+    private function notify(string $title, bool $success, string $body): void
+    {
+        if ($this->notifyUserId === null) {
+            return;
+        }
+
+        $user = User::find($this->notifyUserId);
+        if (! $user) {
+            return;
+        }
+
+        $notification = Notification::make()->title($title)->body($body);
+        ($success ? $notification->success() : $notification->danger())->sendToDatabase($user);
+    }
+}

--- a/app/Services/TeamBackupService.php
+++ b/app/Services/TeamBackupService.php
@@ -55,14 +55,21 @@ class TeamBackupService
         // ponytail: loads each model's rows into memory to serialize; fine for
         // realistic team sizes. If a team ever holds millions of rows, stream
         // chunkById to NDJSON temp files and addFile instead.
+        //
+        // Raw DB rows (not Eloquent ->toJson()) so values are DB-native and the
+        // restore is a verbatim DB::table()->insert() — no cast round-trip
+        // ambiguity (json columns, dates). Keyed by model basename; restore
+        // resolves basename -> table via the same TenantModels enumeration.
         foreach (TenantModels::all() as $class) {
+            $table = (new $class)->getTable();
+
             // A tenant-scoped model with no table is dead/pending schema drift
             // (e.g. SiteSettings) — it holds no rows, so skip rather than fatal.
-            if (! Schema::hasTable((new $class)->getTable())) {
+            if (! Schema::hasTable($table)) {
                 continue;
             }
 
-            $rows = $class::query()->withoutGlobalScope('tenant')->where('team_id', $team->id)->get();
+            $rows = DB::table($table)->where('team_id', $team->id)->get();
             $name = class_basename($class);
             $zip->addFromString("models/{$name}.json", (string) $rows->toJson(JSON_PRETTY_PRINT));
             $manifest['models'][$name] = $rows->count();

--- a/app/Services/TeamRestoreService.php
+++ b/app/Services/TeamRestoreService.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Exceptions\TeamNotEmptyException;
+use App\Exceptions\TeamRestoreException;
+use App\Models\Team;
+use App\Models\TeamBackup;
+use App\Support\TenantModels;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Storage;
+use ZipArchive;
+
+/**
+ * Same-team disaster recovery: re-inserts a team's rows from one of its own
+ * completed backups, with original PKs, so foreign keys stay valid without any
+ * id remapping. Refuses to run against a team that still holds data (would
+ * duplicate rows / collide on PKs). Atomic — a single bad row rolls back the
+ * whole restore. Reads unscoped by design.
+ */
+class TeamRestoreService
+{
+    private const FORMAT_VERSION = 1;
+
+    /**
+     * @return array<string, int> rows restored per model
+     */
+    public function restore(TeamBackup $backup): array
+    {
+        if ($backup->status !== 'completed' || $backup->path === null) {
+            throw new TeamRestoreException("Backup #{$backup->id} is not a completed backup.");
+        }
+
+        $disk = Storage::disk($backup->disk);
+        if (! $disk->exists($backup->path)) {
+            throw new TeamRestoreException("Backup file is missing: {$backup->path}.");
+        }
+
+        // ZipArchive needs a local path — stage the artifact to a temp file.
+        $tmp = tempnam(sys_get_temp_dir(), 'teamrestore');
+        if ($tmp === false) {
+            throw new TeamRestoreException('Could not allocate a temp file for the restore.');
+        }
+        file_put_contents($tmp, (string) $disk->get($backup->path));
+
+        $zip = new ZipArchive;
+        if ($zip->open($tmp) !== true) {
+            @unlink($tmp);
+            throw new TeamRestoreException('Could not open the backup archive.');
+        }
+
+        try {
+            $team = $this->resolveTargetTeam($zip);
+            $this->assertTeamEmpty($team);
+
+            // FK checks OFF must wrap (not nest inside) the transaction: on
+            // sqlite `PRAGMA foreign_keys` is a no-op once a transaction is
+            // open, so toggle it before BEGIN. With FKs off, insert order is
+            // irrelevant; the inner transaction keeps the restore atomic.
+            $restored = [];
+            Schema::withoutForeignKeyConstraints(function () use ($zip, $team, &$restored): void {
+                $restored = DB::transaction(fn (): array => $this->insertRows($zip, $team));
+            });
+
+            return $restored;
+        } finally {
+            $zip->close();
+            @unlink($tmp);
+        }
+    }
+
+    private function resolveTargetTeam(ZipArchive $zip): Team
+    {
+        $manifestJson = $zip->getFromName('manifest.json');
+        if ($manifestJson === false) {
+            throw new TeamRestoreException('Backup archive has no manifest.');
+        }
+
+        $manifest = json_decode($manifestJson, true);
+        if (! is_array($manifest) || ($manifest['format_version'] ?? null) !== self::FORMAT_VERSION) {
+            throw new TeamRestoreException('Unsupported or unreadable backup format.');
+        }
+
+        $team = Team::withoutGlobalScope('archived')->find($manifest['team']['id'] ?? 0);
+        if (! $team) {
+            throw new TeamRestoreException('Target team no longer exists.');
+        }
+
+        return $team;
+    }
+
+    /**
+     * The first team-scoped table already holding data for the team, or null
+     * when the team is empty. Public so a trigger can give instant "not empty"
+     * feedback before queueing a restore.
+     */
+    public function firstPopulatedTable(Team $team): ?string
+    {
+        foreach (TenantModels::all() as $class) {
+            $table = (new $class)->getTable();
+            if (Schema::hasTable($table) && DB::table($table)->where('team_id', $team->id)->exists()) {
+                return $table;
+            }
+        }
+
+        return null;
+    }
+
+    private function assertTeamEmpty(Team $team): void
+    {
+        if ($table = $this->firstPopulatedTable($team)) {
+            throw new TeamNotEmptyException(
+                "Team {$team->id} already has data (`{$table}`); refusing to restore over it."
+            );
+        }
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function insertRows(ZipArchive $zip, Team $team): array
+    {
+        $restored = [];
+
+        foreach (TenantModels::all() as $class) {
+            $table = (new $class)->getTable();
+            if (! Schema::hasTable($table)) {
+                continue;
+            }
+
+            $json = $zip->getFromName('models/'.class_basename($class).'.json');
+            if ($json === false) {
+                continue;
+            }
+
+            /** @var list<array<string, mixed>> $rows */
+            $rows = json_decode((string) $json, true) ?: [];
+            // Trust nothing: only rows actually belonging to this team.
+            $rows = array_values(array_filter(
+                $rows,
+                fn (array $row): bool => (int) ($row['team_id'] ?? 0) === $team->id,
+            ));
+
+            if ($rows === []) {
+                continue;
+            }
+
+            foreach (array_chunk($rows, 500) as $chunk) {
+                DB::table($table)->insert($chunk);
+            }
+            $restored[class_basename($class)] = count($rows);
+        }
+
+        return $restored;
+    }
+}

--- a/docs/superpowers/specs/2026-07-06-f3-team-restore-design.md
+++ b/docs/superpowers/specs/2026-07-06-f3-team-restore-design.md
@@ -1,0 +1,96 @@
+# F3 — Team data restore (design)
+
+**Date:** 2026-07-06
+**Status:** approved, implementing
+**Slice of F3:** restore — the round-trip partner of backup (PR #476). Sibling slices:
+`create` (done), `archive` (#475), `backup` (#476), `clone` (future). Restore is
+**same-team disaster recovery**, not cross-env migration (that overlaps `clone`).
+
+## Problem
+
+PR #476 exports a team's data to a JSON-snapshot zip, but nothing consumes it. A backup
+you cannot restore is half a feature. This adds restore: re-insert a team's data from one
+of its own completed backups.
+
+## Decisions (locked with user)
+
+1. **Target:** **same team, disaster recovery.** Re-insert rows into their *original*
+   `team_id` with *original* PKs. Refuses if the team already holds rows (won't
+   duplicate/collide). FKs stay valid automatically — no id remapping.
+2. **Source:** a **stored `team_backups` record** (trusted artifact already on our disk).
+   No uploaded zips — no untrusted-file / zip-slip surface.
+3. **Trigger:** super_admin only — a Restore action on `TeamBackupResource` + a
+   `team:restore {backup}` command (mirrors backup).
+
+## Backup format fix (matched pair)
+
+Restore defines the contract, so switch the backup's **model** serialization from Eloquent
+`->get()->toJson()` to raw **`DB::table()->get()`** (DB-native scalar values). Restore then
+becomes a verbatim `DB::table()->insert()` with no cast round-trip ambiguity (json columns
+serialize to arrays under Eloquent but the query-builder insert needs strings; raw rows
+sidestep it entirely). `format_version` stays `1` — #476 is unreleased, nothing to migrate.
+The extras were already raw `DB::table`, so only the models loop changes.
+
+## Architecture
+
+### 1. `App\Services\TeamRestoreService`
+
+`restore(TeamBackup $backup): array` (rows restored per model):
+
+- **Validate:** backup `status === 'completed'`; the file exists on `$backup->disk`; the
+  zip opens; `manifest.json` present; `format_version === 1`. Each failure throws a typed
+  `TeamRestoreException` with a clear message.
+- **Resolve target:** `Team::withoutGlobalScope('archived')->find($manifest['team']['id'])`
+  — must exist (same-team recovery). Missing → throw.
+- **Guard (refuse if not empty):** if any `TenantModels::all()` table already holds a row
+  for that `team_id`, throw `TeamNotEmptyException`. Prevents duplicate/PK-collision.
+- **Insert:** one `DB::transaction` wrapping `Schema::withoutForeignKeyConstraints(...)`.
+  For each `models/{Model}.json`: decode, `DB::table($table)->insert($chunk)` in chunks,
+  preserving original ids/timestamps. FK-off ⇒ insert order irrelevant; the transaction ⇒
+  a single bad row rolls back the whole restore (no partial team).
+- **Extras untouched:** the team, memberships, and subscription survive a data-loss event
+  (rows deleted, team intact), so restore only re-inserts the deleted model data.
+- Skips a model whose table is absent (same drift guard as backup).
+
+### 2. `App\Jobs\RestoreTeamBackup` (queued)
+
+Mirrors backup for large-team safety. Runs the service; on success/failure sends a Filament
+**database notification** to the initiating super_admin. Not `TenantAware` — writes
+unscoped by design.
+
+### 3. Triggers (super_admin only)
+
+- **Restore** row action on `TeamBackupResource`, visible when `status === 'completed'`.
+  Strong confirmation modal (writes data). A cheap pre-check (is the target team empty?)
+  gives instant "can't restore — team not empty" feedback before dispatching.
+- `team:restore {backup}` command — resolves the `TeamBackup`, dispatches the job. Unknown
+  id → clean failure.
+
+## Security
+
+- Super_admin only (mirrors backup).
+- Trusted on-disk artifact — no upload, no zip-slip surface.
+- FK checks disabled **only inside the transaction**; `withoutForeignKeyConstraints`
+  restores prior state after.
+- Restore writes data → confirmation gate on the UI trigger.
+
+## Testing (TDD, PHPUnit + sqlite, then MySQL-verify)
+
+- **Round-trip:** seed a team + Contact/Lead/Task with cross-model FKs → backup → delete all
+  the team's rows → restore → rows return with original ids and FK links intact.
+- **Refuse when non-empty:** team still has a row → `TeamNotEmptyException`, nothing changes.
+- **Refuse invalid source:** backup not `completed` / file missing / `format_version`
+  mismatch → typed exception.
+- **Atomicity:** a corrupt `models/*.json` mid-restore → transaction rolls back, zero rows
+  inserted.
+- **Command:** restores a valid backup; unknown id fails.
+- **Admin action:** visible only for `completed` backups; gated to super_admin.
+- **MySQL verify:** `withoutForeignKeyConstraints` + explicit-id inserts round-trip on
+  MySQL 8.4.
+
+## Out of scope (YAGNI)
+
+- New-team / cross-env restore (that is `clone` — needs full FK remapping).
+- Selective/partial restore, merge into a populated team.
+- Uploaded zips (untrusted input).
+- Restoring extras (team / memberships / subscription).

--- a/tests/Feature/Filament/TeamBackupRestoreActionTest.php
+++ b/tests/Feature/Filament/TeamBackupRestoreActionTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament;
+
+use App\Filament\Resources\TeamBackupResource\Pages\ListTeamBackups;
+use App\Jobs\RestoreTeamBackup;
+use App\Models\Contact;
+use App\Models\Team;
+use App\Models\TeamBackup;
+use App\Models\User;
+use Database\Seeders\RolesSeeder;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class TeamBackupRestoreActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function actingSuperAdmin(): void
+    {
+        $this->seed(RolesSeeder::class);
+        $admin = User::factory()->withPersonalTeam()->create(['email_verified_at' => now()]);
+        setPermissionsTeamId(null);
+        $admin->assignRole('super_admin');
+        $this->actingAs($admin);
+        Filament::setCurrentPanel(Filament::getPanel('admin'));
+    }
+
+    public function test_restore_action_queues_for_an_empty_team(): void
+    {
+        Bus::fake();
+        $this->actingSuperAdmin();
+        $team = Team::factory()->create();
+        $backup = TeamBackup::factory()->create([
+            'team_id' => $team->id, 'status' => 'completed', 'path' => 'backups/x.zip',
+        ]);
+
+        Livewire::test(ListTeamBackups::class)
+            ->callTableAction('restore', $backup);
+
+        Bus::assertDispatched(RestoreTeamBackup::class);
+    }
+
+    public function test_restore_action_refuses_a_non_empty_team(): void
+    {
+        Bus::fake();
+        $this->actingSuperAdmin();
+        $team = Team::factory()->create();
+        Contact::factory()->create(['team_id' => $team->id]);
+        $backup = TeamBackup::factory()->create([
+            'team_id' => $team->id, 'status' => 'completed', 'path' => 'backups/x.zip',
+        ]);
+
+        Livewire::test(ListTeamBackups::class)
+            ->callTableAction('restore', $backup);
+
+        Bus::assertNotDispatched(RestoreTeamBackup::class);
+    }
+}

--- a/tests/Feature/Teams/RestoreTeamBackupJobTest.php
+++ b/tests/Feature/Teams/RestoreTeamBackupJobTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Teams;
+
+use App\Jobs\RestoreTeamBackup;
+use App\Models\Contact;
+use App\Models\Team;
+use App\Models\TeamBackup;
+use App\Models\User;
+use App\Services\TeamBackupService;
+use App\Services\TeamRestoreService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+use Throwable;
+
+class RestoreTeamBackupJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_job_restores_and_notifies_the_initiator(): void
+    {
+        Storage::fake('local');
+        $admin = User::factory()->create();
+        $team = Team::factory()->create();
+        $contact = Contact::factory()->create(['team_id' => $team->id]);
+
+        $result = (new TeamBackupService)->backup($team, 'local');
+        $backup = TeamBackup::factory()->create([
+            'team_id' => $team->id, 'disk' => 'local', 'path' => $result['path'], 'status' => 'completed',
+        ]);
+        Contact::withoutGlobalScope('tenant')->where('team_id', $team->id)->delete();
+
+        (new RestoreTeamBackup($backup->id, $admin->id))->handle(app(TeamRestoreService::class));
+
+        $this->assertDatabaseHas('contacts', ['id' => $contact->id]);
+        $this->assertSame(1, $admin->fresh()->notifications()->count());
+    }
+
+    public function test_job_rethrows_on_failure(): void
+    {
+        $team = Team::factory()->create();
+        $backup = TeamBackup::factory()->create(['team_id' => $team->id, 'status' => 'pending']);
+
+        $this->expectException(Throwable::class);
+        (new RestoreTeamBackup($backup->id))->handle(app(TeamRestoreService::class));
+    }
+}

--- a/tests/Feature/Teams/RestoreTeamCommandTest.php
+++ b/tests/Feature/Teams/RestoreTeamCommandTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Teams;
+
+use App\Jobs\RestoreTeamBackup;
+use App\Models\Team;
+use App\Models\TeamBackup;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Tests\TestCase;
+
+class RestoreTeamCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_command_queues_a_restore(): void
+    {
+        Bus::fake();
+        $team = Team::factory()->create();
+        $backup = TeamBackup::factory()->create(['team_id' => $team->id, 'status' => 'completed', 'path' => 'backups/x.zip']);
+
+        $this->artisan('team:restore', ['backup' => $backup->id])->assertSuccessful();
+
+        Bus::assertDispatched(RestoreTeamBackup::class);
+    }
+
+    public function test_command_fails_for_unknown_backup(): void
+    {
+        Bus::fake();
+
+        $this->artisan('team:restore', ['backup' => 999999])->assertFailed();
+
+        Bus::assertNotDispatched(RestoreTeamBackup::class);
+    }
+}

--- a/tests/Feature/Teams/TeamRestoreServiceTest.php
+++ b/tests/Feature/Teams/TeamRestoreServiceTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Teams;
+
+use App\Exceptions\TeamNotEmptyException;
+use App\Exceptions\TeamRestoreException;
+use App\Models\Contact;
+use App\Models\Lead;
+use App\Models\Task;
+use App\Models\Team;
+use App\Models\TeamBackup;
+use App\Services\TeamBackupService;
+use App\Services\TeamRestoreService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+use Throwable;
+use ZipArchive;
+
+class TeamRestoreServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** Back up a team and return its completed TeamBackup row. */
+    private function backupOf(Team $team): TeamBackup
+    {
+        $result = (new TeamBackupService)->backup($team, 'local');
+
+        return TeamBackup::factory()->create([
+            'team_id' => $team->id,
+            'disk' => 'local',
+            'path' => $result['path'],
+            'size_bytes' => $result['size'],
+            'status' => 'completed',
+        ]);
+    }
+
+    public function test_round_trips_rows_with_original_ids_and_fks(): void
+    {
+        Storage::fake('local');
+        $team = Team::factory()->create();
+        $contact = Contact::factory()->create(['team_id' => $team->id, 'name' => 'RoundTrip Co']);
+        $task = Task::factory()->create(['team_id' => $team->id, 'contact_id' => $contact->id]);
+
+        $backup = $this->backupOf($team);
+
+        Task::withoutGlobalScope('tenant')->where('team_id', $team->id)->delete();
+        Contact::withoutGlobalScope('tenant')->where('team_id', $team->id)->delete();
+        $this->assertDatabaseMissing('contacts', ['id' => $contact->id]);
+
+        $restored = (new TeamRestoreService)->restore($backup);
+
+        $this->assertDatabaseHas('contacts', ['id' => $contact->id, 'name' => 'RoundTrip Co', 'team_id' => $team->id]);
+        $this->assertDatabaseHas('tasks', ['id' => $task->id, 'contact_id' => $contact->id]);
+        $this->assertSame(1, $restored['Contact']);
+    }
+
+    public function test_refuses_to_restore_over_a_non_empty_team(): void
+    {
+        Storage::fake('local');
+        $team = Team::factory()->create();
+        Contact::factory()->create(['team_id' => $team->id]);
+        $backup = $this->backupOf($team);
+
+        // team still populated -> must refuse
+        $this->expectException(TeamNotEmptyException::class);
+        (new TeamRestoreService)->restore($backup);
+    }
+
+    public function test_rejects_a_non_completed_backup(): void
+    {
+        $team = Team::factory()->create();
+        $backup = TeamBackup::factory()->create(['team_id' => $team->id, 'status' => 'pending']);
+
+        $this->expectException(TeamRestoreException::class);
+        (new TeamRestoreService)->restore($backup);
+    }
+
+    public function test_rejects_when_the_backup_file_is_missing(): void
+    {
+        Storage::fake('local');
+        $team = Team::factory()->create();
+        $backup = TeamBackup::factory()->create([
+            'team_id' => $team->id,
+            'disk' => 'local',
+            'path' => 'backups/gone.zip',
+            'status' => 'completed',
+        ]);
+
+        $this->expectException(TeamRestoreException::class);
+        (new TeamRestoreService)->restore($backup);
+    }
+
+    public function test_restore_is_atomic_on_failure(): void
+    {
+        Storage::fake('local');
+        $team = Team::factory()->create();
+        $contact = Contact::factory()->create(['team_id' => $team->id]);
+        $backup = $this->backupOf($team);
+
+        // Corrupt a later model's entry (Lead sorts after Contact) with an
+        // unknown column so its insert throws mid-restore.
+        $full = Storage::disk('local')->path((string) $backup->path);
+        $zip = new ZipArchive;
+        $zip->open($full);
+        $zip->addFromString('models/Lead.json', (string) json_encode([['team_id' => $team->id, 'bogus_col' => 1]]));
+        $zip->close();
+
+        Contact::withoutGlobalScope('tenant')->where('team_id', $team->id)->delete();
+
+        try {
+            (new TeamRestoreService)->restore($backup);
+            $this->fail('expected the restore to throw');
+        } catch (Throwable) {
+            // expected
+        }
+
+        // Contact inserted before Lead failed -> transaction rolled back -> gone.
+        $this->assertDatabaseMissing('contacts', ['id' => $contact->id]);
+        $this->assertSame(0, Lead::withoutGlobalScope('tenant')->where('team_id', $team->id)->count());
+    }
+}


### PR DESCRIPTION
## F3 — Team data restore (round-trips #476)

The backup from #476 had no consumer — a backup you can't restore is half a feature. This adds **same-team disaster recovery**: re-insert a team's data from one of its own completed backups.

Design: [`docs/superpowers/specs/2026-07-06-f3-team-restore-design.md`](../blob/feat/f3-team-restore/docs/superpowers/specs/2026-07-06-f3-team-restore-design.md).
Not cross-env/new-team restore — that's `clone` (needs FK remapping) and stays out of scope.

### How it works
- **`TeamRestoreService`** reads a **stored (trusted)** `team_backups` zip and re-inserts each model's rows with **original PKs** → FKs stay valid, **no id remapping**.
- **Refuses if the team already holds any row** (`TeamNotEmptyException`) — no duplicates, no PK collision.
- Inserts inside **one transaction** wrapped by `Schema::withoutForeignKeyConstraints` → insert order is irrelevant and a single bad row **rolls the whole restore back**. The FK toggle **wraps, not nests inside**, the transaction — sqlite ignores `PRAGMA foreign_keys` once a transaction is open (and the test DB enforces FKs).
- **Extras untouched** (team / memberships / subscription) — they survive a data-loss event.

### Backup format fix (matched pair)
The backup's model rows now serialize via raw **`DB::table()->get()`** (DB-native) instead of Eloquent `->toJson()`, so a json column or date isn't cast out then mis-typed back in. `format_version` stays `1` (#476 unreleased).

### Triggers (super_admin only)
Queued **`RestoreTeamBackup`** job notifies the initiating super_admin. Fired by `team:restore {backup}` or a **Restore** action on `TeamBackupResource` (confirmation + instant "team not empty" pre-check). Trusted on-disk artifact — no upload / zip-slip surface.

### Verification
- **784 pass / 1 skip / 0 fail** (+11: service 5 incl. round-trip + atomic-rollback, job 2, command 2, action 2).
- **MySQL 8.4 verified**: the FK-sensitive round-trip, refuse-non-empty, and atomic-rollback all pass with explicit-id inserts on real MySQL (not just sqlite).
- **PHPStan: 0 new** (21 pre-existing baseline entries, identical with/without this branch).

### Out of scope (YAGNI)
New-team/cross-env restore (`clone`), selective/partial restore, merge into a populated team, uploaded zips, restoring extras.