### PR TITLE
feat(teams): cross-env backup import into a new team (F3)

### DIFF
--- a/app/Console/Commands/ImportTeam.php
+++ b/app/Console/Commands/ImportTeam.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use App\Services\ImportTeamBackupService;
+use Illuminate\Console\Command;
+
+class ImportTeam extends Command
+{
+    protected $signature = 'team:import {path : Local path to a backup zip} {--name= : New team name} {--owner= : Importer/owner user id}';
+
+    protected $description = 'Import a backup zip from another environment into a new team.';
+
+    public function handle(ImportTeamBackupService $service): int
+    {
+        $path = (string) $this->argument('path');
+        if (! is_file($path)) {
+            $this->error("File not found: {$path}");
+
+            return self::FAILURE;
+        }
+
+        $owner = $this->option('owner') !== null
+            ? User::find((int) $this->option('owner'))
+            : User::query()->orderBy('id')->first();
+
+        if (! $owner) {
+            $this->error('No owner user resolved — pass --owner.');
+
+            return self::FAILURE;
+        }
+
+        $team = $service->import($path, $this->option('name') ?: null, $owner);
+
+        $this->info("Imported into new team {$team->id} ({$team->name}), owned by user {$owner->id}.");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Exceptions/TeamImportException.php
+++ b/app/Exceptions/TeamImportException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions;
+
+use RuntimeException;
+
+/**
+ * A cross-environment backup import could not proceed (unreadable archive,
+ * missing manifest, unsupported format). Message is safe to show a super admin.
+ */
+class TeamImportException extends RuntimeException {}

--- a/app/Filament/Resources/TeamResource/Pages/ListTeams.php
+++ b/app/Filament/Resources/TeamResource/Pages/ListTeams.php
@@ -5,9 +5,47 @@ declare(strict_types=1);
 namespace App\Filament\Resources\TeamResource\Pages;
 
 use App\Filament\Resources\TeamResource;
+use App\Jobs\ImportTeamBackup;
+use Filament\Actions\Action;
+use Filament\Forms\Components\FileUpload;
+use Filament\Forms\Components\TextInput;
+use Filament\Notifications\Notification;
 use Filament\Resources\Pages\ListRecords;
 
 class ListTeams extends ListRecords
 {
     protected static string $resource = TeamResource::class;
+
+    #[\Override]
+    protected function getHeaderActions(): array
+    {
+        return [
+            Action::make('import')
+                ->label('Import backup')
+                ->icon('heroicon-o-arrow-up-tray')
+                ->color('gray')
+                ->modalDescription('Import a backup zip from another environment into a brand-new team. All records are re-owned by you.')
+                ->schema([
+                    TextInput::make('name')
+                        ->label('New team name')
+                        ->helperText('Leave blank to use the name from the backup.'),
+                    FileUpload::make('file')
+                        ->label('Backup zip')
+                        ->disk('local')
+                        ->directory('imports')
+                        ->acceptedFileTypes(['application/zip', 'application/x-zip-compressed'])
+                        ->required(),
+                ])
+                ->action(function (array $data): void {
+                    ImportTeamBackup::dispatch(
+                        'local',
+                        (string) $data['file'],
+                        $data['name'] ?: null,
+                        (int) auth()->id(),
+                    );
+
+                    Notification::make()->title('Import queued')->success()->send();
+                }),
+        ];
+    }
 }

--- a/app/Jobs/ImportTeamBackup.php
+++ b/app/Jobs/ImportTeamBackup.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use App\Models\User;
+use App\Services\ImportTeamBackupService;
+use Filament\Notifications\Notification;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Storage;
+use Throwable;
+
+/**
+ * Imports an uploaded backup zip (from another environment) into a new team,
+ * off the request cycle. Stages the stored upload to a local temp file (zip
+ * reads need a local path), runs the import, notifies the initiating admin.
+ */
+class ImportTeamBackup implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public function __construct(
+        public string $disk,
+        public string $path,
+        public ?string $name,
+        public int $importerId,
+    ) {}
+
+    public function handle(ImportTeamBackupService $service): void
+    {
+        $importer = User::findOrFail($this->importerId);
+
+        $tmp = tempnam(sys_get_temp_dir(), 'teamimport');
+        file_put_contents($tmp, (string) Storage::disk($this->disk)->get($this->path));
+
+        try {
+            $team = $service->import($tmp, $this->name, $importer);
+            $this->notify('Import complete', true, "Imported into new team “{$team->name}” (#{$team->id}).", $importer);
+        } catch (Throwable $e) {
+            $this->notify('Import failed', false, $e->getMessage(), $importer);
+            throw $e;
+        } finally {
+            @unlink($tmp);
+        }
+    }
+
+    private function notify(string $title, bool $success, string $body, User $user): void
+    {
+        $notification = Notification::make()->title($title)->body($body);
+        ($success ? $notification->success() : $notification->danger())->sendToDatabase($user);
+    }
+}

--- a/app/Services/ImportTeamBackupService.php
+++ b/app/Services/ImportTeamBackupService.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Exceptions\TeamImportException;
+use App\Models\Team;
+use App\Models\User;
+use App\Support\SchemaGraph;
+use App\Support\TenantModels;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use ZipArchive;
+
+/**
+ * Imports a backup zip taken on a DIFFERENT database into a brand-new team.
+ * Every row gets a fresh PK; cross-model foreign keys are remapped via the
+ * introspected schema graph; user references resolve to the importing admin
+ * (source-env user ids are meaningless here). Not to be confused with restore
+ * (#477), which is same-team, original-PK recovery.
+ */
+class ImportTeamBackupService
+{
+    private const FORMAT_VERSION = 1;
+
+    /** Columns that reference users but may lack a declared FK constraint. */
+    private const USER_REF_COLUMNS = ['assigned_to', 'created_by', 'updated_by', 'user_id', 'owner_id'];
+
+    public function import(string $localZipPath, ?string $name, User $importer): Team
+    {
+        $zip = new ZipArchive;
+        if ($zip->open($localZipPath) !== true) {
+            throw new TeamImportException('Could not open the backup archive.');
+        }
+
+        try {
+            $manifest = json_decode((string) $zip->getFromName('manifest.json'), true);
+            if (! is_array($manifest) || ($manifest['format_version'] ?? null) !== self::FORMAT_VERSION) {
+                throw new TeamImportException('Unsupported or unreadable backup format.');
+            }
+
+            $teamName = $name ?: (string) ($manifest['team']['name'] ?? 'Imported team');
+
+            // FK checks OFF must wrap (not nest inside) the transaction — sqlite
+            // ignores PRAGMA foreign_keys once a transaction is open. The team is
+            // created INSIDE the transaction so a failed import (e.g. a unique
+            // collision on the target env) rolls it back — no orphan team.
+            return Schema::withoutForeignKeyConstraints(
+                fn (): Team => DB::transaction(function () use ($zip, $teamName, $importer): Team {
+                    $team = new Team;
+                    $team->name = $teamName;
+                    $team->user_id = $importer->id;
+                    $team->personal_team = false;
+                    $team->save();
+
+                    $idMap = $this->insertAll($zip, $team);
+                    $this->remapForeignKeys($team, $idMap, $importer->id);
+
+                    return $team;
+                }),
+            );
+        } finally {
+            $zip->close();
+        }
+    }
+
+    /**
+     * @return array<string, array<int, int>> table => (old id => new id)
+     */
+    private function insertAll(ZipArchive $zip, Team $team): array
+    {
+        $idMap = [];
+
+        foreach (TenantModels::all() as $class) {
+            $table = (new $class)->getTable();
+            if (! Schema::hasTable($table)) {
+                continue;
+            }
+
+            $json = $zip->getFromName('models/'.class_basename($class).'.json');
+            if ($json === false) {
+                continue;
+            }
+
+            /** @var list<array<string, mixed>> $rows */
+            $rows = json_decode((string) $json, true) ?: [];
+            $map = [];
+            foreach ($rows as $row) {
+                $oldId = (int) $row['id'];
+                unset($row['id']);
+                $row['team_id'] = $team->id;
+                $map[$oldId] = (int) DB::table($table)->insertGetId($row);
+            }
+
+            if ($map !== []) {
+                $idMap[$table] = $map;
+            }
+        }
+
+        return $idMap;
+    }
+
+    /**
+     * @param  array<string, array<int, int>>  $idMap
+     */
+    private function remapForeignKeys(Team $team, array $idMap, int $importerId): void
+    {
+        $edges = SchemaGraph::edges(array_keys($idMap));
+
+        foreach (array_keys($idMap) as $table) {
+            $patchable = $this->patchableColumns($table, $edges[$table] ?? []);
+            if ($patchable === []) {
+                continue;
+            }
+
+            foreach (DB::table($table)->where('team_id', $team->id)->get() as $row) {
+                $updates = [];
+                foreach ($patchable as $column => $referenced) {
+                    $old = $row->{$column} ?? null;
+                    if ($old === null) {
+                        continue;
+                    }
+
+                    if ($referenced === 'users') {
+                        $updates[$column] = $importerId;
+                    } elseif (isset($idMap[$referenced])) {
+                        // Reference into another imported table; unmapped -> null.
+                        $updates[$column] = $idMap[$referenced][(int) $old] ?? null;
+                    }
+                    // Reference to a non-imported, non-user table: left as-is.
+                }
+
+                if ($updates !== []) {
+                    DB::table($table)->where('id', $row->id)->update($updates);
+                }
+            }
+        }
+    }
+
+    /**
+     * Declared FK columns (authoritative referenced table) plus name-heuristic
+     * user columns that have no declared FK. team_id is never remapped.
+     *
+     * @param  array<string, string>  $fkEdges  column => referenced table
+     * @return array<string, string> column => referenced table
+     */
+    private function patchableColumns(string $table, array $fkEdges): array
+    {
+        $patchable = [];
+
+        foreach ($fkEdges as $column => $referenced) {
+            if ($column === 'team_id') {
+                continue;
+            }
+            $patchable[$column] = $referenced;
+        }
+
+        foreach (self::USER_REF_COLUMNS as $column) {
+            if (! isset($patchable[$column]) && Schema::hasColumn($table, $column)) {
+                $patchable[$column] = 'users';
+            }
+        }
+
+        // Undeclared FKs: many `xxx_id` columns have no DB constraint. Guess the
+        // referenced table by Laravel convention (contact_id -> contacts). The
+        // remap only fires when that table was actually imported, so a wrong
+        // guess (e.g. google_event_id) is harmless — it stays as-is.
+        foreach (Schema::getColumnListing($table) as $column) {
+            if (isset($patchable[$column]) || $column === 'team_id' || $column === 'id') {
+                continue;
+            }
+            if (str_ends_with($column, '_id')) {
+                $patchable[$column] = Str::plural(substr($column, 0, -3));
+            }
+        }
+
+        return $patchable;
+    }
+}

--- a/app/Support/SchemaGraph.php
+++ b/app/Support/SchemaGraph.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Introspects declared foreign keys from the live schema so a cross-env import
+ * can remap them without a hand-maintained edge map (which drifts). Uses
+ * Laravel's cross-database Schema::getForeignKeys() (PRAGMA on sqlite,
+ * information_schema on MySQL).
+ */
+class SchemaGraph
+{
+    /**
+     * @param  list<string>  $tables
+     * @return array<string, array<string, string>> table => [column => referenced table]
+     */
+    public static function edges(array $tables): array
+    {
+        $map = [];
+
+        foreach ($tables as $table) {
+            if (! Schema::hasTable($table)) {
+                continue;
+            }
+
+            foreach (Schema::getForeignKeys($table) as $fk) {
+                $columns = $fk['columns'] ?? [];
+                $referenced = $fk['foreign_table'] ?? null;
+                if ($referenced === null) {
+                    continue;
+                }
+
+                // Only single-column FKs are remappable row-by-row; the schema
+                // has no composite FKs among team-scoped tables.
+                if (count($columns) === 1) {
+                    $map[$table][$columns[0]] = $referenced;
+                }
+            }
+        }
+
+        return $map;
+    }
+}

