### PR TITLE
feat(portal): revoke customer portal access (G_5)

### DIFF
--- a/app/Actions/Portal/RevokePortalCustomer.php
+++ b/app/Actions/Portal/RevokePortalCustomer.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Portal;
+
+use App\Enums\Role;
+use App\Exceptions\PortalOnboardingException;
+use App\Models\Contact;
+use App\Support\PortalCustomer;
+
+/**
+ * Removes a customer's portal access by stripping the global `customer` role.
+ * canAccessPanel('portal') keys on that role, so access is denied on the next
+ * request. The User row, its team, and its tickets/documents are preserved;
+ * re-inviting restores access.
+ */
+class RevokePortalCustomer
+{
+    public function __invoke(Contact $contact): void
+    {
+        $user = PortalCustomer::forEmail($contact->getAttribute('email'));
+        if ($user === null) {
+            throw new PortalOnboardingException('This contact is not a portal customer.');
+        }
+
+        setPermissionsTeamId(null);
+        $user->removeRole(Role::Customer->value);
+    }
+}

--- a/app/Filament/App/Resources/ContactResource.php
+++ b/app/Filament/App/Resources/ContactResource.php
@@ -3,6 +3,7 @@
 namespace App\Filament\App\Resources;
 
 use App\Actions\Portal\InvitePortalCustomer;
+use App\Actions\Portal\RevokePortalCustomer;
 use App\Exceptions\PortalOnboardingException;
 use App\Filament\App\Resources\ContactResource\Pages\CreateContact;
 use App\Filament\App\Resources\ContactResource\Pages\EditContact;
@@ -10,6 +11,7 @@ use App\Filament\App\Resources\ContactResource\Pages\ListContacts;
 use App\Models\Company;
 use App\Models\Contact;
 use App\Services\TwilioService;
+use App\Support\PortalCustomer;
 use Filament\Actions\Action;
 use Filament\Actions\BulkAction;
 use Filament\Actions\DeleteBulkAction;
@@ -211,6 +213,20 @@ class ContactResource extends Resource
                             Notification::make()->title('Portal invitation sent')->success()->send();
                         } catch (PortalOnboardingException $e) {
                             Notification::make()->title('Could not invite')->body($e->getMessage())->danger()->send();
+                        }
+                    }),
+                Action::make('revokePortalAccess')
+                    ->label('Revoke portal access')
+                    ->icon('heroicon-o-user-minus')
+                    ->color('danger')
+                    ->visible(fn (Contact $record): bool => PortalCustomer::existsForEmail($record->email))
+                    ->requiresConfirmation()
+                    ->action(function (Contact $record, RevokePortalCustomer $revoke): void {
+                        try {
+                            $revoke($record);
+                            Notification::make()->title('Portal access revoked')->success()->send();
+                        } catch (PortalOnboardingException $e) {
+                            Notification::make()->title('Could not revoke')->body($e->getMessage())->danger()->send();
                         }
                     }),
             ])

--- a/app/Support/PortalCustomer.php
+++ b/app/Support/PortalCustomer.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use App\Enums\Role;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Spatie\Permission\PermissionRegistrar;
+
+/**
+ * Resolves whether an email is an active portal customer — i.e. a User holding
+ * the global (team_id = null) `customer` role. Queried directly so it never
+ * mutates the request's permission-team context (safe to call inside Filament
+ * action visibility closures during a tenant-scoped request).
+ */
+class PortalCustomer
+{
+    public static function forEmail(?string $email): ?User
+    {
+        if (blank($email)) {
+            return null;
+        }
+
+        $user = User::where('email', $email)->first();
+        if (! $user instanceof User) {
+            return null;
+        }
+
+        return self::hasGlobalCustomerRole($user) ? $user : null;
+    }
+
+    public static function existsForEmail(?string $email): bool
+    {
+        return self::forEmail($email) instanceof User;
+    }
+
+    private static function hasGlobalCustomerRole(User $user): bool
+    {
+        $tables = config('permission.table_names');
+        $morphKey = config('permission.column_names.model_morph_key');
+        $teamKey = config('permission.column_names.team_foreign_key');
+        $roleKey = app(PermissionRegistrar::class)->pivotRole;
+
+        return DB::table($tables['model_has_roles'])
+            ->join($tables['roles'], $tables['roles'].'.id', '=', $tables['model_has_roles'].'.'.$roleKey)
+            ->where($tables['model_has_roles'].'.model_type', $user->getMorphClass())
+            ->where($tables['model_has_roles'].'.'.$morphKey, $user->getKey())
+            ->whereNull($tables['model_has_roles'].'.'.$teamKey)
+            ->where($tables['roles'].'.name', Role::Customer->value)
+            ->exists();
+    }
+}

