### PR TITLE
feat(portal): knowledge-base browse with feedback (G_5)

### DIFF
--- a/app/Filament/Portal/Resources/KnowledgeBaseArticleResource.php
+++ b/app/Filament/Portal/Resources/KnowledgeBaseArticleResource.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Portal\Resources;
+
+use App\Filament\Portal\Resources\KnowledgeBaseArticleResource\Pages\ListArticles;
+use App\Filament\Portal\Resources\KnowledgeBaseArticleResource\Pages\ViewArticle;
+use App\Models\KnowledgeBaseArticle;
+use App\Models\User;
+use Filament\Actions\ViewAction;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Auth;
+
+class KnowledgeBaseArticleResource extends Resource
+{
+    protected static ?string $model = KnowledgeBaseArticle::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-book-open';
+
+    protected static ?string $navigationLabel = 'Knowledge base';
+
+    protected static ?string $slug = 'articles';
+
+    /**
+     * A customer sees only the published articles of their own tenant. Filament
+     * resolves table rows and single-record routes through this query, so an
+     * unpublished or other-team article id 404s.
+     */
+    #[\Override]
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->where('team_id', self::currentTeamId())
+            ->where('is_published', true);
+    }
+
+    #[\Override]
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+
+    #[\Override]
+    public static function form(Schema $schema): Schema
+    {
+        // Rendered read-only by the View page.
+        return $schema->components([
+            TextInput::make('title')->disabled(),
+            TextInput::make('category')->disabled(),
+            Textarea::make('content')->disabled()->rows(12)->columnSpanFull(),
+        ]);
+    }
+
+    #[\Override]
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('title')->searchable(),
+                TextColumn::make('category')->badge()->sortable(),
+                TextColumn::make('updated_at')->dateTime()->sortable(),
+            ])
+            ->filters([
+                SelectFilter::make('category')
+                    ->options(fn (): array => KnowledgeBaseArticle::query()
+                        ->where('team_id', self::currentTeamId())
+                        ->whereNotNull('category')
+                        ->distinct()
+                        ->pluck('category', 'category')
+                        ->all()),
+            ])
+            ->recordActions([
+                ViewAction::make(),
+            ])
+            ->defaultSort('title');
+    }
+
+    #[\Override]
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListArticles::route('/'),
+            'view' => ViewArticle::route('/{record}'),
+        ];
+    }
+
+    private static function currentTeamId(): ?int
+    {
+        $user = Auth::user();
+
+        return $user instanceof User ? $user->getAttribute('current_team_id') : null;
+    }
+}

--- a/app/Filament/Portal/Resources/KnowledgeBaseArticleResource/Pages/ListArticles.php
+++ b/app/Filament/Portal/Resources/KnowledgeBaseArticleResource/Pages/ListArticles.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Portal\Resources\KnowledgeBaseArticleResource\Pages;
+
+use App\Filament\Portal\Resources\KnowledgeBaseArticleResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListArticles extends ListRecords
+{
+    protected static string $resource = KnowledgeBaseArticleResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [];
+    }
+}

--- a/app/Filament/Portal/Resources/KnowledgeBaseArticleResource/Pages/ViewArticle.php
+++ b/app/Filament/Portal/Resources/KnowledgeBaseArticleResource/Pages/ViewArticle.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Portal\Resources\KnowledgeBaseArticleResource\Pages;
+
+use App\Filament\Portal\Resources\KnowledgeBaseArticleResource;
+use Filament\Actions\Action;
+use Filament\Notifications\Notification;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewArticle extends ViewRecord
+{
+    protected static string $resource = KnowledgeBaseArticleResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        // The record is already scoped to the customer's team + published, so
+        // feedback can only land on an article they may actually read.
+        // ponytail: votes aren't deduped per customer (no per-user vote table) —
+        // a later slice if abuse matters.
+        return [
+            Action::make('helpful')
+                ->label('Helpful')
+                ->icon('heroicon-o-hand-thumb-up')
+                ->color('success')
+                ->action(fn () => $this->recordFeedback('helpful_count')),
+            Action::make('not_helpful')
+                ->label('Not helpful')
+                ->icon('heroicon-o-hand-thumb-down')
+                ->color('gray')
+                ->action(fn () => $this->recordFeedback('not_helpful_count')),
+        ];
+    }
+
+    private function recordFeedback(string $column): void
+    {
+        $this->getRecord()->increment($column);
+
+        Notification::make()->title('Thanks for your feedback')->success()->send();
+    }
+}

