### PR TITLE
feat(portal): staff download of ticket attachments (G_5)

### DIFF
--- a/app/Filament/App/Resources/TicketResource.php
+++ b/app/Filament/App/Resources/TicketResource.php
@@ -24,6 +24,7 @@ use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Storage;
 
 class TicketResource extends Resource
 {
@@ -153,6 +154,13 @@ class TicketResource extends Resource
                     ]))
                     ->icon('heroicon-o-chat-bubble-left-right')
                     ->label('View Messages'),
+                Action::make('downloadAttachment')
+                    ->label('Attachment')
+                    ->icon('heroicon-o-paper-clip')
+                    // Shown only for portal-raised tickets that carry a customer
+                    // upload. Tenant scoping restricts staff to their team's tickets.
+                    ->visible(fn (Ticket $record): bool => filled($record->getAttribute('attachment')))
+                    ->action(fn (Ticket $record) => Storage::disk('local')->download($record->getAttribute('attachment'))),
             ])
             ->toolbarActions([
                 DeleteBulkAction::make(),

--- a/docs/superpowers/specs/2026-07-07-g5-staff-attachment-design.md
+++ b/docs/superpowers/specs/2026-07-07-g5-staff-attachment-design.md
@@ -1,0 +1,31 @@
+# G_5 slice 8 — Staff-side ticket attachment display (design)
+
+**Date:** 2026-07-07
+**Status:** approved, implementing
+**Epic:** G_5 customer portal, slice 8. Closes the loop on portal ticket attachments (#481):
+staff can now see and download the file a customer uploaded.
+
+## Problem
+
+Slice 2 (#481) lets a portal customer attach a file when raising a ticket (`tickets.attachment`,
+private `local` disk). But staff working the ticket on the app-panel `TicketResource` have no
+way to reach it — the attachment is write-only from the customer's side.
+
+## Decision
+
+Add a **Download attachment** row action to the app-panel `TicketResource`, visible only when
+the ticket carries an `attachment`, streaming the file off the private `local` disk (mirrors the
+portal-side download). Tenant scoping is inherited: the app panel is team-scoped, so staff only
+ever see/download their own team's tickets.
+
+## Testing (TDD)
+
+- A staff member (manager, in a team) can download a ticket's attachment via the row action
+  (`Storage::fake('local')` + a stored file → `assertFileDownloaded`).
+- (Tenancy is enforced by the app panel's existing team scope; not re-tested here.)
+- MySQL 8.4 verify; phpstan 0-new; pint clean.
+
+## Out of scope (ceilings)
+
+Single attachment only (matches #481); no inline preview; the attachment is not surfaced on the
+edit form, only as a download action; no separate access log.

--- a/tests/Feature/Filament/StaffTicketAttachmentTest.php
+++ b/tests/Feature/Filament/StaffTicketAttachmentTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament;
+
+use App\Filament\App\Resources\TicketResource\Pages\ListTickets;
+use App\Models\Ticket;
+use App\Models\User;
+use Database\Seeders\RolesSeeder;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class StaffTicketAttachmentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_staff_can_download_a_ticket_attachment(): void
+    {
+        $this->seed(RolesSeeder::class);
+        Storage::fake('local');
+
+        $staff = User::factory()->withPersonalTeam()->create(['email_verified_at' => now()]);
+        $team = $staff->currentTeam;
+        setPermissionsTeamId($team->id);
+        $staff->assignRole('manager');
+        $this->actingAs($staff);
+        Filament::setCurrentPanel(Filament::getPanel('app'));
+        Filament::setTenant($team);
+
+        Storage::disk('local')->put('ticket-attachments/report.pdf', 'binary');
+        $ticket = Ticket::factory()->create([
+            'team_id' => $team->id,
+            'attachment' => 'ticket-attachments/report.pdf',
+        ]);
+
+        Livewire::test(ListTickets::class)
+            ->callTableAction('downloadAttachment', $ticket)
+            ->assertFileDownloaded('report.pdf');
+    }
+}


### PR DESCRIPTION
Eighth slice of the **G_5 customer portal** epic — closes the loop on portal ticket attachments (#481). Spec: `docs/superpowers/specs/2026-07-07-g5-staff-attachment-design.md`.

## What
Staff working a ticket on the app-panel `TicketResource` can now **see and download the file a customer attached** when raising the ticket.

## How
- A **Download attachment** row action on the app `TicketResource`, visible only when the ticket carries an `attachment` (the `tickets.attachment` column from #481), streaming off the private `local` disk (mirrors the portal-side download).
- **Tenant-enforced** — the app panel is team-scoped, so staff only ever see/download their own team's tickets. No new gate.

## Verification
- New `tests/Feature/Filament/StaffTicketAttachmentTest.php` — a staff member downloads a ticket's attachment via the row action. **1/1 green.**
- Full suite **830 passed / 1 skipped / 0 failed** (no regressions).
- **MySQL 8.4-verified**; phpstan **0 new**; pint clean.

## Out of scope (ceilings)
Single attachment only (matches #481); no inline preview; surfaced as a download action, not on the edit form; no access log.