### PR TITLE
feat(portal): customer ticket creation (G_5)

### DIFF
--- a/app/Events/NewTicket.php
+++ b/app/Events/NewTicket.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Team;
+use App\Models\Ticket;
+use Illuminate\Foundation\Events\Dispatchable;
+
+class NewTicket
+{
+    use Dispatchable;
+
+    public function __construct(public Ticket $ticket) {}
+
+    /** Team this event belongs to — used to scope notifications (anti cross-tenant leak). */
+    public function team(): ?Team
+    {
+        return $this->ticket->team;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->ticket->id,
+            'subject' => $this->ticket->subject,
+            'priority' => $this->ticket->priority,
+            'status' => $this->ticket->status,
+            'source' => $this->ticket->source,
+            'team_id' => $this->ticket->getAttribute('team_id'),
+        ];
+    }
+}

--- a/app/Filament/Portal/Resources/TicketResource.php
+++ b/app/Filament/Portal/Resources/TicketResource.php
@@ -4,10 +4,14 @@ declare(strict_types=1);
 
 namespace App\Filament\Portal\Resources;
 
+use App\Filament\Portal\Resources\TicketResource\Pages\CreateTicket;
 use App\Filament\Portal\Resources\TicketResource\Pages\ListTickets;
 use App\Filament\Portal\Resources\TicketResource\Pages\ViewTicket;
 use App\Models\Ticket;
+use App\Models\User;
 use Filament\Actions\ViewAction;
+use Filament\Forms\Components\FileUpload;
+use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Resource;
@@ -36,21 +40,38 @@ class TicketResource extends Resource
         return parent::getEloquentQuery()->where('user_id', Auth::id());
     }
 
+    /**
+     * A customer can only raise a ticket once they belong to a tenant — the new
+     * ticket's team_id comes from their current_team_id, so without one the
+     * ticket could not route to any staff. Gates the button and the create route.
+     */
     #[\Override]
     public static function canCreate(): bool
     {
-        return false;
+        $user = Auth::user();
+
+        return $user instanceof User && filled($user->getAttribute('current_team_id'));
     }
 
     #[\Override]
     public static function form(Schema $schema): Schema
     {
-        // Rendered read-only by the View page.
+        // Editable on the Create page; the View page (ViewRecord) renders it
+        // read-only. Ticket routing fields (user_id/team_id/source/email_id/status)
+        // are set server-side in CreateTicket, never exposed here.
         return $schema->components([
-            TextInput::make('subject')->disabled(),
-            TextInput::make('status')->disabled(),
-            TextInput::make('priority')->disabled(),
-            Textarea::make('body')->disabled()->columnSpanFull(),
+            TextInput::make('subject')->required()->maxLength(255),
+            Textarea::make('body')->label('Description')->required()->columnSpanFull(),
+            Select::make('priority')
+                ->options(['low' => 'Low', 'medium' => 'Medium', 'high' => 'High'])
+                ->default('medium')
+                ->required(),
+            FileUpload::make('attachment')
+                ->disk('local')
+                ->directory('ticket-attachments')
+                ->visibility('private')
+                ->acceptedFileTypes(['image/png', 'image/jpeg', 'application/pdf'])
+                ->maxSize(5120),
         ]);
     }
 
@@ -75,6 +96,7 @@ class TicketResource extends Resource
     {
         return [
             'index' => ListTickets::route('/'),
+            'create' => CreateTicket::route('/create'),
             'view' => ViewTicket::route('/{record}'),
         ];
     }