--- a/docs/superpowers/specs/2026-07-06-f3-cross-env-import-design.md
+++ b/docs/superpowers/specs/2026-07-06-f3-cross-env-import-design.md
@@ -1,0 +1,94 @@
+# F3 — Cross-env backup import (design)
+
+**Date:** 2026-07-06
+**Status:** approved, implementing
+**Relation:** the cross-environment complement to restore (#477). #477 restores a team's
+own backup into its original team_id (same DB, original PKs). This imports a backup from a
+**different database** into a **brand-new team** with new PKs and a fully remapped FK graph.
+
+## Problem
+
+A backup zip (#476) taken on one install can't be used on another: its `team_id` and every
+PK collide with the target DB, and its 19 user-reference columns point at source-env users.
+Restore (#477) deliberately handles only the same-env case.
+
+## Decisions (locked with user)
+
+1. **Target:** a brand-new team on the target env; new PKs; full FK remap.
+2. **User references:** **importer owns everything.** Every user-ref column
+   (assigned_to/created_by/updated_by/user_id/owner_id + any declared FK to `users`)
+   resolves to the importing super_admin; the new team's sole member is the importer. No
+   backup-format change, no email matching, always valid.
+3. **Trigger:** super_admin — an upload action + a `team:import` command.
+
+## Scale (measured)
+
+60 tables carry `team_id`; 101 FK constraints; 19 user-ref columns. Too large to hand-map
+(that is what drifted in clone) — so the FK graph is **introspected from the live schema**.
+
+## Architecture
+
+### 1. `App\Support\SchemaGraph`
+
+`edges(): array` → `table => [column => referencedTable]`, read once from
+`information_schema.KEY_COLUMN_USAGE` (all 101 FK constraints). Built from the DB, so it
+cannot drift. Cached for the request.
+
+### 2. `App\Services\ImportTeamBackupService`
+
+`import(string $localZipPath, string $name, User $importer): Team`:
+
+- **Validate (untrusted input):** zip opens; `manifest.json` present; `format_version === 1`.
+  Zip-slip-safe by construction — only fixed entry names are read via
+  `getFromName('models/{Name}.json')`; the zip is never directory-walked or extracted to
+  disk.
+- **New team** owned by `$importer` (`personal_team = false`).
+- All inside `Schema::withoutForeignKeyConstraints(fn => DB::transaction(...))` (FK-off
+  **wraps** the transaction — sqlite ignores `PRAGMA foreign_keys` once one is open):
+  - **Pass 1 — insert:** for each backup `models/{Name}.json` whose table exists, insert
+    every row with a fresh PK, `team_id` = new team, all other columns verbatim; record
+    `old→new` per table.
+  - **Pass 2 — patch** each row's FK columns using `SchemaGraph`:
+    - referenced table **users** (or a name-heuristic column: assigned_to / created_by /
+      updated_by / user_id / owner_id) ⇒ **importer id**;
+    - referenced table **in the imported set** ⇒ remap via that table's `old→new` map;
+    - otherwise ⇒ left as-is (best-effort — a ceiling, see below).
+- Membership: the importer only.
+- Returns the new team.
+
+### 3. `App\Jobs\ImportTeamBackup` (queued)
+
+Full-data import can be large → off the request cycle. Reads the stored upload, calls the
+service, notifies the initiating super_admin (Filament DB notification). Not `TenantAware`.
+
+### 4. Triggers (super_admin only)
+
+- **Import backup** header action on the admin `ListTeams` page: a `FileUpload` (zip, size
+  limit) + new-team name → store the upload to a private disk → dispatch `ImportTeamBackup`.
+- `team:import {path} {--name=} {--owner=}` command (ops; reads a local zip). `--owner`
+  defaults to the first super_admin; `--name` defaults to the manifest team name.
+
+## Security
+
+Super_admin only. Upload validated (zip mime + size) and stored to a **private** disk.
+Zip-slip-safe (fixed entry names only). Import writes solely into the freshly created team.
+
+## Testing (TDD, PHPUnit + sqlite, then MySQL-verify)
+
+- **Cross-team round-trip:** seed team A with Contact + Task (`task.contact_id` → the
+  contact) + a user ref (`task.assigned_to`); back up A; import; assert a **new** team B
+  holds the rows with **new PKs**, `task.contact_id` rewired to B's contact, and
+  `task.assigned_to` = the importer.
+- **Source untouched:** team A's rows and ids unchanged.
+- **Bad input rejected:** missing manifest / wrong `format_version` → typed exception.
+- Command + action gated to super_admin; unknown / missing file fails cleanly.
+- MySQL 8.4 verify (introspection + FK-off remap + explicit-id inserts).
+
+## Out of scope / ceilings (stated, not hidden)
+
+- **Undeclared** references (a `*_id` with no FK constraint, non-user) are absent from
+  `information_schema` → not remapped (left as-is). Most references here are declared FKs.
+- The ~7 `team_id` tables that are neither `IsTenantModel` nor a backup extra aren't in the
+  backup → not imported.
+- No email-based user mapping, no cross-env user/role import, no merge into an existing
+  team, no backup-format change.

--- a/docs/superpowers/specs/2026-07-06-f3-cross-env-import-design.md
+++ b/docs/superpowers/specs/2026-07-06-f3-cross-env-import-design.md
@@ -86,8 +86,15 @@ Zip-slip-safe (fixed entry names only). Import writes solely into the freshly cr
 
 ## Out of scope / ceilings (stated, not hidden)
 
-- **Undeclared** references (a `*_id` with no FK constraint, non-user) are absent from
-  `information_schema` → not remapped (left as-is). Most references here are declared FKs.
+- **Undeclared** FKs (a `*_id` column with no DB constraint) aren't in the schema graph, so
+  they are remapped **best-effort by Laravel naming convention** (`contact_id` → `contacts`)
+  — the remap only fires when the guessed table was actually imported, so a wrong guess is
+  harmless. A reference that follows neither a declared FK nor the naming convention is left
+  as-is.
+- **Unique-constraint collisions**: importing verbatim rows into a target env that already
+  holds a colliding unique value (e.g. a contact email) fails — the whole import rolls back
+  atomically (no partial team). Cross-env assumes a disjoint/fresh target; this is a loud,
+  safe failure, not corruption.
 - The ~7 `team_id` tables that are neither `IsTenantModel` nor a backup extra aren't in the
   backup → not imported.
 - No email-based user mapping, no cross-env user/role import, no merge into an existing

--- a/tests/Feature/Teams/ImportTeamBackupJobTest.php
+++ b/tests/Feature/Teams/ImportTeamBackupJobTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Teams;
+
+use App\Jobs\ImportTeamBackup;
+use App\Models\Contact;
+use App\Models\Team;
+use App\Models\User;
+use App\Services\ImportTeamBackupService;
+use App\Services\TeamBackupService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+use Throwable;
+
+class ImportTeamBackupJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_job_imports_a_stored_zip_and_notifies(): void
+    {
+        Storage::fake('local');
+        $importer = User::factory()->create();
+        $source = Team::factory()->create();
+        Contact::factory()->create(['team_id' => $source->id]);
+
+        $result = (new TeamBackupService)->backup($source, 'local');
+        Contact::withoutGlobalScope('tenant')->where('team_id', $source->id)->delete();
+
+        (new ImportTeamBackup('local', $result['path'], 'Imported', $importer->id))
+            ->handle(app(ImportTeamBackupService::class));
+
+        $new = Team::where('name', 'Imported')->first();
+        $this->assertNotNull($new);
+        $this->assertSame(1, Contact::withoutGlobalScope('tenant')->where('team_id', $new->id)->count());
+        $this->assertSame(1, $importer->fresh()->notifications()->count());
+    }
+
+    public function test_job_rethrows_on_failure(): void
+    {
+        Storage::fake('local');
+        $importer = User::factory()->create();
+        Storage::disk('local')->put('imports/bad.zip', 'not a zip');
+
+        $this->expectException(Throwable::class);
+        (new ImportTeamBackup('local', 'imports/bad.zip', 'X', $importer->id))
+            ->handle(app(ImportTeamBackupService::class));
+    }
+}

--- a/tests/Feature/Teams/ImportTeamBackupServiceTest.php
+++ b/tests/Feature/Teams/ImportTeamBackupServiceTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Teams;
+
+use App\Exceptions\TeamImportException;
+use App\Models\Contact;
+use App\Models\Task;
+use App\Models\Team;
+use App\Models\User;
+use App\Services\ImportTeamBackupService;
+use App\Services\TeamBackupService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+use ZipArchive;
+
+class ImportTeamBackupServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Back up a team, then delete its rows to simulate a disjoint target env
+     * (a real cross-env import lands in a DB that does not already hold this
+     * team's data / colliding unique values). Returns the backup's local path.
+     */
+    private function backupThenClear(Team $source): string
+    {
+        $result = (new TeamBackupService)->backup($source, 'local');
+
+        Task::withoutGlobalScope('tenant')->where('team_id', $source->id)->delete();
+        Contact::withoutGlobalScope('tenant')->where('team_id', $source->id)->delete();
+
+        return Storage::disk('local')->path($result['path']);
+    }
+
+    public function test_imports_a_backup_into_a_new_team_remapping_fks_and_users(): void
+    {
+        Storage::fake('local');
+        $importer = User::factory()->create();
+        $assignee = User::factory()->create();
+
+        $source = Team::factory()->create();
+        $contact = Contact::factory()->create(['team_id' => $source->id, 'name' => 'CrossEnv Co']);
+        Task::factory()->create([
+            'team_id' => $source->id, 'contact_id' => $contact->id, 'assigned_to' => $assignee->id,
+        ]);
+
+        $localZip = $this->backupThenClear($source);
+
+        $new = (new ImportTeamBackupService)->import($localZip, 'Imported Team', $importer);
+
+        $this->assertNotSame($source->id, $new->id);
+        $this->assertSame($importer->id, $new->user_id);
+
+        $newContact = DB::table('contacts')->where('team_id', $new->id)->first();
+        $newTask = DB::table('tasks')->where('team_id', $new->id)->first();
+        $this->assertNotNull($newContact);
+        $this->assertNotNull($newTask);
+        $this->assertSame('CrossEnv Co', $newContact->name);
+
+        // New PK, cross-model FK rewired to the imported contact.
+        $this->assertNotSame($contact->id, (int) $newContact->id);
+        $this->assertSame((int) $newContact->id, (int) $newTask->contact_id);
+
+        // User reference resolves to the importer, not the source-env assignee.
+        $this->assertSame($importer->id, (int) $newTask->assigned_to);
+    }
+
+    public function test_import_is_atomic_and_leaves_no_orphan_team_on_failure(): void
+    {
+        Storage::fake('local');
+        $importer = User::factory()->create();
+        $source = Team::factory()->create();
+        Contact::factory()->create(['team_id' => $source->id, 'email' => 'dupe@example.com']);
+
+        // Do NOT clear the source: the imported contact's unique email collides,
+        // so the insert fails mid-import.
+        $result = (new TeamBackupService)->backup($source, 'local');
+        $teamsBefore = DB::table('teams')->count();
+
+        try {
+            (new ImportTeamBackupService)->import(Storage::disk('local')->path($result['path']), 'X', $importer);
+            $this->fail('expected a unique-collision failure');
+        } catch (\Throwable) {
+            // expected
+        }
+
+        // Team was created inside the transaction -> rolled back, no orphan.
+        $this->assertSame($teamsBefore, DB::table('teams')->count());
+    }
+
+    public function test_rejects_a_bad_archive(): void
+    {
+        Storage::fake('local');
+        Storage::disk('local')->put('bad.zip', 'not a zip');
+        $importer = User::factory()->create();
+
+        $this->expectException(TeamImportException::class);
+        (new ImportTeamBackupService)->import(Storage::disk('local')->path('bad.zip'), 'X', $importer);
+    }
+
+    public function test_rejects_wrong_format_version(): void
+    {
+        Storage::fake('local');
+        $importer = User::factory()->create();
+        $path = Storage::disk('local')->path('v2.zip');
+        $zip = new ZipArchive;
+        $zip->open($path, ZipArchive::CREATE);
+        $zip->addFromString('manifest.json', (string) json_encode(['format_version' => 99, 'team' => ['id' => 1, 'name' => 'x']]));
+        $zip->close();
+
+        $this->expectException(TeamImportException::class);
+        (new ImportTeamBackupService)->import($path, 'X', $importer);
+    }
+}

--- a/tests/Feature/Teams/ImportTeamCommandTest.php
+++ b/tests/Feature/Teams/ImportTeamCommandTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Teams;
+
+use App\Models\Contact;
+use App\Models\Team;
+use App\Models\User;
+use App\Services\TeamBackupService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class ImportTeamCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_command_imports_a_zip_into_a_new_team(): void
+    {
+        Storage::fake('local');
+        $owner = User::factory()->create();
+        $source = Team::factory()->create();
+        Contact::factory()->create(['team_id' => $source->id]);
+
+        $result = (new TeamBackupService)->backup($source, 'local');
+        Contact::withoutGlobalScope('tenant')->where('team_id', $source->id)->delete();
+        $path = Storage::disk('local')->path($result['path']);
+
+        $this->artisan('team:import', ['path' => $path, '--name' => 'Imported', '--owner' => $owner->id])
+            ->assertSuccessful();
+
+        $new = Team::where('name', 'Imported')->first();
+        $this->assertNotNull($new);
+        $this->assertSame($owner->id, $new->user_id);
+        $this->assertSame(1, Contact::withoutGlobalScope('tenant')->where('team_id', $new->id)->count());
+    }
+
+    public function test_command_fails_for_a_missing_file(): void
+    {
+        $this->artisan('team:import', ['path' => '/no/such/file.zip'])->assertFailed();
+    }
+}


### PR DESCRIPTION
## F3 — Cross-env backup import

The cross-environment complement to restore (#477). #477 restores a team's own backup into its original `team_id` (same DB, original PKs). This **imports a backup taken on a different database** into a **brand-new team** — its source `team_id` and every PK collide with the target, so nothing can be preserved verbatim.

Design: [`docs/superpowers/specs/2026-07-06-f3-cross-env-import-design.md`](../blob/feat/f3-cross-env-import/docs/superpowers/specs/2026-07-06-f3-cross-env-import-design.md).

### Scale
60 `team_id` tables · 101 FK constraints · 19 user-ref columns — far too much to hand-map (that's what drifted in clone).

### How it works
- **`SchemaGraph`** introspects the FK graph from the **live schema** (cross-DB `Schema::getForeignKeys()` — PRAGMA on sqlite, information_schema on MySQL). Built from the DB → **cannot drift.**
- **`ImportTeamBackupService`** creates a new team owned by the importer, inserts every backup row with a fresh PK, then remaps FKs:
  - declared FK → remap via the introspected graph;
  - **undeclared** `xxx_id` → best-effort by Laravel convention (`contact_id`→`contacts`), only when the guessed table was actually imported (wrong guess is harmless);
  - **users** (or assigned_to/created_by/…) → **the importer** (source-env user ids are meaningless).
- All inside `Schema::withoutForeignKeyConstraints` wrapping a transaction (same FK-off rule as restore/clone). The **team is created inside the transaction** so a failed import (e.g. a unique collision on the target) rolls back with **no orphan team**.

### Triggers (super_admin only)
Import-backup **upload action** on the admin `ListTeams` page (queued `ImportTeamBackup` job + notification) + `team:import {path} {--name=} {--owner=}`. Zip-slip-safe — only fixed entry names are read.

### Verification
- **792 pass / 1 skip / 0 fail** (+8: service 4 incl. cross-team round-trip + atomic-no-orphan, command 2, job 2).
- **MySQL 8.4 verified**: FK introspection + FK-off remap + explicit-id inserts round-trip on real MySQL.
- **PHPStan: 0 new** (21 pre-existing baseline, identical).

### Ceilings (stated)
Unique-constraint collisions on a non-disjoint target fail atomically (loud, safe — no corruption); references following neither a declared FK nor the naming convention are left as-is; the ~7 non-`IsTenantModel` `team_id` tables aren't in the backup; no email-based user mapping / no merge into an existing team.