### PR TITLE
feat(portal): customer ticket self-service portal (G_5)

### DIFF
--- a/app/Enums/Role.php
+++ b/app/Enums/Role.php
@@ -9,6 +9,7 @@ enum Role: string
     case Manager = 'manager';
     case SalesRep = 'sales_rep';
     case Free = 'free';
+    case Customer = 'customer';
 
     public static function values(): array
     {

--- a/app/Filament/Portal/Resources/TicketResource.php
+++ b/app/Filament/Portal/Resources/TicketResource.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Portal\Resources;
+
+use App\Filament\Portal\Resources\TicketResource\Pages\ListTickets;
+use App\Filament\Portal\Resources\TicketResource\Pages\ViewTicket;
+use App\Models\Ticket;
+use Filament\Actions\ViewAction;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Auth;
+
+class TicketResource extends Resource
+{
+    protected static ?string $model = Ticket::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-lifebuoy';
+
+    protected static ?string $navigationLabel = 'Support tickets';
+
+    /**
+     * A customer only ever sees the tickets they raised. Filament resolves both
+     * table rows and single-record routes through this query, so an id the
+     * customer does not own resolves to a 404 (no cross-customer disclosure).
+     */
+    #[\Override]
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()->where('user_id', Auth::id());
+    }
+
+    #[\Override]
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+
+    #[\Override]
+    public static function form(Schema $schema): Schema
+    {
+        // Rendered read-only by the View page.
+        return $schema->components([
+            TextInput::make('subject')->disabled(),
+            TextInput::make('status')->disabled(),
+            TextInput::make('priority')->disabled(),
+            Textarea::make('body')->disabled()->columnSpanFull(),
+        ]);
+    }
+
+    #[\Override]
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('subject')->searchable(),
+                TextColumn::make('status')->badge(),
+                TextColumn::make('priority')->badge(),
+                TextColumn::make('updated_at')->dateTime()->sortable(),
+            ])
+            ->recordActions([
+                ViewAction::make(),
+            ])
+            ->defaultSort('updated_at', 'desc');
+    }
+
+    #[\Override]
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListTickets::route('/'),
+            'view' => ViewTicket::route('/{record}'),
+        ];
+    }
+}

--- a/app/Filament/Portal/Resources/TicketResource/Pages/ListTickets.php
+++ b/app/Filament/Portal/Resources/TicketResource/Pages/ListTickets.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Portal\Resources\TicketResource\Pages;
+
+use App\Filament\Portal\Resources\TicketResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListTickets extends ListRecords
+{
+    protected static string $resource = TicketResource::class;
+
+    // No create action — customers can view and reply, not raise tickets here
+    // (portal ticket creation is a later G_5 slice).
+    protected function getHeaderActions(): array
+    {
+        return [];
+    }
+}

--- a/app/Filament/Portal/Resources/TicketResource/Pages/ViewTicket.php
+++ b/app/Filament/Portal/Resources/TicketResource/Pages/ViewTicket.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Portal\Resources\TicketResource\Pages;
+
+use App\Filament\Portal\Resources\TicketResource;
+use App\Models\Message;
+use App\Models\Ticket;
+use Filament\Actions\Action;
+use Filament\Forms\Components\Textarea;
+use Filament\Notifications\Notification;
+use Filament\Resources\Pages\ViewRecord;
+use Illuminate\Support\Facades\Auth;
+
+class ViewTicket extends ViewRecord
+{
+    protected static string $resource = TicketResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Action::make('reply')
+                ->label('Reply')
+                ->icon('heroicon-o-arrow-uturn-left')
+                ->schema([
+                    Textarea::make('content')->label('Your reply')->required(),
+                ])
+                ->action(function (array $data): void {
+                    /** @var Ticket $ticket */
+                    $ticket = $this->getRecord(); // already ownership-scoped by resolveRecord
+
+                    $message = new Message([
+                        'channel' => 'portal',
+                        'sender' => Auth::user()->email,
+                        'content' => $data['content'],
+                        'priority' => $ticket->priority ?: 'medium',
+                        'status' => 'unread',
+                        // ponytail: messages.account_id is a legacy NOT NULL int with no
+                        // default; 0 sentinel when the ticket has no source account.
+                        'account_id' => (int) ($ticket->account_id ?? 0),
+                        'metadata' => [],
+                        'timestamp' => now(),
+                        'ticket_id' => $ticket->id,
+                    ]);
+
+                    // team_id is system-managed (not fillable on Message). Set it
+                    // directly so the reply carries the ticket's tenant and stays
+                    // visible to staff on the team-scoped app panel; the portal is
+                    // non-tenant, so IsTenantModel's creating hook won't stamp it.
+                    $message->setAttribute('team_id', $ticket->getAttribute('team_id'));
+                    $message->save();
+
+                    Notification::make()->title('Reply sent')->success()->send();
+                }),
+        ];
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -110,7 +110,11 @@ class User extends Authenticatable implements FilamentUser, HasDefaultTenant, Ha
         return match ($panel->getId()) {
             'super_admin' => $this->hasRole(Role::SuperAdmin),
             'admin' => $this->hasRole(Role::Admin) || $this->hasRole(Role::SuperAdmin),
-            default => true,
+            'portal' => $this->hasRole(Role::Customer),
+            // app + any future panel: staff only. A customer (external end user)
+            // must never reach the staff surfaces, so fence them out explicitly
+            // rather than falling through to the permissive default.
+            default => ! $this->hasRole(Role::Customer),
         };
     }
 

