### PR TITLE
feat(portal): customer document access (G_5)

### DIFF
--- a/app/Filament/Portal/Resources/DocumentResource.php
+++ b/app/Filament/Portal/Resources/DocumentResource.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Portal\Resources;
+
+use App\Filament\Portal\Resources\DocumentResource\Pages\ListDocuments;
+use App\Models\Contact;
+use App\Models\Document;
+use App\Models\User;
+use App\Services\DocumentService;
+use Filament\Actions\Action;
+use Filament\Resources\Resource;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Auth;
+
+class DocumentResource extends Resource
+{
+    protected static ?string $model = Document::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-document-text';
+
+    protected static ?string $navigationLabel = 'Documents';
+
+    protected static ?string $slug = 'documents';
+
+    /**
+     * A customer sees only the documents attached to their own Contact (matched
+     * by email + team via the onboarding link). Document is not IsTenantModel, so
+     * the team filter is applied explicitly. A null contact id yields zero rows.
+     */
+    #[\Override]
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->where('team_id', self::currentTeamId())
+            ->where('documentable_type', Contact::class)
+            ->where('documentable_id', self::customerContactId());
+    }
+
+    #[\Override]
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+
+    #[\Override]
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('name')->searchable(),
+                TextColumn::make('type')->badge(),
+                TextColumn::make('updated_at')->dateTime()->sortable(),
+            ])
+            ->recordActions([
+                Action::make('download')
+                    ->label('Download')
+                    ->icon('heroicon-o-arrow-down-tray')
+                    ->action(fn (Document $record, DocumentService $service) => $service->download($record)),
+            ])
+            ->defaultSort('updated_at', 'desc');
+    }
+
+    #[\Override]
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListDocuments::route('/'),
+        ];
+    }
+
+    private static function currentTeamId(): ?int
+    {
+        $user = Auth::user();
+
+        return $user instanceof User ? $user->getAttribute('current_team_id') : null;
+    }
+
+    private static function customerContactId(): ?int
+    {
+        $user = Auth::user();
+        if (! $user instanceof User) {
+            return null;
+        }
+
+        return Contact::query()
+            ->where('team_id', $user->getAttribute('current_team_id'))
+            ->where('email', $user->getAttribute('email'))
+            ->value('id');
+    }
+}

--- a/app/Filament/Portal/Resources/DocumentResource/Pages/ListDocuments.php
+++ b/app/Filament/Portal/Resources/DocumentResource/Pages/ListDocuments.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Portal\Resources\DocumentResource\Pages;
+
+use App\Filament\Portal\Resources\DocumentResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListDocuments extends ListRecords
+{
+    protected static string $resource = DocumentResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [];
+    }
+}

--- a/docs/superpowers/specs/2026-07-07-g5-portal-documents-design.md
+++ b/docs/superpowers/specs/2026-07-07-g5-portal-documents-design.md
@@ -1,0 +1,58 @@
+# G_5 slice 5 — Portal document access (design)
+
+**Date:** 2026-07-07
+**Status:** approved, implementing
+**Epic:** G_5 customer portal, slice 5. Lets a customer see and download the documents shared
+with them.
+
+## Problem / scope note
+
+The user asked for "quote/document access", but there is **no quote/proposal artifact** for
+customers — `QuoteRequest` is an inbound lead form (name/email/message). So this slice is
+**document access** only. A customer-received "quote" would need a new billing/proposal model
+(a separate epic).
+
+`Document` is polymorphic (`documentable` morphTo) and carries `team_id` but is **not**
+`IsTenantModel` (no auto-scope). `Contact` already has `documents()` (morphMany), and
+onboarding links a customer to a `Contact` by email + team. So "documents shared with me" =
+the documents attached to the customer's own Contact.
+
+## Decision (locked with user)
+
+**Scope to the customer's own Contact's documents** (leak-safe, per-customer). A customer never
+sees internal or other customers' files.
+
+## Architecture
+
+### Portal resource — `Filament\Portal\Resources\DocumentResource`
+
+Read-only, slug `documents`, index only (no create/edit/view/delete pages).
+
+- **Resolve the customer's contact:** `Contact` where `team_id = customer.current_team_id` and
+  `email = customer.email` → its id (null if none).
+- `getEloquentQuery()` → `where('team_id', <current_team_id>)
+  ->where('documentable_type', Contact::class)->where('documentable_id', <contactId>)`. A null
+  contact id yields zero rows (safe default). Filament resolves table rows through this, so a
+  row action can only ever act on the customer's own documents.
+- **List:** name/title, type (badge), size, updated_at. A **Download** row action that reuses
+  `DocumentService::download($record)` (same default disk + filename convention as the rest of
+  the app), streaming only the resolved (scoped) record.
+
+No `{record}` route is registered, so there is no direct-URL IDOR surface; the download action
+resolves through the scoped table query.
+
+## Testing (TDD, PHPUnit + sqlite, then MySQL-verify)
+
+- **Only own-contact documents:** a customer with a matching Contact sees documents attached to
+  that Contact; a document on another contact (same team) and a document on another team are
+  **not** listed.
+- **No matching contact → empty:** a customer whose email matches no contact sees nothing.
+- **Download:** the customer streams their own document (`Storage::fake` + a stored file →
+  `assertFileDownloaded`).
+- MySQL 8.4 verify; phpstan 0-new; pint clean.
+
+## Out of scope / ceilings (stated)
+
+No customer-received quotes/proposals (no such model); documents attached to a customer's Deals
+or Company are not shown (Contact only — the direct identity link); no upload from the portal;
+no per-document share toggle; email→contact match assumes one contact per email per team.