--- a/docs/superpowers/specs/2026-07-07-g5-portal-revoke-design.md
+++ b/docs/superpowers/specs/2026-07-07-g5-portal-revoke-design.md
@@ -1,0 +1,59 @@
+# G_5 slice 6 — Revoke portal access (design)
+
+**Date:** 2026-07-07
+**Status:** approved, implementing
+**Epic:** G_5 customer portal, slice 6. The admin complement to invite (#482): staff can take a
+customer's portal access away.
+
+## Problem
+
+Onboarding (#482) grants portal access by giving a `User` the global `customer` role. There is
+no way to take it back — a departed or abusive customer keeps access. Staff need a revoke.
+
+## Decision
+
+**Revoke = remove the global `customer` role.** `canAccessPanel('portal')` already keys on
+`hasRole(Customer)`, so removing the role denies portal access on the next request with no new
+gate. The `User` row, its `current_team_id`, and all its tickets/documents are preserved
+(revocation is not deletion); re-inviting (#482) restores access.
+
+## Architecture
+
+### 1. `App\Support\PortalCustomer` (shared helper)
+
+- `forEmail(?string $email): ?User` — the `User` with that email **iff** it holds a global
+  (`team_id = null`) `customer` role. Checked with a direct `model_has_roles` query (config-
+  driven, mirroring `InvitePortalCustomer::emailBelongsToStaff`) so it does **not** mutate the
+  request's permission-team context.
+- `existsForEmail(?string $email): bool`.
+
+### 2. `App\Actions\Portal\RevokePortalCustomer`
+
+`__invoke(Contact $contact): void`:
+- Resolve `PortalCustomer::forEmail($contact->email)`; if none, throw `PortalOnboardingException`
+  ("not a portal customer" — nothing to revoke).
+- `setPermissionsTeamId(null); $user->removeRole(Role::Customer->value)` (mirrors the invite
+  action's global-role handling).
+
+### 3. `ContactResource` action
+
+A **"Revoke portal access"** row action (app panel, staff), **visible only when**
+`PortalCustomer::existsForEmail($record->email)`. `requiresConfirmation`; catches
+`PortalOnboardingException` → notification. Additive — the "Invite to portal" action is left as
+is (so it still doubles as a resend), and revoke simply appears alongside for active customers.
+
+## Testing (TDD, PHPUnit + sqlite, then MySQL-verify)
+
+- **Revokes:** a provisioned portal customer loses the `customer` role; the `User` row and its
+  `current_team_id` remain.
+- **Locked out:** after revoke, the (former) customer gets 403 at `/portal/tickets`.
+- **Refuses non-customer:** a contact whose email maps to a staff user or no user →
+  `PortalOnboardingException`; that user's other roles are untouched.
+- **ContactResource action:** the revoke row action removes the role.
+- MySQL 8.4 verify; phpstan 0-new; pint clean.
+
+## Out of scope (ceilings)
+
+No audit log of revoke/invite events; an already-authenticated session is denied on its next
+panel request (not force-logged-out mid-session); no bulk revoke; no "disabled but role kept"
+state — revoke is role removal.

--- a/tests/Feature/Portal/PortalRevokeTest.php
+++ b/tests/Feature/Portal/PortalRevokeTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Portal;
+
+use App\Actions\Portal\InvitePortalCustomer;
+use App\Actions\Portal\RevokePortalCustomer;
+use App\Exceptions\PortalOnboardingException;
+use App\Filament\App\Resources\ContactResource\Pages\ListContacts;
+use App\Models\Contact;
+use App\Models\Team;
+use App\Models\User;
+use Database\Seeders\RolesSeeder;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class PortalRevokeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolesSeeder::class);
+    }
+
+    /**
+     * @return array{0: Contact, 1: User}
+     */
+    private function provision(Team $team, string $email = 'cust@example.com'): array
+    {
+        Notification::fake();
+        $contact = Contact::factory()->create(['team_id' => $team->id, 'email' => $email]);
+        $user = app(InvitePortalCustomer::class)($contact);
+
+        return [$contact, $user];
+    }
+
+    public function test_revokes_customer_role_but_keeps_user(): void
+    {
+        $team = Team::factory()->create();
+        [$contact, $user] = $this->provision($team);
+        setPermissionsTeamId(null);
+        $this->assertTrue($user->fresh()->hasRole('customer'));
+
+        app(RevokePortalCustomer::class)($contact);
+
+        setPermissionsTeamId(null);
+        $this->assertFalse($user->fresh()->hasRole('customer'));
+        $this->assertNotNull(User::find($user->id));
+        $this->assertSame($team->id, $user->fresh()->getAttribute('current_team_id'));
+    }
+
+    public function test_revoked_customer_cannot_access_portal(): void
+    {
+        $team = Team::factory()->create();
+        [$contact, $user] = $this->provision($team);
+
+        app(RevokePortalCustomer::class)($contact);
+
+        $this->actingAs($user->fresh());
+        Filament::setCurrentPanel(Filament::getPanel('portal'));
+        $this->get('/portal/tickets')->assertForbidden();
+    }
+
+    public function test_refuses_when_not_a_portal_customer(): void
+    {
+        $team = Team::factory()->create();
+        $staff = User::factory()->create(['email' => 'staff@example.com']);
+        setPermissionsTeamId($team->id);
+        $staff->assignRole('manager');
+        $contact = Contact::factory()->create(['team_id' => $team->id, 'email' => 'staff@example.com']);
+
+        $this->expectException(PortalOnboardingException::class);
+        try {
+            app(RevokePortalCustomer::class)($contact);
+        } finally {
+            setPermissionsTeamId($team->id);
+            $this->assertTrue($staff->fresh()->hasRole('manager'));
+        }
+    }
+
+    public function test_contact_resource_revoke_action(): void
+    {
+        $staff = User::factory()->withPersonalTeam()->create(['email_verified_at' => now()]);
+        $team = $staff->currentTeam;
+        setPermissionsTeamId($team->id);
+        $staff->assignRole('manager');
+        $this->actingAs($staff);
+        Filament::setCurrentPanel(Filament::getPanel('app'));
+        Filament::setTenant($team);
+
+        [$contact, $user] = $this->provision($team, 'lead@example.com');
+
+        Livewire::test(ListContacts::class)
+            ->callTableAction('revokePortalAccess', $contact);
+
+        setPermissionsTeamId(null);
+        $this->assertFalse($user->fresh()->hasRole('customer'));
+    }
+}


### PR DESCRIPTION
Sixth slice of the **G_5 customer portal** epic — the admin complement to invite (#482). Spec: `docs/superpowers/specs/2026-07-07-g5-portal-revoke-design.md`.

## What
Staff can **revoke a customer's portal access** from the app-panel `ContactResource`.

## How
- **Revoke = remove the global `customer` role.** `canAccessPanel('portal')` already keys on `hasRole(Customer)`, so access is denied on the next request — no new gate. The `User` row, its `current_team_id`, and all its tickets/documents are **preserved** (revocation ≠ deletion); re-inviting (#482) restores access.
- **`App\Actions\Portal\RevokePortalCustomer`** — resolves the portal customer for the contact's email and strips the role; refuses (typed exception) if the email isn't an active portal customer.
- **`App\Support\PortalCustomer`** — `forEmail` / `existsForEmail` resolve an active portal customer via a direct `model_has_roles` query, so it **never mutates the request's permission-team context** (safe inside Filament action-visibility closures during a tenant-scoped request).
- **`ContactResource`** — a "Revoke portal access" row action, visible only for active portal customers, `requiresConfirmation`. Additive: the invite action is untouched (still doubles as a resend).

## Verification
- New `tests/Feature/Portal/PortalRevokeTest.php` — role stripped but User/team preserved, revoked customer gets **403** at `/portal/tickets`, refuses a non-customer (staff role untouched), and the `ContactResource` action works. **4/4 green.**
- Full suite **827 passed / 1 skipped / 0 failed** (no regressions).
- **MySQL 8.4-verified**; phpstan **0 new**; pint clean.

## Out of scope (ceilings)
No audit log of invite/revoke; an active session is denied on its next request (not force-logged-out mid-session); no bulk revoke.