### PR TITLE
feat(portal): customer onboarding via staff invite (G_5)

### DIFF
--- a/app/Actions/Portal/InvitePortalCustomer.php
+++ b/app/Actions/Portal/InvitePortalCustomer.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Portal;
+
+use App\Enums\Role;
+use App\Exceptions\PortalOnboardingException;
+use App\Models\Contact;
+use App\Models\User;
+use App\Notifications\PortalInvitation;
+use Filament\Facades\Filament;
+use Illuminate\Auth\Passwords\PasswordBroker;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Password;
+use Illuminate\Support\Str;
+use Spatie\Permission\PermissionRegistrar;
+
+/**
+ * Provisions a Contact as a portal customer: a User with the global `customer`
+ * role, current_team_id = the contact's tenant (unblocks ticket creation), a
+ * verified email, and a portal password-reset link mailed so they can set a
+ * password and log in.
+ */
+class InvitePortalCustomer
+{
+    public function __invoke(Contact $contact): User
+    {
+        $email = $contact->getAttribute('email');
+        if (blank($email)) {
+            throw new PortalOnboardingException('This contact has no email address to invite.');
+        }
+
+        if ($this->emailBelongsToStaff($email)) {
+            throw new PortalOnboardingException('That email already belongs to a staff account.');
+        }
+
+        // Random password so the account cannot be logged into until the reset
+        // link is used; firstOrCreate keeps re-invites idempotent.
+        $user = User::firstOrCreate(
+            ['email' => $email],
+            [
+                'name' => $contact->getAttribute('name') ?: $email,
+                'password' => Hash::make(Str::random(40)),
+            ],
+        );
+
+        $user->forceFill([
+            'current_team_id' => $contact->getAttribute('team_id'),
+            'email_verified_at' => $user->email_verified_at ?? now(),
+        ])->save();
+
+        setPermissionsTeamId(null);
+        if (! $user->hasRole(Role::Customer)) {
+            $user->assignRole(Role::Customer->value);
+        }
+
+        /** @var PasswordBroker $broker */
+        $broker = Password::broker();
+        $token = $broker->createToken($user);
+        $url = Filament::getPanel('portal')->getResetPasswordUrl($token, $user);
+        $user->notify(new PortalInvitation($url));
+
+        return $user;
+    }
+
+    /**
+     * True when a user with this email already holds any role other than
+     * `customer` (in any team or globally) — a staff account we must never
+     * downgrade. Queried team-agnostically, mirroring User::hasGlobalRole.
+     */
+    private function emailBelongsToStaff(string $email): bool
+    {
+        $user = User::where('email', $email)->first();
+        if (! $user instanceof User) {
+            return false;
+        }
+
+        $tables = config('permission.table_names');
+        $morphKey = config('permission.column_names.model_morph_key');
+        $roleKey = app(PermissionRegistrar::class)->pivotRole;
+
+        return DB::table($tables['model_has_roles'])
+            ->join($tables['roles'], $tables['roles'].'.id', '=', $tables['model_has_roles'].'.'.$roleKey)
+            ->where($tables['model_has_roles'].'.model_type', $user->getMorphClass())
+            ->where($tables['model_has_roles'].'.'.$morphKey, $user->getKey())
+            ->where($tables['roles'].'.name', '!=', Role::Customer->value)
+            ->exists();
+    }
+}

--- a/app/Exceptions/PortalOnboardingException.php
+++ b/app/Exceptions/PortalOnboardingException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions;
+
+use RuntimeException;
+
+class PortalOnboardingException extends RuntimeException {}

--- a/app/Filament/App/Resources/ContactResource.php
+++ b/app/Filament/App/Resources/ContactResource.php
@@ -2,6 +2,8 @@
 
 namespace App\Filament\App\Resources;
 
+use App\Actions\Portal\InvitePortalCustomer;
+use App\Exceptions\PortalOnboardingException;
 use App\Filament\App\Resources\ContactResource\Pages\CreateContact;
 use App\Filament\App\Resources\ContactResource\Pages\EditContact;
 use App\Filament\App\Resources\ContactResource\Pages\ListContacts;