--- a/app/Models/KnowledgeBaseArticle.php
+++ b/app/Models/KnowledgeBaseArticle.php
@@ -17,5 +17,12 @@ class KnowledgeBaseArticle extends Model
         'title',
         'content',
         'category',
+        'is_published',
+        'helpful_count',
+        'not_helpful_count',
+    ];
+
+    protected $casts = [
+        'is_published' => 'boolean',
     ];
 }

--- a/database/factories/KnowledgeBaseArticleFactory.php
+++ b/database/factories/KnowledgeBaseArticleFactory.php
@@ -12,26 +12,20 @@ class KnowledgeBaseArticleFactory extends Factory
 {
     protected $model = KnowledgeBaseArticle::class;
 
-    public function definition()
+    /** @return array<string, mixed> */
+    public function definition(): array
     {
+        // Only real columns — the table is title/content/category/team_id plus the
+        // portal fields added in 2026_07_07. The prior factory wrote ~10 phantom
+        // columns (slug/status/author_id/…) that do not exist and broke inserts.
         return [
             'team_id' => Team::factory(),
             'title' => $this->faker->sentence(),
-            'slug' => $this->faker->slug(),
             'content' => $this->faker->paragraphs(5, true),
-            'excerpt' => $this->faker->paragraph(),
             'category' => $this->faker->randomElement(['getting-started', 'features', 'troubleshooting', 'faq']),
-            'tags' => json_encode($this->faker->words(3)),
-            'author_id' => Team::factory(),
-            'status' => $this->faker->randomElement(['draft', 'published', 'archived']),
-            'published_at' => $this->faker->optional()->dateTimeThisYear(),
-            'view_count' => $this->faker->numberBetween(0, 10000),
-            'helpful_count' => $this->faker->numberBetween(0, 1000),
-            'not_helpful_count' => $this->faker->numberBetween(0, 100),
-            'meta_title' => $this->faker->optional()->sentence(),
-            'meta_description' => $this->faker->optional()->paragraph(),
-            'created_at' => now(),
-            'updated_at' => now(),
+            'is_published' => true,
+            'helpful_count' => 0,
+            'not_helpful_count' => 0,
         ];
     }
 }

