### PR TITLE
feat(teams): clone a team's config into a new team (F3)

### DIFF
--- a/app/Console/Commands/CloneTeam.php
+++ b/app/Console/Commands/CloneTeam.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\Team;
+use App\Models\User;
+use App\Services\TeamCloneService;
+use Illuminate\Console\Command;
+
+class CloneTeam extends Command
+{
+    protected $signature = 'team:clone {source : Source team id} {--name= : New team name} {--owner= : Owner user id}';
+
+    protected $description = 'Clone a team\'s configuration (template) into a new team.';
+
+    public function handle(TeamCloneService $service): int
+    {
+        $source = Team::withoutGlobalScope('archived')->find((int) $this->argument('source'));
+        if (! $source) {
+            $this->error("Team {$this->argument('source')} not found.");
+
+            return self::FAILURE;
+        }
+
+        $ownerId = $this->option('owner') !== null ? (int) $this->option('owner') : (int) $source->user_id;
+        $owner = User::find($ownerId);
+        if (! $owner) {
+            $this->error("Owner user {$ownerId} not found.");
+
+            return self::FAILURE;
+        }
+
+        $name = $this->option('name') ?: "Copy of {$source->name}";
+        $new = $service->clone($source, $name, $owner);
+
+        $this->info("Cloned team {$source->id} -> new team {$new->id} ({$new->name}).");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Filament/Resources/TeamResource.php
+++ b/app/Filament/Resources/TeamResource.php
@@ -7,7 +7,12 @@ namespace App\Filament\Resources;
 use App\Enums\Role;
 use App\Filament\Resources\TeamResource\Pages\ListTeams;
 use App\Models\Team;
+use App\Models\User;
+use App\Services\TeamCloneService;
 use Filament\Actions\Action;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Notifications\Notification;
 use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\IconColumn;
@@ -69,6 +74,38 @@ class TeamResource extends Resource
                     ->requiresConfirmation()
                     ->visible(fn (Team $record): bool => $record->isArchived())
                     ->action(fn (Team $record) => $record->restore()),
+                Action::make('clone')
+                    ->label('Clone')
+                    ->icon('heroicon-o-document-duplicate')
+                    ->color('gray')
+                    ->schema([
+                        TextInput::make('name')
+                            ->label('New team name')
+                            ->required()
+                            ->default(fn (Team $record): string => "Copy of {$record->name}"),
+                        Select::make('owner_id')
+                            ->label('Owner')
+                            ->options(fn (): array => User::query()->pluck('name', 'id')->all())
+                            ->searchable()
+                            ->required()
+                            ->default(fn (Team $record): int => $record->user_id),
+                    ])
+                    ->action(function (Team $record, array $data): void {
+                        $owner = User::find((int) $data['owner_id']);
+                        if (! $owner) {
+                            Notification::make()->title('Owner not found')->danger()->send();
+
+                            return;
+                        }
+
+                        $new = app(TeamCloneService::class)->clone($record, (string) $data['name'], $owner);
+
+                        Notification::make()
+                            ->title('Team cloned')
+                            ->body("Created “{$new->name}” from “{$record->name}”.")
+                            ->success()
+                            ->send();
+                    }),
             ]);
     }
 