@@ -196,6 +198,19 @@ class ContactResource extends Resource
                             Notification::make()->title('Call initiated successfully')->success()->send();
                         } else {
                             Notification::make()->title('Failed to initiate call')->danger()->send();
+                        }
+                    }),
+                Action::make('inviteToPortal')
+                    ->label('Invite to portal')
+                    ->icon('heroicon-o-user-plus')
+                    ->visible(fn (Contact $record): bool => filled($record->email))
+                    ->requiresConfirmation()
+                    ->action(function (Contact $record, InvitePortalCustomer $invite): void {
+                        try {
+                            $invite($record);
+                            Notification::make()->title('Portal invitation sent')->success()->send();
+                        } catch (PortalOnboardingException $e) {
+                            Notification::make()->title('Could not invite')->body($e->getMessage())->danger()->send();
                         }
                     }),
             ])

--- a/app/Notifications/PortalInvitation.php
+++ b/app/Notifications/PortalInvitation.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class PortalInvitation extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(public string $url) {}
+
+    /** @return array<int, string> */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('You have been invited to the customer portal')
+            ->line('An account has been created for you on the customer portal.')
+            ->action('Set your password', $this->url)
+            ->line('If you did not expect this invitation, you can ignore this email.');
+    }
+}

--- a/app/Providers/Filament/PortalPanelProvider.php
+++ b/app/Providers/Filament/PortalPanelProvider.php
@@ -32,6 +32,7 @@ class PortalPanelProvider extends PanelProvider
             ->id('portal')
             ->path('portal')
             ->login()
+            ->passwordReset()
             ->colors([
                 'primary' => Color::Blue,
             ])