--- a/app/Filament/Portal/Resources/TicketResource/Pages/CreateTicket.php
+++ b/app/Filament/Portal/Resources/TicketResource/Pages/CreateTicket.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Portal\Resources\TicketResource\Pages;
+
+use App\Events\NewTicket;
+use App\Filament\Portal\Resources\TicketResource;
+use App\Models\User;
+use Filament\Resources\Pages\CreateRecord;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Str;
+
+class CreateTicket extends CreateRecord
+{
+    protected static string $resource = TicketResource::class;
+
+    /**
+     * Inject the routing fields the customer never supplies. team_id is the
+     * customer's own tenant (canCreate guarantees it is set); email_id is minted
+     * here because the column is unique NOT NULL (the email intake path uses the
+     * mail message-id — the portal has none).
+     */
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        /** @var User $user */
+        $user = Auth::user();
+
+        $data['user_id'] = $user->getKey();
+        $data['team_id'] = $user->getAttribute('current_team_id');
+        $data['source'] = 'portal';
+        $data['email_id'] = 'portal-'.Str::uuid()->toString();
+        $data['status'] = 'open';
+
+        return $data;
+    }
+
+    protected function afterCreate(): void
+    {
+        NewTicket::dispatch($this->record);
+    }
+}

--- a/app/Filament/Portal/Resources/TicketResource/Pages/ListTickets.php
+++ b/app/Filament/Portal/Resources/TicketResource/Pages/ListTickets.php
@@ -5,16 +5,19 @@ declare(strict_types=1);
 namespace App\Filament\Portal\Resources\TicketResource\Pages;
 
 use App\Filament\Portal\Resources\TicketResource;
+use Filament\Actions\CreateAction;
 use Filament\Resources\Pages\ListRecords;
 
 class ListTickets extends ListRecords
 {
     protected static string $resource = TicketResource::class;
 
-    // No create action — customers can view and reply, not raise tickets here
-    // (portal ticket creation is a later G_5 slice).
+    // CreateAction hides itself when TicketResource::canCreate() is false
+    // (customer without a tenant), so team-less customers get no button.
     protected function getHeaderActions(): array
     {
-        return [];
+        return [
+            CreateAction::make(),
+        ];
     }
 }

