### PR TITLE
feat(portal): customer dashboard landing (G_5)

### DIFF
--- a/app/Filament/Portal/Widgets/PortalOverview.php
+++ b/app/Filament/Portal/Widgets/PortalOverview.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Portal\Widgets;
+
+use App\Filament\Portal\Resources\DocumentResource;
+use App\Filament\Portal\Resources\KnowledgeBaseArticleResource;
+use App\Filament\Portal\Resources\TicketResource;
+use Filament\Widgets\StatsOverviewWidget;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+
+/**
+ * Portal landing overview. Each stat reuses the matching resource's
+ * getEloquentQuery(), so the customer's scoping (tickets per-user, KB
+ * team+published, documents own-contact) is inherited from one source of truth
+ * — the counts can never show data the resource itself would hide.
+ */
+class PortalOverview extends StatsOverviewWidget
+{
+    protected function getStats(): array
+    {
+        return [
+            Stat::make('Open tickets', (string) TicketResource::getEloquentQuery()->where('status', '!=', 'closed')->count())
+                ->icon('heroicon-o-lifebuoy'),
+            Stat::make('Closed tickets', (string) TicketResource::getEloquentQuery()->where('status', 'closed')->count())
+                ->icon('heroicon-o-check-circle'),
+            Stat::make('Help articles', (string) KnowledgeBaseArticleResource::getEloquentQuery()->count())
+                ->icon('heroicon-o-book-open'),
+            Stat::make('Documents', (string) DocumentResource::getEloquentQuery()->count())
+                ->icon('heroicon-o-document-text'),
+        ];
+    }
+}

--- a/app/Providers/Filament/PortalPanelProvider.php
+++ b/app/Providers/Filament/PortalPanelProvider.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App\Providers\Filament;
 
+use App\Filament\Portal\Widgets\PortalOverview;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\DisableBladeIconComponents;
 use Filament\Http\Middleware\DispatchServingFilamentEvent;
+use Filament\Pages\Dashboard;
 use Filament\Panel;
 use Filament\PanelProvider;
 use Filament\Support\Colors\Color;
@@ -37,7 +39,12 @@ class PortalPanelProvider extends PanelProvider
                 'primary' => Color::Blue,
             ])
             ->discoverResources(in: app_path('Filament/Portal/Resources'), for: 'App\\Filament\\Portal\\Resources')
-            ->pages([])
+            ->pages([
+                Dashboard::class,
+            ])
+            ->widgets([
+                PortalOverview::class,
+            ])
             ->middleware([
                 EncryptCookies::class,
                 AddQueuedCookiesToResponse::class,

--- a/docs/superpowers/specs/2026-07-07-g5-portal-dashboard-design.md
+++ b/docs/superpowers/specs/2026-07-07-g5-portal-dashboard-design.md
@@ -1,0 +1,45 @@
+# G_5 slice 9 — Portal dashboard / landing (design)
+
+**Date:** 2026-07-07
+**Status:** approved, implementing
+**Epic:** G_5 customer portal, slice 9. Gives the portal a home page instead of dropping the
+customer straight into a bare resource list.
+
+## Problem
+
+The portal panel registers no pages (`->pages([])`), so `/portal` has no landing — the customer
+arrives at whichever resource Filament picks first, with no overview. There is no at-a-glance
+sense of "my open tickets / help / documents".
+
+## Decision
+
+Register Filament's default `Dashboard` as the portal landing, populated by a single
+**stats-overview widget** with four scoped counts:
+
+- **Open tickets** — the customer's non-closed tickets
+- **Closed tickets** — the customer's closed tickets
+- **Help articles** — published KB articles for their tenant
+- **Documents** — documents shared with them
+
+Each count **reuses the corresponding resource's `getEloquentQuery()`** (Ticket per-user, KB
+team+published, Document own-contact), so the dashboard inherits the exact, already-tested
+scoping — one source of truth, no new leak surface.
+
+## Architecture
+
+- `App\Filament\Portal\Widgets\PortalOverview` extends `StatsOverviewWidget`; `getStats()` builds
+  the four `Stat`s from the resource query builders.
+- `PortalPanelProvider`: `->pages([Dashboard::class])` + `->widgets([PortalOverview::class])`, so
+  `/portal` renders the dashboard with the overview.
+
+## Testing (TDD)
+
+- `/portal` (dashboard) loads for a customer (200).
+- The overview widget renders (labels present) and reflects the customer's scoped data — e.g.
+  with 3 open tickets for the customer and one for another user, the Open-tickets stat reads 3.
+- MySQL 8.4 verify; phpstan 0-new; pint clean.
+
+## Out of scope (ceilings)
+
+No recent-activity feed or charts; no per-resource deep links beyond the panel nav; counts are
+live (not cached); no personalised greeting beyond Filament defaults.

--- a/tests/Feature/Portal/PortalDashboardTest.php
+++ b/tests/Feature/Portal/PortalDashboardTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Portal;
+
+use App\Filament\Portal\Widgets\PortalOverview;
+use App\Models\Ticket;
+use App\Models\User;
+use Database\Seeders\RolesSeeder;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class PortalDashboardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function actingCustomer(): User
+    {
+        $this->seed(RolesSeeder::class);
+        $customer = User::factory()->create(['email_verified_at' => now()]);
+        setPermissionsTeamId(null);
+        $customer->assignRole('customer');
+        $this->actingAs($customer);
+        Filament::setCurrentPanel(Filament::getPanel('portal'));
+
+        return $customer;
+    }
+
+    public function test_dashboard_loads_for_customer(): void
+    {
+        $this->actingCustomer();
+
+        $this->get('/portal')->assertOk();
+    }
+
+    public function test_overview_widget_shows_scoped_counts(): void
+    {
+        $customer = $this->actingCustomer();
+        Ticket::factory()->count(3)->create(['user_id' => $customer->id, 'status' => 'open']);
+        Ticket::factory()->create(); // another user's ticket — must not be counted
+
+        Livewire::test(PortalOverview::class)
+            ->assertSee('Open tickets')
+            ->assertSee('Help articles')
+            ->assertSee('Documents')
+            ->assertSee('3');
+    }
+}


### PR DESCRIPTION
Ninth slice of the **G_5 customer portal** epic. Spec: `docs/superpowers/specs/2026-07-07-g5-portal-dashboard-design.md`.

## What
Gives the portal a **home page**. Previously `/portal` registered no pages and dropped the customer into a bare resource; now it lands on a dashboard with an at-a-glance overview.

## How
- **`PortalOverview`** stats-overview widget: **Open tickets**, **Closed tickets**, **Help articles**, **Documents**.
- Each count **reuses the matching resource's `getEloquentQuery()`** (Ticket per-user, KB team+published, Document own-contact), so the dashboard inherits the exact, already-tested scoping — one source of truth, no new leak surface.
- `PortalPanelProvider` registers Filament's `Dashboard` + the widget, so `/portal` renders the overview.

## Verification
- New `tests/Feature/Portal/PortalDashboardTest.php` — `/portal` loads for a customer, and the overview reflects scoped counts (3 own open tickets counted, another user's excluded). **2/2 green.**
- Full suite **832 passed / 1 skipped / 0 failed** (no regressions).
- **MySQL 8.4-verified**; phpstan **0 new**; pint clean.

## Out of scope (ceilings)
No activity feed/charts; counts are live (not cached); no personalised greeting beyond Filament defaults.