--- a/app/Providers/Filament/PortalPanelProvider.php
+++ b/app/Providers/Filament/PortalPanelProvider.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Providers\Filament;
+
+use Filament\Http\Middleware\Authenticate;
+use Filament\Http\Middleware\DisableBladeIconComponents;
+use Filament\Http\Middleware\DispatchServingFilamentEvent;
+use Filament\Panel;
+use Filament\PanelProvider;
+use Filament\Support\Colors\Color;
+use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
+use Illuminate\Cookie\Middleware\EncryptCookies;
+use Illuminate\Foundation\Http\Middleware\PreventRequestForgery;
+use Illuminate\Routing\Middleware\SubstituteBindings;
+use Illuminate\Session\Middleware\AuthenticateSession;
+use Illuminate\Session\Middleware\StartSession;
+use Illuminate\View\Middleware\ShareErrorsFromSession;
+
+/**
+ * Customer-facing portal (G_5). External customers are Users holding the
+ * `customer` role (see User::canAccessPanel). Intentionally NON-tenant: a
+ * customer has no Jetstream team membership; ticket visibility is scoped by
+ * requester (user_id) inside the resource, which is the security boundary here.
+ */
+class PortalPanelProvider extends PanelProvider
+{
+    public function panel(Panel $panel): Panel
+    {
+        return $panel
+            ->id('portal')
+            ->path('portal')
+            ->login()
+            ->colors([
+                'primary' => Color::Blue,
+            ])
+            ->discoverResources(in: app_path('Filament/Portal/Resources'), for: 'App\\Filament\\Portal\\Resources')
+            ->pages([])
+            ->middleware([
+                EncryptCookies::class,
+                AddQueuedCookiesToResponse::class,
+                StartSession::class,
+                AuthenticateSession::class,
+                ShareErrorsFromSession::class,
+                PreventRequestForgery::class,
+                SubstituteBindings::class,
+                DisableBladeIconComponents::class,
+                DispatchServingFilamentEvent::class,
+            ])
+            ->authMiddleware([
+                Authenticate::class,
+            ]);
+    }
+}

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -6,6 +6,7 @@ return [
     App\Providers\EventServiceProvider::class,
     App\Providers\Filament\AdminPanelProvider::class,
     App\Providers\Filament\AppPanelProvider::class,
+    App\Providers\Filament\PortalPanelProvider::class,
     App\Providers\FortifyServiceProvider::class,
     App\Providers\HorizonServiceProvider::class,
     App\Providers\JetstreamServiceProvider::class,

--- a/database/migrations/2026_07_07_120000_add_team_id_to_tickets_table.php
+++ b/database/migrations/2026_07_07_120000_add_team_id_to_tickets_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Ticket uses IsTenantModel but the table never had a team_id column (a
+     * long-standing model<->schema drift). Add it so a ticket carries a real
+     * tenant — the customer portal (G_5) needs it so a customer's reply inherits
+     * the ticket's team and stays visible to staff on the team-scoped app panel.
+     */
+    public function up(): void
+    {
+        if (Schema::hasColumn('tickets', 'team_id')) {
+            return;
+        }
+
+        Schema::table('tickets', function (Blueprint $table): void {
+            $table->foreignId('team_id')->nullable()->after('user_id')->constrained()->nullOnDelete();
+        });
+
+        // Best-effort backfill: a ticket's tenant is its requester's current team.
+        DB::table('tickets')->whereNull('team_id')->update([
+            'team_id' => DB::raw('(select current_team_id from users where users.id = tickets.user_id)'),
+        ]);
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasColumn('tickets', 'team_id')) {
+            return;
+        }
+
+        Schema::table('tickets', function (Blueprint $table): void {
+            $table->dropForeign(['team_id']);
+            $table->dropColumn('team_id');
+        });
+    }
+};