--- a/database/migrations/2026_07_07_140000_add_portal_fields_to_knowledge_base_articles_table.php
+++ b/database/migrations/2026_07_07_140000_add_portal_fields_to_knowledge_base_articles_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('knowledge_base_articles', function (Blueprint $table): void {
+            if (! Schema::hasColumn('knowledge_base_articles', 'is_published')) {
+                // Default true so existing content stays visible; staff can hide
+                // an article from the portal without deleting it.
+                $table->boolean('is_published')->default(true)->after('category');
+            }
+            if (! Schema::hasColumn('knowledge_base_articles', 'helpful_count')) {
+                $table->unsignedInteger('helpful_count')->default(0)->after('is_published');
+            }
+            if (! Schema::hasColumn('knowledge_base_articles', 'not_helpful_count')) {
+                $table->unsignedInteger('not_helpful_count')->default(0)->after('helpful_count');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('knowledge_base_articles', function (Blueprint $table): void {
+            foreach (['is_published', 'helpful_count', 'not_helpful_count'] as $column) {
+                if (Schema::hasColumn('knowledge_base_articles', $column)) {
+                    $table->dropColumn($column);
+                }
+            }
+        });
+    }
+};

--- a/docs/superpowers/specs/2026-07-07-g5-portal-kb-design.md
+++ b/docs/superpowers/specs/2026-07-07-g5-portal-kb-design.md
@@ -1,0 +1,81 @@
+# G_5 slice 4 — Portal knowledge-base browse (design)
+
+**Date:** 2026-07-07
+**Status:** approved, implementing
+**Epic:** G_5 customer portal, slice 4. Adds customer self-help: browse and read the tenant's
+knowledge-base articles, with a publish gate and helpful/not-helpful feedback.
+
+## Problem
+
+Customers have no self-service reference — every question becomes a ticket. The
+`KnowledgeBaseArticle` model exists and is team-scoped (`IsTenantModel`), but there is no
+portal surface to read articles, no publish state (drafts would be customer-visible), and the
+factory is **broken** (writes ~10 columns the table lacks). A legacy public
+`KnowledgeBaseController` renders all articles globally with no tenancy or auth — untouched
+here.
+
+## Decisions (locked with user)
+
+1. **Publish gate:** add `is_published` (default true); the portal shows only published
+   articles. Staff can hide an article without deleting it; default true keeps existing content
+   visible.
+2. **Helpful feedback:** a "Helpful" / "Not helpful" action per article, incrementing counters.
+
+## Drift fix (required)
+
+The `knowledge_base_articles` table is only `title/content/category/team_id/timestamps`, but
+`KnowledgeBaseArticleFactory` writes `slug/excerpt/tags/author_id/status/published_at/
+view_count/meta_*`. This slice makes real **only the columns it needs** and strips the rest
+from the factory (YAGNI — those features aren't built).
+
+## Architecture
+
+### 1. Migration (guarded)
+
+Add to `knowledge_base_articles`: `is_published` (boolean, default `true`), `helpful_count`
+(unsigned int, default 0), `not_helpful_count` (unsigned int, default 0).
+
+### 2. Model
+
+Add `is_published`, `helpful_count`, `not_helpful_count` to `$fillable`; cast
+`is_published => bool`.
+
+### 3. Factory
+
+Strip to the real columns: `team_id`, `title`, `content`, `category`, `is_published`,
+`helpful_count`, `not_helpful_count`. (Fixes the broken factory.)
+
+### 4. Portal resource — `Filament\Portal\Resources\KnowledgeBaseArticleResource`
+
+Read-only (no create/edit/delete), slug `articles`, label "Knowledge base".
+
+- `getEloquentQuery()` → `where('team_id', <customer's current_team_id>)->where('is_published',
+  true)`. Filament resolves both table rows and single-record routes through this, so an
+  unpublished or other-team article id 404s.
+- **List:** title + category (badge); searchable on title/content; category `SelectFilter`.
+- **View page:** title + content, plus two header actions **"Helpful"** / **"Not helpful"**
+  that `increment('helpful_count')` / `increment('not_helpful_count')` on the scoped record and
+  show a thank-you notification.
+
+### 5. Scope
+
+Team-shared: every one of a tenant's customers sees the same published KB (unlike tickets,
+which are per-user). The portal panel is non-tenant, so the team filter is applied explicitly
+in the resource query.
+
+## Testing (TDD, PHPUnit + sqlite, then MySQL-verify)
+
+- **Only own-team published:** seed published + unpublished for the customer's team and a
+  published article for another team; the list shows only the own-team published one.
+- **Unpublished / foreign → 404:** viewing an unpublished or other-team article id is not found.
+- **Feedback:** "Helpful" increments `helpful_count`; "Not helpful" increments
+  `not_helpful_count`, on the scoped record.
+- **Index reachable:** a customer with a team can load the resource index.
+- MySQL 8.4 verify (migration + queries); phpstan 0-new; pint clean.
+
+## Out of scope / ceilings (stated)
+
+Repeated votes are not deduped (no per-user vote table — a later slice); rating totals aren't
+shown to customers; the legacy public `KnowledgeBaseController` is left as-is; slug/SEO/tags/
+author columns are not added; no staff KB-authoring UI (articles come from seeds/existing data
+or a future slice).

--- a/tests/Feature/Portal/PortalKnowledgeBaseTest.php
+++ b/tests/Feature/Portal/PortalKnowledgeBaseTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Portal;
+
+use App\Filament\Portal\Resources\KnowledgeBaseArticleResource\Pages\ListArticles;
+use App\Filament\Portal\Resources\KnowledgeBaseArticleResource\Pages\ViewArticle;
+use App\Models\KnowledgeBaseArticle;
+use App\Models\Team;
+use App\Models\User;
+use Database\Seeders\RolesSeeder;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class PortalKnowledgeBaseTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Team $team;
+
+    private function actingCustomer(): User
+    {
+        $this->seed(RolesSeeder::class);
+        $this->team = Team::factory()->create();
+        $customer = User::factory()->create(['email_verified_at' => now()]);
+        $customer->forceFill(['current_team_id' => $this->team->id])->save();
+        setPermissionsTeamId(null);
+        $customer->assignRole('customer');
+
+        $this->actingAs($customer);
+        Filament::setCurrentPanel(Filament::getPanel('portal'));
+
+        return $customer;
+    }
+
+    public function test_lists_only_own_team_published_articles(): void
+    {
+        $this->actingCustomer();
+        $mine = KnowledgeBaseArticle::factory()->create(['team_id' => $this->team->id, 'is_published' => true]);
+        $draft = KnowledgeBaseArticle::factory()->create(['team_id' => $this->team->id, 'is_published' => false]);
+        $otherTeam = KnowledgeBaseArticle::factory()->create(['is_published' => true]);
+
+        Livewire::test(ListArticles::class)
+            ->assertCanSeeTableRecords([$mine])
+            ->assertCanNotSeeTableRecords([$draft, $otherTeam]);
+    }
+
+    public function test_unpublished_or_foreign_article_is_not_found(): void
+    {
+        $this->actingCustomer();
+        $published = KnowledgeBaseArticle::factory()->create(['team_id' => $this->team->id, 'is_published' => true]);
+        $draft = KnowledgeBaseArticle::factory()->create(['team_id' => $this->team->id, 'is_published' => false]);
+        $foreign = KnowledgeBaseArticle::factory()->create(['is_published' => true]);
+
+        $this->get('/portal/articles/'.$published->id)->assertOk();
+        $this->get('/portal/articles/'.$draft->id)->assertNotFound();
+        $this->get('/portal/articles/'.$foreign->id)->assertNotFound();
+    }
+
+    public function test_helpful_action_increments_helpful_count(): void
+    {
+        $this->actingCustomer();
+        $article = KnowledgeBaseArticle::factory()->create([
+            'team_id' => $this->team->id,
+            'is_published' => true,
+            'helpful_count' => 4,
+        ]);
+
+        Livewire::test(ViewArticle::class, ['record' => $article->getKey()])
+            ->callAction('helpful');
+
+        $this->assertSame(5, (int) $article->fresh()->helpful_count);
+    }
+
+    public function test_not_helpful_action_increments_not_helpful_count(): void
+    {
+        $this->actingCustomer();
+        $article = KnowledgeBaseArticle::factory()->create([
+            'team_id' => $this->team->id,
+            'is_published' => true,
+            'not_helpful_count' => 1,
+        ]);
+
+        Livewire::test(ViewArticle::class, ['record' => $article->getKey()])
+            ->callAction('not_helpful');
+
+        $this->assertSame(2, (int) $article->fresh()->not_helpful_count);
+    }
+}