--- a/app/Services/TeamCloneService.php
+++ b/app/Services/TeamCloneService.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\Chatbot;
+use App\Models\CustomField;
+use App\Models\EmailTemplate;
+use App\Models\KnowledgeBaseArticle;
+use App\Models\Menu;
+use App\Models\Pipeline;
+use App\Models\ReportBuilder;
+use App\Models\Stage;
+use App\Models\Tag;
+use App\Models\Team;
+use App\Models\User;
+use App\Models\Workflow;
+use App\Models\WorkflowAction;
+use App\Models\WorkflowCondition;
+use App\Models\WorkflowTrigger;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Clones a team's CONFIGURATION into a brand-new team (a template). Copies the
+ * structural models below with fresh PKs and remaps their intra-config foreign
+ * keys; does NOT copy transactional data (contacts/leads/deals/tasks/…) or
+ * members.
+ */
+class TeamCloneService
+{
+    /** Config models to copy, in a stable order. */
+    private const CLONEABLE_MODELS = [
+        Pipeline::class,
+        Stage::class,
+        Workflow::class,
+        WorkflowAction::class,
+        WorkflowCondition::class,
+        WorkflowTrigger::class,
+        EmailTemplate::class,
+        CustomField::class,
+        Tag::class,
+        KnowledgeBaseArticle::class,
+        Chatbot::class,
+        ReportBuilder::class,
+        Menu::class,
+    ];
+
+    /**
+     * Cross-model FK columns to remap: model => [column => referenced model].
+     * Verified against the live schema — Pipeline.stage_id is a model-declared
+     * relation with no column (drift), so it is not here; the hasColumn guard
+     * in patchForeignKeys also skips any edge whose column is absent.
+     *
+     * @var array<class-string, array<string, class-string>>
+     */
+    private const FK_EDGES = [
+        Stage::class => ['pipeline_id' => Pipeline::class],
+        WorkflowAction::class => ['workflow_id' => Workflow::class],
+        WorkflowCondition::class => ['workflow_action_id' => WorkflowAction::class],
+        WorkflowTrigger::class => ['workflow_id' => Workflow::class],
+        Menu::class => ['parent_id' => Menu::class],
+    ];
+
+    public function clone(Team $source, string $name, User $owner): Team
+    {
+        $team = new Team;
+        $team->name = $name;
+        $team->user_id = $owner->id;
+        $team->personal_team = false;
+        $team->save();
+
+        // FK checks OFF must wrap (not nest inside) the transaction — sqlite
+        // ignores PRAGMA foreign_keys once a transaction is open. With FKs off
+        // we can insert rows keeping their old cross-refs, then patch to the
+        // new ids; this needs no dependency ordering and handles the
+        // self-referential Menu (parent may be inserted after child).
+        Schema::withoutForeignKeyConstraints(function () use ($source, $team): void {
+            DB::transaction(function () use ($source, $team): void {
+                $idMap = $this->copyRows($source, $team);
+                $this->patchForeignKeys($team, $idMap);
+            });
+        });
+
+        return $team;
+    }
+
+    /**
+     * @return array<class-string, array<int, int>> per model: old id => new id
+     */
+    private function copyRows(Team $source, Team $team): array
+    {
+        $idMap = [];
+
+        foreach (self::CLONEABLE_MODELS as $class) {
+            $table = (new $class)->getTable();
+            if (! Schema::hasTable($table)) {
+                continue;
+            }
+
+            $map = [];
+            foreach (DB::table($table)->where('team_id', $source->id)->get() as $row) {
+                $data = (array) $row;
+                $oldId = (int) $data['id'];
+                unset($data['id']);
+                $data['team_id'] = $team->id;
+                // Edge FK columns keep their old values here; patched in pass 2.
+                $map[$oldId] = (int) DB::table($table)->insertGetId($data);
+            }
+
+            $idMap[$class] = $map;
+        }
+
+        return $idMap;
+    }
+
+    /**
+     * @param  array<class-string, array<int, int>>  $idMap
+     */
+    private function patchForeignKeys(Team $team, array $idMap): void
+    {
+        foreach (self::FK_EDGES as $class => $edges) {
+            $table = (new $class)->getTable();
+            if (! Schema::hasTable($table) || empty($idMap[$class])) {
+                continue;
+            }
+
+            // Drift guard: skip an edge whose column the table does not have.
+            $edges = array_filter(
+                $edges,
+                fn (string $column): bool => Schema::hasColumn($table, $column),
+                ARRAY_FILTER_USE_KEY,
+            );
+            if ($edges === []) {
+                continue;
+            }
+
+            foreach (DB::table($table)->where('team_id', $team->id)->get() as $row) {
+                $updates = [];
+                foreach ($edges as $column => $referenced) {
+                    $old = $row->{$column};
+                    if ($old === null) {
+                        continue;
+                    }
+                    // Unmapped ref -> null rather than dangle to the source team.
+                    $updates[$column] = $idMap[$referenced][(int) $old] ?? null;
+                }
+
+                if ($updates !== []) {
+                    DB::table($table)->where('id', $row->id)->update($updates);
+                }
+            }
+        }
+    }
+}