--- a/docs/superpowers/specs/2026-07-07-g5-portal-tickets-design.md
+++ b/docs/superpowers/specs/2026-07-07-g5-portal-tickets-design.md
@@ -1,0 +1,117 @@
+# G_5 slice 1 — Customer portal: auth + own-ticket self-service (design)
+
+**Date:** 2026-07-07
+**Status:** approved, implementing
+**Epic:** G_5 customer portal — the first of several slices. This one is the coupled auth
+foundation plus a first visible feature (ticket self-service). Later slices: KB browse,
+quote/document access, portal ticket *creation*, invite/set-password onboarding, branding.
+
+## Problem
+
+The CRM has two staff surfaces — `admin` (global) and `app` (team-scoped staff) — but no way
+for a tenant's **end customers** to log in and self-serve. Customer-facing data already
+exists (`Ticket` + `Message` threads, `KnowledgeBaseArticle`, `QuoteRequest`, `Document`),
+but it is only reachable by staff. G_5 adds a third surface for external customers.
+
+## Decisions (locked with user)
+
+1. **First slice = thin vertical:** magic-link was declined; customers **log in and view +
+   reply to their own support tickets**. Establishes the portal auth foundation and ships a
+   usable feature in one PR.
+2. **Identity = `User` + a new `customer` role.** No separate identity table, no new auth
+   model. Reuses the existing `users` table, session guard, and Spatie RBAC.
+3. **Auth = password**, via the portal panel's own Filament login (self-contained; does not
+   depend on Fortify's admin-disabled routes).
+4. **Surface = a third Filament panel** (`portal`), reusing Filament auth + resource
+   scaffolding. Ceiling: Filament chrome, minimal customer branding (a later slice).
+
+## Architecture
+
+### 1. `Role::Customer`
+
+Add `case Customer = 'customer';` to `App\Enums\Role`. Seeded as a **global** Spatie role
+(`team_id` null — a customer is not per-team staff). `super_admin` stays the only other
+global role; `admin/manager/sales_rep/free` remain per-team (F4).
+
+### 2. Panel access fencing (trust boundary)
+
+Rework `User::canAccessPanel` from its current `default => true` (which today lets *any*
+authenticated user into `/app`):
+
+```php
+return match ($panel->getId()) {
+    'super_admin' => $this->hasRole(Role::SuperAdmin),
+    'admin'       => $this->hasRole(Role::Admin) || $this->hasRole(Role::SuperAdmin),
+    'portal'      => $this->hasRole(Role::Customer),
+    default       => ! $this->hasRole(Role::Customer), // app + future: staff only
+};
+```
+
+Two-way isolation: a customer reaches **only** `/portal`; staff (non-customer) cannot reach
+`/portal`. This closes the pre-existing `default => true` hole.
+
+### 3. `PortalPanelProvider`
+
+New panel: id `portal`, path `/portal`, `->login()`, **non-tenant** (no `->tenant()`;
+customers need no Jetstream team membership). Web guard. Discovers resources under
+`app/Filament/Portal/Resources`. Minimal brand.
+
+### 4. `Filament\Portal\Resources\TicketResource` (over existing `Ticket`)
+
+- **Ownership scope:** `getEloquentQuery()` = `parent()->where('user_id', Auth::id())`.
+  Filament resolves *record binding* through this query, so `/portal/tickets/{id}` for a
+  ticket the customer does not own → **404** (closes IDOR, same class as the F1 API fix). The
+  portal panel is non-tenant, so `Ticket`'s IsTenantModel `'tenant'` scope runs under null
+  context = **inert** (adds no predicate) → no `tickets.team_id` fatal.
+- **List:** subject / status / priority / updated_at, read-only, newest first.
+- **View page:** the ticket plus its `messages()` thread.
+- **Reply action** (on the View page): creates a `Message`
+  `{ticket_id: <scoped record>, content, sender: <customer>, channel: 'portal',
+  team_id: <ticket tenant>, timestamp: now}`. `ticket_id` is taken from the resolved
+  (already ownership-scoped) record — never from client input — so a customer cannot post to
+  another customer's ticket.
+
+### 5. Reply visibility — `tickets.team_id` (drift fix, folded in)
+
+A staff agent views tickets on the tenant-scoped `app` panel, so a reply `Message` must carry
+the correct `team_id` or it is invisible to staff. `messages` has `team_id`; **`tickets` does
+not**, despite `Ticket` using `IsTenantModel` (recurring CRM model↔schema drift). Fold the fix
+in: a guarded migration adds nullable `team_id` (FK, `nullOnDelete`) to `tickets`, backfilled
+best-effort from the requester's `current_team_id`. The reply inherits `ticket.team_id`. This
+makes `Ticket`'s IsTenantModel honest and keeps the reply in the tenant's data.
+
+## Onboarding ceiling (stated, not built)
+
+Customers minted by the email-to-ticket flow have no password. Slice 1 assumes a credentialed
+customer (staff-set, or Fortify's existing "forgot password" reset, which already mails a
+set-password link to any `User` by email — zero new code). A dedicated invite/set-password
+flow is a later slice.
+
+## Testing (TDD, PHPUnit + sqlite, then MySQL-verify)
+
+- **Panel access, both directions:** a `customer` can GET `/portal`; cannot GET `/app` or
+  `/admin`. A staff user (`manager`) cannot GET `/portal`.
+- **Own-tickets only:** seed tickets for two different users; the customer's list shows only
+  their own.
+- **Foreign ticket 404 (IDOR):** opening another user's ticket id via the portal resource →
+  not found.
+- **Reply creates a correctly-scoped `Message`:** right `ticket_id`, `sender`, `channel`,
+  and `team_id` inherited from the ticket.
+- **Reply cannot target a foreign ticket:** attempting to reply against a ticket the customer
+  does not own is blocked by the scoped record resolution.
+- **`tickets.team_id` migration** applies on MySQL 8.4; phpstan 0-new; pint clean.
+
+Filament test idiom (from F3): assign the role with `setPermissionsTeamId(null); assignRole(...)`,
+mount pages via HTTP GET `/portal/...`, exercise table/record actions via Livewire test
+helpers.
+
+## Build shape
+
+Coupled auth + panel foundation → **inline TDD, one PR to `main`** (not parallel — same as
+F4-RBAC and every F3 slice). Full suite green, phpstan 0-new vs the stale 21-entry baseline,
+MySQL-verified, pint clean.
+
+## Out of scope (later slices)
+
+KB browse, quote/document access, **ticket creation** from the portal, invite/set-password
+onboarding, portal branding/theming, per-customer multi-team, portal notifications.