### PR DESCRIPTION
Fourth slice of the **G_5 customer portal** epic. Spec: `docs/superpowers/specs/2026-07-07-g5-portal-kb-design.md`.

## What
Portal customers can now **browse and read their tenant's knowledge-base articles** (self-help), with a publish gate and per-article helpful/not-helpful feedback.

## How
- **`Filament\Portal\Resources\KnowledgeBaseArticleResource`** (read-only, slug `articles`). `getEloquentQuery()` scopes both the list and single-record resolution to `team_id = customer.current_team_id AND is_published = true` — so an unpublished draft or another team's article id **404s**. Team-shared (every one of a tenant's customers sees the same KB), unlike per-user tickets.
- **List:** title + category badge, searchable, category filter (scoped to the team). **View page:** title/content + **Helpful / Not helpful** actions incrementing counters.
- **Publish gate:** new `is_published` column, default **true** (existing content visible; staff can hide without deleting).
- **Drift fix:** the `KnowledgeBaseArticleFactory` wrote ~10 columns the table never had (`slug/status/author_id/published_at/view_count/meta_*`) — it was broken. Stripped to the real columns; added only `is_published`, `helpful_count`, `not_helpful_count`.

## Verification
- New `tests/Feature/Portal/PortalKnowledgeBaseTest.php` — only own-team published listed, unpublished/foreign → 404, Helpful/Not-helpful increment the right counter. **4/4 green.**
- Full suite **820 passed / 1 skipped / 0 failed** (no regressions; factory fix clean).
- **MySQL 8.4-verified**; phpstan **0 new**; pint clean.

## Out of scope (ceilings)
Votes not deduped per customer (no per-user vote table), rating totals not shown to customers, legacy public `KnowledgeBaseController` untouched, no staff KB-authoring UI, no slug/SEO/tags columns.