--- a/tests/Feature/Portal/PortalDocumentsTest.php
+++ b/tests/Feature/Portal/PortalDocumentsTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Portal;
+
+use App\Filament\Portal\Resources\DocumentResource\Pages\ListDocuments;
+use App\Models\Contact;
+use App\Models\Document;
+use App\Models\Team;
+use App\Models\User;
+use Database\Seeders\RolesSeeder;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class PortalDocumentsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Team $team;
+
+    private User $customer;
+
+    /** Signs in a customer whose email matches a Contact in their team; returns that Contact. */
+    private function actingCustomer(string $email = 'cust@example.com'): Contact
+    {
+        $this->seed(RolesSeeder::class);
+        $this->team = Team::factory()->create();
+        $this->customer = User::factory()->create(['email' => $email, 'email_verified_at' => now()]);
+        $this->customer->forceFill(['current_team_id' => $this->team->id])->save();
+        setPermissionsTeamId(null);
+        $this->customer->assignRole('customer');
+        $this->actingAs($this->customer);
+        Filament::setCurrentPanel(Filament::getPanel('portal'));
+
+        return Contact::factory()->create(['team_id' => $this->team->id, 'email' => $email]);
+    }
+
+    private function documentFor(Contact $contact, array $overrides = []): Document
+    {
+        return Document::factory()->create(array_merge([
+            'team_id' => $contact->team_id,
+            'documentable_type' => Contact::class,
+            'documentable_id' => $contact->id,
+        ], $overrides));
+    }
+
+    public function test_lists_only_own_contacts_documents(): void
+    {
+        $contact = $this->actingCustomer();
+        $mine = $this->documentFor($contact, ['name' => 'My contract']);
+
+        $otherContact = Contact::factory()->create(['team_id' => $this->team->id, 'email' => 'other@example.com']);
+        $otherDoc = $this->documentFor($otherContact, ['name' => 'Someone else']);
+
+        $foreignContact = Contact::factory()->create(); // different team
+        $foreignDoc = $this->documentFor($foreignContact, ['team_id' => $foreignContact->team_id]);
+
+        Livewire::test(ListDocuments::class)
+            ->assertCanSeeTableRecords([$mine])
+            ->assertCanNotSeeTableRecords([$otherDoc, $foreignDoc]);
+    }
+
+    public function test_customer_without_matching_contact_sees_nothing(): void
+    {
+        $contact = $this->actingCustomer();
+        $otherContact = Contact::factory()->create(['team_id' => $this->team->id, 'email' => 'x@example.com']);
+        $doc = $this->documentFor($otherContact);
+        $contact->delete(); // now no contact matches the customer's email
+
+        Livewire::test(ListDocuments::class)
+            ->assertCanNotSeeTableRecords([$doc]);
+    }
+
+    public function test_customer_downloads_own_document(): void
+    {
+        Storage::fake();
+        $contact = $this->actingCustomer();
+        $doc = $this->documentFor($contact, [
+            'file_path' => 'documents/contract.pdf',
+            'original_filename' => 'contract.pdf',
+        ]);
+        Storage::put('documents/contract.pdf', 'binary');
+
+        Livewire::test(ListDocuments::class)
+            ->callTableAction('download', $doc)
+            ->assertFileDownloaded('contract.pdf');
+    }
+}


### PR DESCRIPTION
Fifth slice of the **G_5 customer portal** epic. Spec: `docs/superpowers/specs/2026-07-07-g5-portal-documents-design.md`.

## Scope note
The ask was "quote/document access", but there is **no customer-facing quote/proposal model** (`QuoteRequest` is an inbound lead form). So this slice is **document access** only; a customer-received quote would need a new billing/proposal model (separate epic).

## What
Portal customers **view and download the documents shared with them** — the documents attached to their own `Contact`.

## How (leak-safe scoping)
- **`Filament\Portal\Resources\DocumentResource`** (read-only, slug `documents`, index only). `getEloquentQuery()` scopes to `team_id = customer's team AND documentable_type = Contact AND documentable_id = the customer's contact id` (the Contact matching the customer by email + team, via the onboarding link). A null contact match yields **zero rows** — so internal documents and other customers' files never appear.
- Reuses `Contact.documents()` (morphMany) — no new sharing model.
- **Download** row action reuses `DocumentService::download()` (same disk + filename convention as the rest of the app); resolves through the scoped table query, so no direct-URL IDOR (no `{record}` route).

## Verification
- New `tests/Feature/Portal/PortalDocumentsTest.php` — only own-contact documents listed (another contact's + another team's excluded), no-matching-contact → empty, owner download streams the file. **3/3 green.**
- Full suite **823 passed / 1 skipped / 0 failed** (no regressions).
- **MySQL 8.4-verified**; phpstan **0 new**; pint clean.

## Out of scope (ceilings)
No customer-received quotes/proposals (no model); documents on a customer's Deals/Company not shown (Contact only); no portal upload; no per-document share toggle; assumes one contact per email per team.