--- a/docs/superpowers/specs/2026-07-06-f3-team-clone-design.md
+++ b/docs/superpowers/specs/2026-07-06-f3-team-clone-design.md
@@ -1,0 +1,102 @@
+# F3 — Team template clone (design)
+
+**Date:** 2026-07-06
+**Status:** approved, implementing
+**Slice of F3:** clone — the last of the four ops (create/clone/archive/backup). Closes F3.
+
+## Problem
+
+No way to stand up a new team pre-configured like an existing one. Onboarding a team means
+rebuilding its pipelines, workflows, custom fields, and templates by hand.
+
+## Decisions (locked with user)
+
+1. **What copies:** **config/template only.** Copy the structure a new team needs; do NOT
+   copy transactional data (contacts/leads/deals/tasks/…) or members.
+2. **Target:** a brand-new team (new PKs → intra-config FKs remapped).
+3. **Trigger:** super_admin — a Clone action on the admin `TeamResource` + a `team:clone`
+   command.
+
+## Cloneable set — curated, NOT auto-discovered
+
+Config-vs-data is semantic, so an explicit ordered `CLONEABLE_MODELS` list (opposite of
+backup's auto-discovery):
+
+```
+Pipeline, Stage, Workflow, WorkflowAction, WorkflowCondition, WorkflowTrigger,
+EmailTemplate, CustomField, Tag, KnowledgeBaseArticle, Chatbot, ReportBuilder, Menu
+```
+
+Excludes all transactional models and members. `SiteSettings` is intentionally omitted (it
+has no table — dead/pending drift); a `Schema::hasTable` guard covers any other absent
+table.
+
+## FK-remap engine — copy-then-patch under FK-off
+
+New team → new PKs → intra-config FKs must be rewired. Declared edge map (small):
+
+```
+Stage.pipeline_id            -> Pipeline
+Pipeline.stage_id            -> Stage           (circular pair)
+WorkflowAction.workflow_id   -> Workflow
+WorkflowCondition.workflow_action_id -> WorkflowAction
+WorkflowTrigger.workflow_id  -> Workflow
+Menu.parent_id               -> Menu            (self-ref)
+```
+
+All work happens inside `Schema::withoutForeignKeyConstraints(fn => DB::transaction(...))`
+— the FK toggle **wraps** the transaction (sqlite ignores `PRAGMA foreign_keys` once a
+transaction is open; the test DB enforces FKs).
+
+- **Pass 1 — copy:** for each `CLONEABLE_MODELS` class (skip if no table), read every
+  source row (`DB::table($table)->where('team_id', $source->id)->get()`); for each row drop
+  `id`, set `team_id` = new team, **keep the edge-FK columns at their old values**, insert,
+  record `old_id → new_id` per model. FK-off makes the transiently-stale FK values legal.
+- **Pass 2 — patch:** for each cloned row, rewrite each edge column via the maps
+  (`new = map[referencedModel][old]`); a value with no mapping (or null) is nulled/left.
+
+Keeping old values then patching (rather than null-then-patch) avoids depending on each
+FK column being nullable, and handles the **circular** Pipeline↔Stage and **self-ref** Menu
+uniformly with no dependency ordering.
+
+Only the declared edge columns are remapped. Config models are self-contained (no user_id
+refs among the cloneable set), so no user remapping is needed. Any other `*_id` column is
+copied verbatim — acceptable for config; a config row referencing a non-cloned team-scoped
+row is out of scope (noted as a ceiling).
+
+## New team + trigger
+
+- `TeamCloneService::clone(Team $source, string $name, User $owner): Team` — creates the
+  team (`personal_team = false`, owner = `$owner`), runs the two-pass copy in one
+  transaction, returns the new team. **Synchronous** — config is small (no bulk data), so
+  no job/queue; the admin gets the new team back immediately.
+- Super_admin **Clone** action on the admin `TeamResource`: form = new name (default
+  "Copy of {source}") + owner select (default = source team's owner). + `team:clone
+  {source} {--name=} {--owner=}` command (owner defaults to source owner; name defaults to
+  "Copy of {source}").
+
+## Security
+
+Super_admin only (mirrors archive/backup). Clone reads the source unscoped
+(`withoutGlobalScope('archived')` so an archived team is still a valid template) and writes
+only into the freshly created team.
+
+## Testing (TDD, PHPUnit + sqlite, then MySQL-verify)
+
+- New team created with the given name + owner; `personal_team = false`.
+- Cloned config rows exist under the **new** team_id with **new PKs**; source rows
+  untouched (count unchanged, ids unchanged).
+- **Remap correctness:** cloned `Stage.pipeline_id` → the cloned Pipeline; cloned
+  `Pipeline.stage_id` → the cloned Stage (circular); `WorkflowAction.workflow_id` → cloned
+  Workflow; `WorkflowCondition.workflow_action_id` → cloned action; `Menu.parent_id` →
+  cloned parent.
+- **Data NOT copied:** contacts/leads/deals/tasks count 0 under the new team.
+- Command clones; unknown source id fails. Admin action gated to super_admin.
+- MySQL 8.4 verify (FK-off + copy-then-patch).
+
+## Out of scope (YAGNI)
+
+- Transactional data (that is "everything" / new-team restore).
+- Members + per-team role assignments.
+- Cross-env clone; cloning into an existing team.
+- Remapping `*_id` columns outside the declared edge map.

--- a/docs/superpowers/specs/2026-07-06-f3-team-clone-design.md
+++ b/docs/superpowers/specs/2026-07-06-f3-team-clone-design.md
@@ -33,11 +33,13 @@ table.
 
 ## FK-remap engine — copy-then-patch under FK-off
 
-New team → new PKs → intra-config FKs must be rewired. Declared edge map (small):
+New team → new PKs → intra-config FKs must be rewired. Declared edge map, **verified
+against the live schema** (the Pipeline model declares a `stage_id` relation but the
+`pipelines` table has no such column — model↔schema drift — so it is excluded; a
+`Schema::hasColumn` guard also skips any edge whose column is absent):
 
 ```
 Stage.pipeline_id            -> Pipeline
-Pipeline.stage_id            -> Stage           (circular pair)
 WorkflowAction.workflow_id   -> Workflow
 WorkflowCondition.workflow_action_id -> WorkflowAction
 WorkflowTrigger.workflow_id  -> Workflow
@@ -56,8 +58,9 @@ transaction is open; the test DB enforces FKs).
   (`new = map[referencedModel][old]`); a value with no mapping (or null) is nulled/left.
 
 Keeping old values then patching (rather than null-then-patch) avoids depending on each
-FK column being nullable, and handles the **circular** Pipeline↔Stage and **self-ref** Menu
-uniformly with no dependency ordering.
+FK column being nullable, and handles the **self-ref** Menu (parent may be inserted after
+child) with no dependency ordering — and would absorb a genuine circular edge for free if
+one ever appeared.
 
 Only the declared edge columns are remapped. Config models are self-contained (no user_id
 refs among the cloneable set), so no user remapping is needed. Any other `*_id` column is
@@ -86,10 +89,9 @@ only into the freshly created team.
 - New team created with the given name + owner; `personal_team = false`.
 - Cloned config rows exist under the **new** team_id with **new PKs**; source rows
   untouched (count unchanged, ids unchanged).
-- **Remap correctness:** cloned `Stage.pipeline_id` → the cloned Pipeline; cloned
-  `Pipeline.stage_id` → the cloned Stage (circular); `WorkflowAction.workflow_id` → cloned
-  Workflow; `WorkflowCondition.workflow_action_id` → cloned action; `Menu.parent_id` →
-  cloned parent.
+- **Remap correctness:** cloned `Stage.pipeline_id` → the cloned Pipeline (tree edge);
+  `Menu.parent_id` → the cloned parent (self-ref). The workflow-tree edges use the identical
+  generic code path.
 - **Data NOT copied:** contacts/leads/deals/tasks count 0 under the new team.
 - Command clones; unknown source id fails. Admin action gated to super_admin.
 - MySQL 8.4 verify (FK-off + copy-then-patch).

--- a/tests/Feature/Filament/TeamCloneActionTest.php
+++ b/tests/Feature/Filament/TeamCloneActionTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament;
+
+use App\Filament\Resources\TeamResource;
+use App\Filament\Resources\TeamResource\Pages\ListTeams;
+use App\Models\Pipeline;
+use App\Models\Team;
+use App\Models\User;
+use Database\Seeders\RolesSeeder;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class TeamCloneActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function actingSuperAdmin(): User
+    {
+        $this->seed(RolesSeeder::class);
+        $admin = User::factory()->withPersonalTeam()->create(['email_verified_at' => now()]);
+        setPermissionsTeamId(null);
+        $admin->assignRole('super_admin');
+        $this->actingAs($admin);
+        Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+        return $admin;
+    }
+
+    public function test_super_admin_can_clone_a_team_via_action(): void
+    {
+        $admin = $this->actingSuperAdmin();
+        $source = Team::factory()->create(['user_id' => $admin->id]);
+        Pipeline::factory()->create(['team_id' => $source->id]);
+
+        Livewire::test(ListTeams::class)
+            ->callTableAction('clone', $source, data: [
+                'name' => 'Cloned via UI',
+                'owner_id' => $admin->id,
+            ]);
+
+        $new = Team::where('name', 'Cloned via UI')->first();
+        $this->assertNotNull($new);
+        $this->assertSame(1, Pipeline::withoutGlobalScope('tenant')->where('team_id', $new->id)->count());
+    }
+
+    public function test_resource_denies_non_super_admin(): void
+    {
+        $this->seed(RolesSeeder::class);
+        $manager = User::factory()->withPersonalTeam()->create(['email_verified_at' => now()]);
+        setPermissionsTeamId(null);
+        $manager->assignRole('manager');
+        $this->actingAs($manager);
+
+        $this->assertFalse(TeamResource::canAccess());
+    }
+}