--- a/tests/Feature/Portal/CustomerPortalTicketTest.php
+++ b/tests/Feature/Portal/CustomerPortalTicketTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Portal;
+
+use App\Filament\Portal\Resources\TicketResource\Pages\ListTickets;
+use App\Filament\Portal\Resources\TicketResource\Pages\ViewTicket;
+use App\Models\Team;
+use App\Models\Ticket;
+use App\Models\User;
+use Database\Seeders\RolesSeeder;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class CustomerPortalTicketTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function customer(): User
+    {
+        $this->seed(RolesSeeder::class);
+        $user = User::factory()->create(['email_verified_at' => now()]);
+        setPermissionsTeamId(null);
+        $user->assignRole('customer');
+
+        return $user;
+    }
+
+    private function actingCustomer(): User
+    {
+        $user = $this->customer();
+        $this->actingAs($user);
+        Filament::setCurrentPanel(Filament::getPanel('portal'));
+
+        return $user;
+    }
+
+    public function test_customer_can_access_portal(): void
+    {
+        $this->actingCustomer();
+
+        $this->get('/portal/tickets')->assertOk();
+    }
+
+    public function test_customer_cannot_access_app_or_admin(): void
+    {
+        $this->actingCustomer();
+
+        $this->get('/app')->assertForbidden();
+        $this->get('/admin')->assertForbidden();
+    }
+
+    public function test_staff_cannot_access_portal(): void
+    {
+        $this->seed(RolesSeeder::class);
+        $staff = User::factory()->withPersonalTeam()->create(['email_verified_at' => now()]);
+        setPermissionsTeamId(null);
+        $staff->assignRole('manager');
+        $this->actingAs($staff);
+
+        $this->get('/portal/tickets')->assertForbidden();
+    }
+
+    public function test_customer_sees_only_own_tickets(): void
+    {
+        $customer = $this->actingCustomer();
+        $mine = Ticket::factory()->create(['user_id' => $customer->id, 'subject' => 'My issue']);
+        $other = Ticket::factory()->create(['subject' => 'Someone else']);
+
+        Livewire::test(ListTickets::class)
+            ->assertCanSeeTableRecords([$mine])
+            ->assertCanNotSeeTableRecords([$other]);
+    }
+
+    public function test_customer_cannot_open_foreign_ticket(): void
+    {
+        // The view route is /portal/tickets/{record}; scoped record resolution
+        // means the reply surface for a foreign ticket is a 404 (IDOR closed).
+        $customer = $this->actingCustomer();
+        $mine = Ticket::factory()->create(['user_id' => $customer->id]);
+        $foreign = Ticket::factory()->create();
+
+        $this->get('/portal/tickets/'.$mine->id)->assertOk();
+        $this->get('/portal/tickets/'.$foreign->id)->assertNotFound();
+    }
+
+    public function test_reply_creates_scoped_message_on_own_ticket(): void
+    {
+        $team = Team::factory()->create();
+        $customer = $this->actingCustomer();
+        $ticket = Ticket::factory()->create(['user_id' => $customer->id, 'team_id' => $team->id]);
+
+        Livewire::test(ViewTicket::class, ['record' => $ticket->getKey()])
+            ->callAction('reply', ['content' => 'Any update?']);
+
+        $this->assertDatabaseHas('messages', [
+            'ticket_id' => $ticket->id,
+            'channel' => 'portal',
+            'sender' => $customer->email,
+            'team_id' => $team->id,
+            'content' => 'Any update?',
+        ]);
+    }
+}