--- a/docs/superpowers/specs/2026-07-07-g5-portal-onboarding-design.md
+++ b/docs/superpowers/specs/2026-07-07-g5-portal-onboarding-design.md
@@ -1,0 +1,87 @@
+# G_5 slice 3 — Customer onboarding (design)
+
+**Date:** 2026-07-07
+**Status:** approved, implementing
+**Epic:** G_5 customer portal, slice 3. Slices 1–2 (#480/#481) shipped view/reply and ticket
+creation, but creation requires a `current_team_id` and portal login requires a password —
+neither of which an email-intake customer has. This slice provisions both.
+
+## Problem
+
+A portal customer is a `User` with the `customer` role, but nothing gives that user (a) a
+password to log in or (b) the `current_team_id` that ticket creation demands. Result: the
+portal is unusable for real customers. Onboarding closes both gaps in one staff-initiated
+flow.
+
+## Decisions (locked with user)
+
+1. **Staff invite from a Contact.** An "Invite to portal" action on the app-panel
+   `ContactResource`. The contact supplies email + name, and its `team_id` is the tenant the
+   customer belongs to (resolves routing).
+2. **Filament portal password-reset for the credential.** Enable `->passwordReset()` on the
+   portal panel; the invite emails a one-click portal reset link (Laravel's broker token +
+   `Panel::getResetPasswordUrl`). The customer sets their password on the built-in reset page,
+   then logs in.
+
+## Architecture
+
+### 1. `App\Actions\Portal\InvitePortalCustomer` (invoked by the Filament action)
+
+`__invoke(Contact $contact): User` — a testable unit holding all provisioning logic.
+
+- **Guard — no email:** contact without an email → `InvalidArgumentException` (surfaced as a
+  Filament notification by the action).
+- **Guard — no staff downgrade (trust boundary):** if a `User` with that email exists and
+  holds any non-`customer` role, refuse. Never convert a staff account into a customer.
+- **Provision:** `firstOrCreate` the User keyed on email (`name` from the contact, a **random**
+  password so the account cannot be logged into until reset). Set `current_team_id =
+  contact.team_id`, `email_verified_at = now()` (staff vouched + the reset link proves email
+  ownership; the portal expects a verified user). Assign the global `customer` role under
+  `setPermissionsTeamId(null)`.
+- **Send:** `$token = Password::broker()->createToken($user)`; `$url =
+  Filament::getPanel('portal')->getResetPasswordUrl($token, $user)`; `$user->notify(new
+  PortalInvitation($url))`.
+- **Idempotent:** re-inviting an existing customer re-sends the link.
+
+### 2. `App\Notifications\PortalInvitation`
+
+Mail channel. "You've been invited to the customer portal — set your password:" + the reset
+URL. Queued.
+
+### 3. Portal panel
+
+Add `->passwordReset()` to `PortalPanelProvider`. This registers the portal's own
+request/reset pages; the invite link lands directly on the reset page (token + email
+pre-filled).
+
+### 4. Trigger — `ContactResource` action
+
+An "Invite to portal" row action (app panel, staff, team-scoped). Calls
+`InvitePortalCustomer`; success/failure surfaced as a Filament notification. Visible only when
+the contact has an email.
+
+## Result
+
+Customer clicks the emailed link → sets a password on the portal reset page → logs in at
+`/portal` with email + password. Holding a `current_team_id`, they can raise tickets (slice 2)
+and see/reply to their own (slice 1).
+
+## Testing (TDD, PHPUnit + sqlite, then MySQL-verify)
+
+- `InvitePortalCustomer` provisions a customer from a contact: `customer` role,
+  `current_team_id` = contact's team, `email_verified_at` set, a non-empty password hash; and
+  sends `PortalInvitation` (`Notification::fake`).
+- **Guard:** an email already belonging to a staff user is refused; the staff user's roles are
+  untouched.
+- **Guard:** a contact with no email is refused.
+- **Re-invite:** a second invite of the same contact does not duplicate the user and re-sends.
+- **Filament action:** the `ContactResource` action invokes the provisioning (user created +
+  notified).
+- **Panel wiring:** `GET /portal/password-reset/request` → 200 (confirms `->passwordReset()`).
+- MySQL 8.4 verify; phpstan 0-new; pint clean.
+
+## Out of scope (later slices)
+
+Revoke/disable portal access, resend throttling UI, one customer across multiple tenants,
+self-registration, bulk invite, reset-email branding, tying the portal user back onto the
+Contact as a relation.

--- a/tests/Feature/Portal/PortalOnboardingTest.php
+++ b/tests/Feature/Portal/PortalOnboardingTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Portal;
+
+use App\Actions\Portal\InvitePortalCustomer;
+use App\Exceptions\PortalOnboardingException;
+use App\Filament\App\Resources\ContactResource\Pages\ListContacts;
+use App\Models\Contact;
+use App\Models\Team;
+use App\Models\User;
+use App\Notifications\PortalInvitation;
+use Database\Seeders\RolesSeeder;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class PortalOnboardingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolesSeeder::class);
+    }
+
+    private function contactFor(Team $team, ?string $email = 'customer@example.com'): Contact
+    {
+        return Contact::factory()->create([
+            'team_id' => $team->id,
+            'name' => 'Jane Customer',
+            'email' => $email,
+        ]);
+    }
+
+    public function test_invites_a_contact_as_portal_customer(): void
+    {
+        Notification::fake();
+        $team = Team::factory()->create();
+        $contact = $this->contactFor($team);
+
+        $user = app(InvitePortalCustomer::class)($contact);
+
+        $this->assertSame('customer@example.com', $user->email);
+        $this->assertSame($team->id, $user->getAttribute('current_team_id'));
+        $this->assertNotNull($user->email_verified_at);
+        $this->assertNotEmpty($user->password);
+
+        setPermissionsTeamId(null);
+        $this->assertTrue($user->fresh()->hasRole('customer'));
+
+        Notification::assertSentTo($user, PortalInvitation::class);
+    }
+
+    public function test_refuses_when_email_belongs_to_a_staff_user(): void
+    {
+        Notification::fake();
+        $team = Team::factory()->create();
+        $staff = User::factory()->create(['email' => 'customer@example.com']);
+        setPermissionsTeamId($team->id);
+        $staff->assignRole('manager');
+
+        $contact = $this->contactFor($team);
+
+        $this->expectException(PortalOnboardingException::class);
+        try {
+            app(InvitePortalCustomer::class)($contact);
+        } finally {
+            setPermissionsTeamId($team->id);
+            $this->assertTrue($staff->fresh()->hasRole('manager'));
+            $this->assertFalse($staff->fresh()->hasRole('customer'));
+            Notification::assertNothingSent();
+        }
+    }
+
+    public function test_refuses_a_contact_without_an_email(): void
+    {
+        // contacts.email is NOT NULL, so the real guard target is a blank email.
+        $team = Team::factory()->create();
+        $contact = $this->contactFor($team, '');
+
+        $this->expectException(PortalOnboardingException::class);
+        app(InvitePortalCustomer::class)($contact);
+    }
+
+    public function test_reinvite_does_not_duplicate_the_user(): void
+    {
+        Notification::fake();
+        $team = Team::factory()->create();
+        $contact = $this->contactFor($team);
+
+        $first = app(InvitePortalCustomer::class)($contact);
+        $second = app(InvitePortalCustomer::class)($contact);
+
+        $this->assertSame($first->id, $second->id);
+        $this->assertSame(1, User::where('email', 'customer@example.com')->count());
+        Notification::assertSentToTimes($first, PortalInvitation::class, 2);
+    }
+
+    public function test_portal_password_reset_route_is_available(): void
+    {
+        $this->get('/portal/password-reset/request')->assertOk();
+    }
+
+    public function test_contact_resource_action_invites_the_contact(): void
+    {
+        Notification::fake();
+        $staff = User::factory()->withPersonalTeam()->create(['email_verified_at' => now()]);
+        $team = $staff->currentTeam;
+        setPermissionsTeamId($team->id);
+        $staff->assignRole('manager');
+        $this->actingAs($staff);
+        Filament::setCurrentPanel(Filament::getPanel('app'));
+        Filament::setTenant($team);
+
+        $contact = $this->contactFor($team, 'lead@example.com');
+
+        Livewire::test(ListContacts::class)
+            ->callTableAction('inviteToPortal', $contact);
+
+        $user = User::where('email', 'lead@example.com')->first();
+        $this->assertNotNull($user);
+        $this->assertSame($team->id, $user->getAttribute('current_team_id'));
+        setPermissionsTeamId(null);
+        $this->assertTrue($user->hasRole('customer'));
+        Notification::assertSentTo($user, PortalInvitation::class);
+    }
+}