--- a/tests/Feature/Teams/CloneTeamCommandTest.php
+++ b/tests/Feature/Teams/CloneTeamCommandTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Teams;
+
+use App\Models\Pipeline;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CloneTeamCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_command_clones_config_into_a_new_team(): void
+    {
+        $source = Team::factory()->create();
+        Pipeline::factory()->create(['team_id' => $source->id]);
+        $owner = User::factory()->create();
+
+        $this->artisan('team:clone', [
+            'source' => $source->id,
+            '--name' => 'Fresh Team',
+            '--owner' => $owner->id,
+        ])->assertSuccessful();
+
+        $new = Team::where('name', 'Fresh Team')->first();
+        $this->assertNotNull($new);
+        $this->assertSame($owner->id, $new->user_id);
+        $this->assertSame(1, Pipeline::withoutGlobalScope('tenant')->where('team_id', $new->id)->count());
+    }
+
+    public function test_command_fails_for_unknown_source(): void
+    {
+        $this->artisan('team:clone', ['source' => 999999])->assertFailed();
+    }
+}

--- a/tests/Feature/Teams/TeamCloneServiceTest.php
+++ b/tests/Feature/Teams/TeamCloneServiceTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Teams;
+
+use App\Models\Contact;
+use App\Models\Menu;
+use App\Models\Pipeline;
+use App\Models\Stage;
+use App\Models\Tag;
+use App\Models\Team;
+use App\Models\User;
+use App\Services\TeamCloneService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class TeamCloneServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Source team with the remap shapes that exist in the schema: a
+     * Stage -> Pipeline tree edge and a self-referential Menu parent/child,
+     * plus a trivial config row.
+     *
+     * @return array{Team, int, int} source team, source pipeline id, source stage id
+     */
+    private function seedSource(): array
+    {
+        $source = Team::factory()->create();
+
+        $pipeline = Pipeline::factory()->create(['team_id' => $source->id]);
+        $stage = Stage::factory()->create(['team_id' => $source->id, 'pipeline_id' => $pipeline->id]);
+
+        $parent = Menu::factory()->create(['team_id' => $source->id]);
+        Menu::factory()->create(['team_id' => $source->id, 'parent_id' => $parent->id]); // self ref
+
+        Tag::factory()->create(['team_id' => $source->id, 'name' => 'VIP']); // trivial config
+
+        return [$source, $pipeline->id, $stage->id];
+    }
+
+    public function test_clones_config_and_remaps_foreign_keys(): void
+    {
+        [$source, $sourcePipelineId] = $this->seedSource();
+        $owner = User::factory()->create();
+
+        $new = (new TeamCloneService)->clone($source, 'Cloned Team', $owner);
+
+        $this->assertSame('Cloned Team', $new->name);
+        $this->assertSame($owner->id, $new->user_id);
+        $this->assertFalse((bool) $new->personal_team);
+        $this->assertNotSame($source->id, $new->id);
+
+        $newPipeline = DB::table('pipelines')->where('team_id', $new->id)->first();
+        $newStage = DB::table('stages')->where('team_id', $new->id)->first();
+
+        // New PK, and Stage.pipeline_id rewired to the CLONED pipeline.
+        $this->assertNotSame($sourcePipelineId, (int) $newPipeline->id);
+        $this->assertSame((int) $newPipeline->id, (int) $newStage->pipeline_id);
+
+        // Self-referential menu rewired to the cloned parent.
+        $newParent = DB::table('menus')->where('team_id', $new->id)->whereNull('parent_id')->first();
+        $newChild = DB::table('menus')->where('team_id', $new->id)->whereNotNull('parent_id')->first();
+        $this->assertSame((int) $newParent->id, (int) $newChild->parent_id);
+
+        // Trivial config carried over.
+        $this->assertDatabaseHas('tags', ['team_id' => $new->id, 'name' => 'VIP']);
+    }
+
+    public function test_does_not_clone_transactional_data(): void
+    {
+        [$source] = $this->seedSource();
+        Contact::factory()->create(['team_id' => $source->id]);
+        $owner = User::factory()->create();
+
+        $new = (new TeamCloneService)->clone($source, 'No Data', $owner);
+
+        $this->assertSame(0, DB::table('contacts')->where('team_id', $new->id)->count());
+    }
+
+    public function test_source_team_is_untouched(): void
+    {
+        [$source, $pipelineId, $stageId] = $this->seedSource();
+        $owner = User::factory()->create();
+
+        (new TeamCloneService)->clone($source, 'Clone', $owner);
+
+        $this->assertSame(1, DB::table('pipelines')->where('team_id', $source->id)->count());
+        $this->assertSame($pipelineId, (int) DB::table('stages')->where('id', $stageId)->first()->pipeline_id);
+    }
+}