--- a/app/Filament/Portal/Resources/TicketResource/Pages/ViewTicket.php
+++ b/app/Filament/Portal/Resources/TicketResource/Pages/ViewTicket.php
@@ -12,6 +12,7 @@ use Filament\Forms\Components\Textarea;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\ViewRecord;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Storage;
 
 class ViewTicket extends ViewRecord
 {
@@ -20,6 +21,13 @@ class ViewTicket extends ViewRecord
     protected function getHeaderActions(): array
     {
         return [
+            // The record is already ownership-scoped (TicketResource::getEloquentQuery),
+            // so a customer can only stream their own ticket's file, off the private disk.
+            Action::make('download_attachment')
+                ->label('Download attachment')
+                ->icon('heroicon-o-paper-clip')
+                ->visible(fn (): bool => filled($this->getRecord()->getAttribute('attachment')))
+                ->action(fn () => Storage::disk('local')->download($this->getRecord()->getAttribute('attachment'))),
             Action::make('reply')
                 ->label('Reply')
                 ->icon('heroicon-o-arrow-uturn-left')

--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -23,6 +23,8 @@ class Ticket extends Model
         'source',
         'source_id',
         'account_id',
+        'team_id',
+        'attachment',
     ];
 
     public function user()

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -59,6 +59,9 @@ class EventServiceProvider extends ServiceProvider
         'App\Events\MeetingScheduled' => [
             SendCRMEventNotification::class,
         ],
+        'App\Events\NewTicket' => [
+            SendCRMEventNotification::class,
+        ],
     ];
 
     /**

--- a/config/crm.php
+++ b/config/crm.php
@@ -8,6 +8,7 @@ return [
             'task_overdue' => true,
             'new_comment' => true,
             'meeting_scheduled' => true,
+            'new_ticket' => true,
         ],
     ],
 ];

--- a/database/migrations/2026_07_07_130000_add_attachment_to_tickets_table.php
+++ b/database/migrations/2026_07_07_130000_add_attachment_to_tickets_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasColumn('tickets', 'attachment')) {
+            return;
+        }
+
+        Schema::table('tickets', function (Blueprint $table): void {
+            // Path on the private `local` disk of a single customer-supplied file.
+            $table->string('attachment')->nullable()->after('account_id');
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasColumn('tickets', 'attachment')) {
+            return;
+        }
+
+        Schema::table('tickets', function (Blueprint $table): void {
+            $table->dropColumn('attachment');
+        });
+    }
+};

--- a/docs/superpowers/specs/2026-07-07-g5-portal-ticket-create-design.md
+++ b/docs/superpowers/specs/2026-07-07-g5-portal-ticket-create-design.md
@@ -1,0 +1,103 @@
+# G_5 slice 2 — Portal ticket creation (design)
+
+**Date:** 2026-07-07
+**Status:** approved, implementing
+**Epic:** G_5 customer portal, slice 2. Slice 1 (#480) shipped the portal panel + own-ticket
+view/reply. This adds customer-initiated ticket creation, closing the support loop.
+
+## Problem
+
+A portal customer can view and reply to tickets but cannot raise a new one — every ticket
+still originates from the staff-side email/WhatsApp intake. Customers need a "New ticket"
+surface. The sharp edges: `tickets.email_id` is unique NOT NULL (intake uses the mail
+message-id), and a ticket needs a `team_id` or it is invisible to staff on the team-scoped
+`app` panel.
+
+## Decisions (locked with user)
+
+1. **Require a team — block if missing.** A ticket's tenant = the customer's
+   `current_team_id`. If the customer has none, creation is blocked (no orphan team-null
+   tickets). The onboarding slice provisions the customer↔team link; until then a team-less
+   customer simply cannot create (loud, safe).
+2. **Form:** subject + description + priority + a single file attachment.
+3. **Notify staff:** dispatch a `NewTicket` event wired into the existing
+   `SendCRMEventNotification`, so the owning team's staff are told.
+
+## Architecture
+
+### 1. Create surface — portal `TicketResource`
+
+Add a `CreateTicket` page (resource is currently index + view). Gate:
+
+```php
+public static function canCreate(): bool
+{
+    return filled(Auth::user()?->current_team_id);
+}
+```
+
+`canCreate() == false` hides the New-ticket button **and** 403s the `/portal/tickets/create`
+route for a team-less customer.
+
+**Form components:** `subject` (TextInput, required) · `body` (Textarea, required, labelled
+"Description") · `priority` (Select low/medium/high, default `medium`) · `attachment`
+(FileUpload, single, private `local` disk, accepted mime types + max size).
+
+**Server-set on create** (via `mutateFormDataBeforeCreate`, never from client input):
+
+- `user_id` = `Auth::id()`
+- `team_id` = `Auth::user()->current_team_id` (guaranteed non-null past `canCreate`)
+- `source` = `'portal'`
+- `email_id` = `'portal-'.Str::uuid()` (satisfies the unique NOT NULL column)
+- `status` = `'open'`
+- `priority`, `body`, `subject`, `attachment` from the form.
+
+`afterCreate()` dispatches `NewTicket::dispatch($this->record)`.
+
+### 2. Attachment (trust boundary)
+
+- Stored on the **private** `local` disk (never a public URL).
+- Upload validated: `->acceptedFileTypes([...])` + `->maxSize(...)`.
+- Path persisted to a new nullable `tickets.attachment` column.
+- Retrieval: a `download` action on the portal `ViewTicket` page, shown only when
+  `attachment` is set, streaming via `Storage::disk('local')->download(...)`. The portal
+  resource query is already `user_id`-scoped, so record resolution guarantees a customer
+  downloads only their own ticket's file.
+- Staff-side display of the attachment on the `app` panel is a later follow-up; the column
+  exists, but this slice does not touch the staff resource.
+
+### 3. `NewTicket` event + notification
+
+`App\Events\NewTicket` mirrors `App\Events\NewLead`:
+
+```php
+public function __construct(public Ticket $ticket) {}
+public function team(): ?Team { return $this->ticket->team; }
+public function toArray(): array { return [ 'id' => ..., 'subject' => ..., 'priority' => ..., 'team_id' => ... ]; }
+```
+
+- Register `'App\Events\NewTicket' => [SendCRMEventNotification::class]` in `EventServiceProvider`.
+- Add `'new_ticket' => true` to `config/crm.php` (`notifications.events`).
+- The listener notifies `ticket.team->allUsers()` — the owning tenant's staff only (the
+  #473 anti cross-tenant leak). Team is required, so `team()` is never null.
+
+### 4. Migration
+
+Guarded, nullable `tickets.attachment` (string).
+
+## Testing (TDD, PHPUnit + sqlite, then MySQL-verify)
+
+- **Team'd customer creates:** create page mounts (200); the new ticket has `user_id` = self,
+  `team_id` = own team, `source` = 'portal', a unique `email_id`, `status` = 'open', the
+  chosen priority; the attachment is stored on the private disk and its path saved.
+- **Team-less customer blocked:** `GET /portal/tickets/create` → 403.
+- **Notification:** creating a ticket dispatches `NewTicket` and a staff user on the ticket's
+  team receives a notification (`Notification::fake` + real dispatch through the listener).
+- **Attachment download:** the owner streams their own ticket's file (foreign already 404s via
+  the slice-1 `user_id` scope).
+- MySQL 8.4 verify (migration + create); phpstan 0-new; pint clean.
+
+## Out of scope (later slices)
+
+Multiple attachments, staff-side attachment display on the `app` panel, customer edit/close of
+a ticket, ticket categories/types, rate-limiting / spam guard, portal branding.

--- a/tests/Feature/Portal/CreatePortalTicketTest.php
+++ b/tests/Feature/Portal/CreatePortalTicketTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Portal;
+
+use App\Filament\Portal\Resources\TicketResource\Pages\CreateTicket;
+use App\Filament\Portal\Resources\TicketResource\Pages\ViewTicket;
+use App\Models\Team;
+use App\Models\Ticket;
+use App\Models\User;
+use App\Notifications\CRMEventNotification;
+use Database\Seeders\RolesSeeder;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Storage;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class CreatePortalTicketTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * A customer whose current_team_id points at $team (the tenant they belong
+     * to). $team is owned by a separate staff user so team()->allUsers() has a
+     * staff recipient for the notification test.
+     */
+    private function actingTeamedCustomer(?Team &$team = null, ?User &$staff = null): User
+    {
+        $this->seed(RolesSeeder::class);
+        $staff = User::factory()->create(['email_verified_at' => now()]);
+        $team = Team::factory()->create(['user_id' => $staff->id]);
+
+        $customer = User::factory()->create(['email_verified_at' => now()]);
+        $customer->forceFill(['current_team_id' => $team->id])->save();
+        setPermissionsTeamId(null);
+        $customer->assignRole('customer');
+
+        $this->actingAs($customer);
+        Filament::setCurrentPanel(Filament::getPanel('portal'));
+
+        return $customer;
+    }
+
+    private function actingTeamlessCustomer(): User
+    {
+        $this->seed(RolesSeeder::class);
+        $customer = User::factory()->create(['email_verified_at' => now()]);
+        setPermissionsTeamId(null);
+        $customer->assignRole('customer');
+
+        $this->actingAs($customer);
+        Filament::setCurrentPanel(Filament::getPanel('portal'));
+
+        return $customer;
+    }
+
+    public function test_teamed_customer_can_reach_create_page(): void
+    {
+        $this->actingTeamedCustomer();
+
+        $this->get('/portal/tickets/create')->assertOk();
+    }
+
+    public function test_teamless_customer_cannot_create(): void
+    {
+        $this->actingTeamlessCustomer();
+
+        $this->get('/portal/tickets/create')->assertForbidden();
+    }
+
+    public function test_customer_creates_ticket_with_server_set_fields_and_attachment(): void
+    {
+        Storage::fake('local');
+        $team = null;
+        $customer = $this->actingTeamedCustomer($team);
+        $file = UploadedFile::fake()->create('screenshot.png', 20, 'image/png');
+
+        Livewire::test(CreateTicket::class)
+            ->fillForm([
+                'subject' => 'Login broken',
+                'body' => 'Cannot log in since this morning.',
+                'priority' => 'high',
+                'attachment' => $file,
+            ])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        $ticket = Ticket::withoutGlobalScope('tenant')->where('subject', 'Login broken')->first();
+        $this->assertNotNull($ticket);
+        $this->assertSame($customer->id, $ticket->user_id);
+        $this->assertSame($team->id, $ticket->getAttribute('team_id'));
+        $this->assertSame('portal', $ticket->source);
+        $this->assertSame('open', $ticket->status);
+        $this->assertSame('high', $ticket->priority);
+        $this->assertStringStartsWith('portal-', $ticket->email_id);
+
+        $path = $ticket->getAttribute('attachment');
+        $this->assertNotNull($path);
+        Storage::disk('local')->assertExists($path);
+    }
+
+    public function test_creating_ticket_notifies_team_staff(): void
+    {
+        Storage::fake('local');
+        Notification::fake();
+        $team = null;
+        $staff = null;
+        $this->actingTeamedCustomer($team, $staff);
+
+        Livewire::test(CreateTicket::class)
+            ->fillForm([
+                'subject' => 'Billing question',
+                'body' => 'My invoice looks wrong.',
+                'priority' => 'medium',
+            ])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        Notification::assertSentTo($staff, CRMEventNotification::class);
+    }
+
+    public function test_owner_can_download_their_attachment(): void
+    {
+        Storage::fake('local');
+        $customer = $this->actingTeamlessCustomer();
+        Storage::disk('local')->put('ticket-attachments/note.png', 'binary');
+        $ticket = Ticket::factory()->create([
+            'user_id' => $customer->id,
+            'attachment' => 'ticket-attachments/note.png',
+        ]);
+
+        Livewire::test(ViewTicket::class, ['record' => $ticket->getKey()])
+            ->callAction('download_attachment')
+            ->assertFileDownloaded('note.png');
+    }
+}


