### PR TITLE
feat(portal): customer close/reopen ticket (G_5)

### DIFF
--- a/app/Filament/Portal/Resources/TicketResource/Pages/ViewTicket.php
+++ b/app/Filament/Portal/Resources/TicketResource/Pages/ViewTicket.php
@@ -21,6 +21,26 @@ class ViewTicket extends ViewRecord
     protected function getHeaderActions(): array
     {
         return [
+            // Owner-scoped lifecycle: the record resolves through the scoped
+            // resource query, so a customer only ever transitions their own ticket.
+            Action::make('close')
+                ->label('Close ticket')
+                ->icon('heroicon-o-check-circle')
+                ->color('gray')
+                ->visible(fn (): bool => $this->getRecord()->getAttribute('status') !== 'closed')
+                ->requiresConfirmation()
+                ->action(function (): void {
+                    $this->getRecord()->update(['status' => 'closed']);
+                    Notification::make()->title('Ticket closed')->success()->send();
+                }),
+            Action::make('reopen')
+                ->label('Reopen ticket')
+                ->icon('heroicon-o-arrow-path')
+                ->visible(fn (): bool => $this->getRecord()->getAttribute('status') === 'closed')
+                ->action(function (): void {
+                    $this->getRecord()->update(['status' => 'open']);
+                    Notification::make()->title('Ticket reopened')->success()->send();
+                }),
             // The record is already ownership-scoped (TicketResource::getEloquentQuery),
             // so a customer can only stream their own ticket's file, off the private disk.
             Action::make('download_attachment')

--- a/docs/superpowers/specs/2026-07-07-g5-portal-ticket-close-design.md
+++ b/docs/superpowers/specs/2026-07-07-g5-portal-ticket-close-design.md
@@ -1,0 +1,38 @@
+# G_5 slice 7 — Customer ticket close/reopen (design)
+
+**Date:** 2026-07-07
+**Status:** approved, implementing
+**Epic:** G_5 customer portal, slice 7. Gives the customer the resolve end of the ticket
+lifecycle: close a ticket they no longer need, and reopen it if the issue returns.
+
+## Problem
+
+A customer can create, view and reply to tickets (#480/#481) but cannot mark one resolved.
+Only staff can change status, so a customer's queue fills with tickets that are done.
+
+## Decision
+
+Two owner-scoped status transitions on the portal `ViewTicket` page:
+
+- **Close** — `status = 'closed'`, visible when the ticket is not already closed,
+  `requiresConfirmation`.
+- **Reopen** — `status = 'open'`, visible when the ticket is closed.
+
+Ownership is inherited: `ViewTicket` resolves its record through
+`TicketResource::getEloquentQuery()` (scoped `where user_id = auth id`), so a customer can only
+act on their own tickets — a foreign ticket id already 404s (#480). No new gate.
+
+## Out of scope / ceilings (stated)
+
+No staff notification on close/reopen (there is no ticket-status event; staff see the status in
+their queue); replying to a closed ticket does not auto-reopen it (the customer uses Reopen);
+closed tickets remain listed (the list is not status-filtered), which is intended so the
+customer can reopen.
+
+## Testing (TDD)
+
+- Customer closes an open ticket → `status = 'closed'`.
+- Customer reopens a closed ticket → `status = 'open'`.
+- (Ownership is inherited from #480's scoped record resolution — a foreign ticket view already
+  404s.)
+- MySQL 8.4 verify; phpstan 0-new; pint clean.

--- a/tests/Feature/Portal/PortalTicketLifecycleTest.php
+++ b/tests/Feature/Portal/PortalTicketLifecycleTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Portal;
+
+use App\Filament\Portal\Resources\TicketResource\Pages\ViewTicket;
+use App\Models\Ticket;
+use App\Models\User;
+use Database\Seeders\RolesSeeder;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class PortalTicketLifecycleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function actingCustomer(): User
+    {
+        $this->seed(RolesSeeder::class);
+        $customer = User::factory()->create(['email_verified_at' => now()]);
+        setPermissionsTeamId(null);
+        $customer->assignRole('customer');
+        $this->actingAs($customer);
+        Filament::setCurrentPanel(Filament::getPanel('portal'));
+
+        return $customer;
+    }
+
+    public function test_customer_closes_own_ticket(): void
+    {
+        $customer = $this->actingCustomer();
+        $ticket = Ticket::factory()->create(['user_id' => $customer->id, 'status' => 'open']);
+
+        Livewire::test(ViewTicket::class, ['record' => $ticket->getKey()])
+            ->callAction('close');
+
+        $this->assertSame('closed', $ticket->fresh()->status);
+    }
+
+    public function test_customer_reopens_closed_ticket(): void
+    {
+        $customer = $this->actingCustomer();
+        $ticket = Ticket::factory()->create(['user_id' => $customer->id, 'status' => 'closed']);
+
+        Livewire::test(ViewTicket::class, ['record' => $ticket->getKey()])
+            ->callAction('reopen');
+
+        $this->assertSame('open', $ticket->fresh()->status);
+    }
+}


### PR DESCRIPTION
Seventh slice of the **G_5 customer portal** epic. Spec: `docs/superpowers/specs/2026-07-07-g5-portal-ticket-close-design.md`.

## What
Customers get the resolve end of the ticket lifecycle: **close** a ticket they no longer need and **reopen** it if the issue returns — from the portal `ViewTicket` page.

## How
- **Close** — `status = 'closed'`, `requiresConfirmation`, hidden once already closed.
- **Reopen** — `status = 'open'`, shown only when the ticket is closed.
- **Ownership inherited** — `ViewTicket` resolves its record through `TicketResource::getEloquentQuery()` (scoped `where user_id = auth id`), so a customer only ever transitions their own tickets; a foreign ticket view already 404s (#480). No new gate.

## Verification
- New `tests/Feature/Portal/PortalTicketLifecycleTest.php` — customer closes an open ticket, reopens a closed one. **2/2 green.**
- Full suite **829 passed / 1 skipped / 0 failed** (no regressions).
- **MySQL 8.4-verified**; phpstan **0 new**; pint clean.

## Out of scope (ceilings)
No staff notification on close/reopen (no ticket-status event; staff see status in their queue); replying to a closed ticket does not auto-reopen it; closed tickets stay listed so the customer can reopen.