### PR DESCRIPTION
Third slice of the **G_5 customer portal** epic (follows #480 view/reply, #481 create). Spec: `docs/superpowers/specs/2026-07-07-g5-portal-onboarding-design.md`.

## Why
Slices 1–2 made the portal usable *in theory*, but a real customer had no way in: portal login is password-auth (email-intake customers have none) and ticket creation requires a `current_team_id` (customers had none). This slice provisions **both** in one staff-initiated flow.

## How
- **Invite from a Contact** — an "Invite to portal" action on the app-panel `ContactResource` (staff, team-scoped). Uses the contact's email/name and its `team_id`.
- **`App\Actions\Portal\InvitePortalCustomer`** (testable unit) provisions a `User`: global `customer` role, `current_team_id` = contact's tenant (**unblocks ticket creation**), `email_verified_at` set (staff vouched + the reset link proves ownership), a **random** password (account not loginable until reset). Idempotent via `firstOrCreate`.
- **Credential** — generates a Laravel broker token + the **portal** reset URL (`Panel::getResetPasswordUrl`) and mails a `PortalInvitation`. Portal panel gains `->passwordReset()` to host the set-password page. Customer clicks → sets password → logs in.
- **Guards (trust boundary)** — refuses if the email already belongs to a **staff** account (no privilege downgrade; staff roles untouched) or the contact has no email.

## Verification
- New `tests/Feature/Portal/PortalOnboardingTest.php` — provisioning, both guards, idempotent re-invite, the `ContactResource` action wiring, and the portal reset route. **6/6 green.**
- Full suite **816 passed / 1 skipped / 0 failed** (no regressions).
- **MySQL 8.4-verified** (17/17 portal tests); phpstan **0 new**; pint clean.

## Out of scope (later slices)
Revoke/disable portal access, resend throttling, one customer across multiple tenants, self-registration, bulk invite, reset-email branding.