### PR DESCRIPTION
Second slice of the **G_5 customer portal** epic (follows #480 view/reply). Spec: `docs/superpowers/specs/2026-07-07-g5-portal-ticket-create-design.md`.

## What
A customer can now **raise a support ticket** from the portal — subject, description, priority, and a file attachment — closing the support loop that #480 opened.

## How
- **Create page** on the portal `TicketResource`. `canCreate()` requires the customer's `current_team_id` (their tenant) — **team-less customers are blocked** (button hidden + create route 403s). Enforces the "require a team" decision: every portal ticket routes to a tenant, never staff-invisible.
- **Server-set, never client-supplied** (`mutateFormDataBeforeCreate`): `user_id`, `team_id` (= customer's tenant), `source='portal'`, `status='open'`, and a minted unique `email_id` (`portal-{uuid}` — the column is unique NOT NULL; email intake uses the mail message-id, the portal has none).
- **Attachment** — single file on the **private** `local` disk (never a public URL), mime + size validated on upload; path saved to a new nullable `tickets.attachment`. Retrieval via an ownership-scoped download action on the ViewTicket page (resource query already `user_id`-scoped → owner-only).
- **Staff notification** — new `App\Events\NewTicket` (mirrors `NewLead`, exposes `team()`) wired into the existing `SendCRMEventNotification` via a `new_ticket` config key. Dispatched in `afterCreate`; notifies `ticket.team->allUsers()` — the owning tenant's staff only (the #473 anti cross-tenant leak).

## Verification
- New `tests/Feature/Portal/CreatePortalTicketTest.php` — create-page access gate (both directions), server-set fields + attachment persisted, `NewTicket` notifies team staff, owner downloads own attachment. **5/5 green.**
- Full suite **810 passed / 1 skipped / 0 failed** (no regressions).
- **MySQL 8.4-verified** (attachment migration + create + notification); phpstan **0 new**; pint clean.

## Out of scope (later slices)
Multiple attachments, staff-side attachment display on the app panel, customer edit/close, ticket categories, rate-limiting, portal branding.