### PR TITLE
feat(portal): configurable branding + top navigation (G_5)

### DIFF
--- a/app/Filament/Portal/Widgets/PortalOverview.php
+++ b/app/Filament/Portal/Widgets/PortalOverview.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Portal\Widgets;
+
+use App\Filament\Portal\Resources\DocumentResource;
+use App\Filament\Portal\Resources\KnowledgeBaseArticleResource;
+use App\Filament\Portal\Resources\TicketResource;
+use Filament\Widgets\StatsOverviewWidget;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+
+/**
+ * Portal landing overview. Each stat reuses the matching resource's
+ * getEloquentQuery(), so the customer's scoping (tickets per-user, KB
+ * team+published, documents own-contact) is inherited from one source of truth
+ * — the counts can never show data the resource itself would hide.
+ */
+class PortalOverview extends StatsOverviewWidget
+{
+    protected function getStats(): array
+    {
+        return [
+            Stat::make('Open tickets', (string) TicketResource::getEloquentQuery()->where('status', '!=', 'closed')->count())
+                ->icon('heroicon-o-lifebuoy'),
+            Stat::make('Closed tickets', (string) TicketResource::getEloquentQuery()->where('status', 'closed')->count())
+                ->icon('heroicon-o-check-circle'),
+            Stat::make('Help articles', (string) KnowledgeBaseArticleResource::getEloquentQuery()->count())
+                ->icon('heroicon-o-book-open'),
+            Stat::make('Documents', (string) DocumentResource::getEloquentQuery()->count())
+                ->icon('heroicon-o-document-text'),
+        ];
+    }
+}

--- a/app/Providers/Filament/PortalPanelProvider.php
+++ b/app/Providers/Filament/PortalPanelProvider.php
@@ -35,6 +35,10 @@ class PortalPanelProvider extends PanelProvider
             ->path('portal')
             ->login()
             ->passwordReset()
+            // Customer-facing branding: a configurable name and top navigation so
+            // the portal reads as a product, not the staff admin chrome.
+            ->brandName(fn (): string => (string) config('portal.brand_name'))
+            ->topNavigation()
             ->colors([
                 'primary' => Color::Blue,
             ])

--- a/app/Providers/Filament/PortalPanelProvider.php
+++ b/app/Providers/Filament/PortalPanelProvider.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App\Providers\Filament;
 
+use App\Filament\Portal\Widgets\PortalOverview;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\DisableBladeIconComponents;
 use Filament\Http\Middleware\DispatchServingFilamentEvent;
+use Filament\Pages\Dashboard;
 use Filament\Panel;
 use Filament\PanelProvider;
 use Filament\Support\Colors\Color;
@@ -37,7 +39,12 @@ class PortalPanelProvider extends PanelProvider
                 'primary' => Color::Blue,
             ])
             ->discoverResources(in: app_path('Filament/Portal/Resources'), for: 'App\\Filament\\Portal\\Resources')