### PR DESCRIPTION
## F3 — Team template clone (closes F3)

Fourth and final F3 op (create/clone/archive/backup). Onboarding a team meant rebuilding its structure by hand. This clones the **configuration** of an existing team into a **fresh** team — a template.

Design: [`docs/superpowers/specs/2026-07-06-f3-team-clone-design.md`](../blob/feat/f3-team-clone/docs/superpowers/specs/2026-07-06-f3-team-clone-design.md).

### What copies
Config only: pipelines/stages, workflows, custom fields, tags, email templates, KB articles, chatbots, report builders, menus. **NOT** transactional data (contacts/leads/deals/tasks/…) or members.

### FK-remap engine — copy-then-patch under FK-off
New team → new PKs → intra-config FKs must be rewired. All inside `Schema::withoutForeignKeyConstraints(fn => DB::transaction(...))` (same FK-off-**wraps**-transaction rule as restore — sqlite ignores `PRAGMA foreign_keys` once a transaction is open):
- **Pass 1** inserts each cloned row keeping its old cross-ref value (FK-off makes that legal);
- **Pass 2** rewrites those columns to the new ids via per-model `old→new` maps.

No dependency ordering; handles the self-referential `Menu`.

### Edge map verified against the schema, not the models
`Pipeline` declares a `stage_id` relation but the `pipelines` table **has no such column** (model↔schema drift — the recurring CRM trap, caught here by the test). Excluded from the edge map, and a `Schema::hasColumn` guard skips any edge whose column is absent, so drift can never crash a clone. Real edges: `Stage.pipeline_id`, the workflow tree, `Menu.parent_id`.

### Trigger (super_admin only)
Clone action on the admin `TeamResource` (name + owner form, defaults "Copy of {source}" / source owner) + `team:clone {source} {--name=} {--owner=}`. Synchronous — config is small, no queue.

### Verification
- **791 pass / 1 skip / 0 fail** (+7: service 3 incl. remap correctness + data-exclusion + source-untouched, command 2, action 2).
- **MySQL 8.4 verified**: the FK-off copy-then-patch remap round-trips with explicit inserts on real MySQL.
- **PHPStan: 0 new** (21 pre-existing baseline entries, identical with/without this branch).

### Out of scope (YAGNI)
Transactional data (= new-team restore), members + role assignments, cross-env, cloning into an existing team, remapping `*_id` columns outside the declared edge map.