### PR DESCRIPTION
First slice of the **G_5 customer portal** epic. Spec: `docs/superpowers/specs/2026-07-07-g5-portal-tickets-design.md`.

## What
A third Filament panel (`portal`, `/portal`) for a tenant's **end customers** — Users holding a new global `Role::Customer` — distinct from the staff `admin`/`app` surfaces. First feature: a customer logs in and **views + replies to their own support tickets**.

## How
- **`Role::Customer`** — auto-seeded by `RolesSeeder` (iterates `Role::cases()`), global (team_id null).
- **Panel fencing (`User::canAccessPanel`)** — `portal => customer`; everything else `=> ! customer`. Two-way isolation: a customer reaches only `/portal`; staff can't reach it. Closes the pre-existing `default => true` hole that let any authenticated user into `/app`.
- **`PortalPanelProvider`** — non-tenant (customers have no Jetstream team); web guard; own login.
- **`Filament\Portal\Resources\TicketResource`** — `getEloquentQuery()` scopes to `where('user_id', auth id)`, which Filament also uses for single-record resolution → a foreign ticket id **404s** (IDOR closed). Read + reply only (no create/edit). Reply appends a `Message` to the thread (`channel: portal`, `sender:` customer email), `team_id` set directly (system-managed, not fillable).
- **`tickets.team_id`** — nullable FK added + backfilled from the requester's `current_team_id`. `Ticket` uses `IsTenantModel` but the table never had the column (model↔schema drift); folding the fix in gives a reply a real tenant to inherit so it stays visible to staff on the team-scoped `app` panel.

## Verification
- New `tests/Feature/Portal/CustomerPortalTicketTest.php` — panel access both directions, own-tickets-only, foreign-ticket 404, reply creates a correctly-scoped Message. **6/6 green.**
- Full suite **805 passed / 1 skipped / 0 failed** (no regressions).
- **MySQL 8.4-verified** (migration + backfill + team_id reply insert).
- phpstan **0 new** (22 pre-existing `ignore.unmatched` baseline entries); pint clean.

## Out of scope (later slices)
KB browse, quote/document access, portal ticket **creation**, invite/set-password onboarding, portal branding.