-            ->pages([])
+            ->pages([
+                Dashboard::class,
+            ])
+            ->widgets([
+                PortalOverview::class,
+            ])
             ->middleware([
                 EncryptCookies::class,
                 AddQueuedCookiesToResponse::class,

--- a/config/portal.php
+++ b/config/portal.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    /*
+    | The name shown in the customer portal's top bar. Override per deployment
+    | (white-labelling) via the PORTAL_BRAND_NAME env var.
+    */
+    'brand_name' => env('PORTAL_BRAND_NAME', 'Customer Portal'),
+];

--- a/docs/superpowers/specs/2026-07-07-g5-portal-branding-design.md
+++ b/docs/superpowers/specs/2026-07-07-g5-portal-branding-design.md
@@ -1,0 +1,42 @@
+# G_5 slice 10 — Portal branding / theming (design)
+
+**Date:** 2026-07-07
+**Status:** approved, implementing
+**Epic:** G_5 customer portal, slice 10. Makes the portal read as a customer product rather than
+the staff admin chrome. Stacks on the dashboard slice (#488).
+
+## Problem
+
+The portal reuses Filament's default admin look — a generic sidebar with the app name. Nothing
+signals to a customer that this is *their* support portal, and the brand can't be changed per
+deployment (white-labelling).
+
+## Decision
+
+Asset-free, config-driven branding on the panel:
+
+- **Brand name** — a configurable `config('portal.brand_name')` (env `PORTAL_BRAND_NAME`, default
+  "Customer Portal"), wired as a `brandName` **closure** so it re-reads at render (overridable at
+  runtime / per deployment).
+- **Top navigation** — `->topNavigation()` gives a horizontal product-style nav instead of the
+  admin sidebar.
+- Keep the existing Blue primary accent.
+
+No logo/favicon assets (those need real files — out of scope); no custom CSS build.
+
+## Architecture
+
+- `config/portal.php` → `brand_name`.
+- `PortalPanelProvider`: `->brandName(fn () => config('portal.brand_name'))->topNavigation()`.
+
+## Testing (TDD)
+
+- The portal renders the default brand name ("Customer Portal").
+- The brand name is configurable — setting `config(['portal.brand_name' => 'Acme Support'])` shows
+  "Acme Support" (proves the closure re-reads config).
+- MySQL 8.4 verify; phpstan 0-new; pint clean.
+
+## Out of scope (ceilings)
+
+No logo/favicon (asset files); no per-tenant branding (single deployment-level brand); no custom
+theme CSS/fonts; no dark-mode palette tuning.

--- a/docs/superpowers/specs/2026-07-07-g5-portal-dashboard-design.md
+++ b/docs/superpowers/specs/2026-07-07-g5-portal-dashboard-design.md
@@ -1,0 +1,45 @@
+# G_5 slice 9 — Portal dashboard / landing (design)
+
+**Date:** 2026-07-07
+**Status:** approved, implementing
+**Epic:** G_5 customer portal, slice 9. Gives the portal a home page instead of dropping the
+customer straight into a bare resource list.
+
+## Problem
+
+The portal panel registers no pages (`->pages([])`), so `/portal` has no landing — the customer
+arrives at whichever resource Filament picks first, with no overview. There is no at-a-glance
+sense of "my open tickets / help / documents".
+
+## Decision
+
+Register Filament's default `Dashboard` as the portal landing, populated by a single
+**stats-overview widget** with four scoped counts:
+
+- **Open tickets** — the customer's non-closed tickets
+- **Closed tickets** — the customer's closed tickets
+- **Help articles** — published KB articles for their tenant
+- **Documents** — documents shared with them
+
+Each count **reuses the corresponding resource's `getEloquentQuery()`** (Ticket per-user, KB
+team+published, Document own-contact), so the dashboard inherits the exact, already-tested
+scoping — one source of truth, no new leak surface.
+
+## Architecture
+
+- `App\Filament\Portal\Widgets\PortalOverview` extends `StatsOverviewWidget`; `getStats()` builds
+  the four `Stat`s from the resource query builders.
+- `PortalPanelProvider`: `->pages([Dashboard::class])` + `->widgets([PortalOverview::class])`, so
+  `/portal` renders the dashboard with the overview.
+
+## Testing (TDD)
+
+- `/portal` (dashboard) loads for a customer (200).
+- The overview widget renders (labels present) and reflects the customer's scoped data — e.g.
+  with 3 open tickets for the customer and one for another user, the Open-tickets stat reads 3.
+- MySQL 8.4 verify; phpstan 0-new; pint clean.
+
+## Out of scope (ceilings)
+
+No recent-activity feed or charts; no per-resource deep links beyond the panel nav; counts are
+live (not cached); no personalised greeting beyond Filament defaults.

--- a/tests/Feature/Portal/PortalBrandingTest.php
+++ b/tests/Feature/Portal/PortalBrandingTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Portal;
+
+use App\Models\User;
+use Database\Seeders\RolesSeeder;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PortalBrandingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function actingCustomer(): User
+    {
+        $this->seed(RolesSeeder::class);
+        $customer = User::factory()->create(['email_verified_at' => now()]);
+        setPermissionsTeamId(null);
+        $customer->assignRole('customer');
+        $this->actingAs($customer);
+        Filament::setCurrentPanel(Filament::getPanel('portal'));
+
+        return $customer;
+    }
+
+    public function test_portal_shows_default_brand_name(): void
+    {
+        $this->actingCustomer();
+
+        $this->get('/portal')->assertOk()->assertSee('Customer Portal');
+    }
+
+    public function test_brand_name_is_configurable(): void
+    {
+        $this->actingCustomer();
+        config(['portal.brand_name' => 'Acme Support']);
+
+        $this->get('/portal')->assertSee('Acme Support');
+    }
+}

--- a/tests/Feature/Portal/PortalDashboardTest.php
+++ b/tests/Feature/Portal/PortalDashboardTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Portal;
+
+use App\Filament\Portal\Widgets\PortalOverview;
+use App\Models\Ticket;
+use App\Models\User;
+use Database\Seeders\RolesSeeder;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class PortalDashboardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function actingCustomer(): User
+    {
+        $this->seed(RolesSeeder::class);
+        $customer = User::factory()->create(['email_verified_at' => now()]);
+        setPermissionsTeamId(null);
+        $customer->assignRole('customer');
+        $this->actingAs($customer);
+        Filament::setCurrentPanel(Filament::getPanel('portal'));
+
+        return $customer;
+    }
+
+    public function test_dashboard_loads_for_customer(): void
+    {
+        $this->actingCustomer();
+
+        $this->get('/portal')->assertOk();
+    }
+
+    public function test_overview_widget_shows_scoped_counts(): void
+    {
+        $customer = $this->actingCustomer();
+        Ticket::factory()->count(3)->create(['user_id' => $customer->id, 'status' => 'open']);
+        Ticket::factory()->create(); // another user's ticket — must not be counted
+
+        Livewire::test(PortalOverview::class)
+            ->assertSee('Open tickets')
+            ->assertSee('Help articles')
+            ->assertSee('Documents')
+            ->assertSee('3');
+    }
+}


### PR DESCRIPTION
Tenth slice of the **G_5 customer portal** epic. Spec: `docs/superpowers/specs/2026-07-07-g5-portal-branding-design.md`.

> ⚠️ **Stacked on #488** (portal dashboard). This branch was cut from `feat/g5-portal-dashboard` because both edit `PortalPanelProvider`; until #488 merges, this PR's diff also shows the dashboard commits. **Merge #488 first**, then this diff reduces to the branding change alone.

## What
Makes the portal read as a customer product rather than staff admin chrome — asset-free, config-driven.

## How
- **Brand name** — `config('portal.brand_name')` (env `PORTAL_BRAND_NAME`, default "Customer Portal"), wired as a `brandName` **closure** so it re-reads at render (runtime / per-deployment white-labelling).
- **Top navigation** — `->topNavigation()` gives a horizontal product-style nav instead of the admin sidebar.
- Keeps the Blue primary accent.

## Verification
- New `tests/Feature/Portal/PortalBrandingTest.php` — default brand name renders; brand name is configurable (closure re-reads config). **2/2 green.**
- Full suite **834 passed / 1 skipped / 0 failed** (includes #488's dashboard tests; no regressions).
- **MySQL 8.4-verified**; phpstan **0 new**; pint clean.

## Out of scope (ceilings)
No logo/favicon (asset files); no per-tenant branding (deployment-level); no custom theme CSS/fonts; no dark-mode palette tuning.