### PR TITLE
feat(portal): audit invite/revoke of portal access (G_5)

### DIFF
--- a/app/Actions/Portal/InvitePortalCustomer.php
+++ b/app/Actions/Portal/InvitePortalCustomer.php
@@ -9,6 +9,7 @@ use App\Exceptions\PortalOnboardingException;
 use App\Models\Contact;
 use App\Models\User;
 use App\Notifications\PortalInvitation;
+use App\Services\AuditLogService;
 use Filament\Facades\Filament;
 use Illuminate\Auth\Passwords\PasswordBroker;
 use Illuminate\Support\Facades\DB;
@@ -25,6 +26,8 @@ use Spatie\Permission\PermissionRegistrar;
  */
 class InvitePortalCustomer
 {
+    public function __construct(private readonly AuditLogService $audit) {}
+
     public function __invoke(Contact $contact): User
     {
         $email = $contact->getAttribute('email');
@@ -61,6 +64,8 @@ class InvitePortalCustomer
         $token = $broker->createToken($user);
         $url = Filament::getPanel('portal')->getResetPasswordUrl($token, $user);
         $user->notify(new PortalInvitation($url));
+
+        $this->audit->record('portal.invited', "Invited {$email} to the customer portal.", $user);
 
         return $user;
     }

--- a/app/Actions/Portal/RevokePortalCustomer.php
+++ b/app/Actions/Portal/RevokePortalCustomer.php
@@ -7,6 +7,7 @@ namespace App\Actions\Portal;
 use App\Enums\Role;
 use App\Exceptions\PortalOnboardingException;
 use App\Models\Contact;
+use App\Services\AuditLogService;
 use App\Support\PortalCustomer;
 
 /**
@@ -17,6 +18,8 @@ use App\Support\PortalCustomer;
  */
 class RevokePortalCustomer
 {
+    public function __construct(private readonly AuditLogService $audit) {}
+
     public function __invoke(Contact $contact): void
     {
         $user = PortalCustomer::forEmail($contact->getAttribute('email'));
@@ -26,5 +29,8 @@ class RevokePortalCustomer
 
         setPermissionsTeamId(null);
         $user->removeRole(Role::Customer->value);
+
+        $email = $user->getAttribute('email');
+        $this->audit->record('portal.revoked', "Revoked portal access for {$email}.", $user);
     }
 }

--- a/app/Services/AuditLogService.php
+++ b/app/Services/AuditLogService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Models\AuditLog;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Auth;
 
 class AuditLogService
@@ -14,6 +15,28 @@ class AuditLogService
             'action' => $action,
             'description' => $description,
             'ip_address' => request()->ip(),
+        ]);
+    }
+
+    /**
+     * Record an attributable action against an optional subject. Skipped when
+     * there is no authenticated actor (audit_logs.user_id is NOT NULL and an
+     * unattributable entry has no compliance value). team_id is stamped by
+     * AuditLog's IsTenantModel hook from the active tenant.
+     */
+    public function record(string $action, string $description, ?Model $auditable = null): void
+    {
+        if (! Auth::check()) {
+            return;
+        }
+
+        AuditLog::create([
+            'user_id' => Auth::id(),
+            'action' => $action,
+            'description' => $description,
+            'ip_address' => request()->ip() ?? '0.0.0.0',
+            'auditable_type' => $auditable?->getMorphClass(),
+            'auditable_id' => $auditable?->getKey(),
         ]);
     }
 }

--- a/docs/superpowers/specs/2026-07-07-g5-portal-audit-design.md
+++ b/docs/superpowers/specs/2026-07-07-g5-portal-audit-design.md
@@ -1,0 +1,48 @@
+# G_5 slice 11 — Invite/revoke audit log (design)
+
+**Date:** 2026-07-07
+**Status:** approved, implementing
+**Epic:** G_5 customer portal, slice 11. A compliance trail for who granted or removed a
+customer's portal access, and when.
+
+## Problem
+
+Onboarding (#482) and revoke (#485) change a person's access to tenant data, but leave no
+record — there's no way to answer "who invited this customer?" or "when was access revoked?".
+
+## Decision
+
+Reuse the existing `AuditLog` model / `audit_logs` table (no new table). Record an entry on each
+invite and revoke: the acting staff user, an action code, a description, and the affected
+customer as the polymorphic `auditable`.
+
+## Architecture
+
+- **`AuditLogService::record(action, description, ?auditable)`** — a richer companion to the
+  existing thin `log()`. Sets `user_id = Auth::id()`, the action/description/ip, and the
+  `auditable` morph. **Skipped when there is no authenticated actor** (`audit_logs.user_id` is
+  NOT NULL and an unattributable entry has no compliance value). `team_id` is stamped by
+  `AuditLog`'s `IsTenantModel` hook from the active tenant.
+- **`InvitePortalCustomer`** — after provisioning + mailing the link, records
+  `portal.invited` against the new customer User.
+- **`RevokePortalCustomer`** — after stripping the role, records `portal.revoked` against the
+  User.
+- Both actions gain a constructor-injected `AuditLogService`.
+
+The Filament invite/revoke actions run authenticated (staff), so entries are always attributed
+there; direct/console invocations without an actor simply skip the log.
+
+## Testing (TDD)
+
+- Inviting (as a staff actor) writes an `audit_logs` row: `action = portal.invited`, `user_id =`
+  the staff, `auditable` = the customer.
+- Revoking writes `action = portal.revoked` against the customer.
+- With no authenticated actor, no entry is written (guard holds; existing #482 unit tests that
+  call the action without `actingAs` stay green).
+- MySQL 8.4 verify; phpstan 0-new; pint clean.
+
+## Out of scope (ceilings)
+
+No admin UI to browse the portal audit trail (the entries live in `audit_logs`, viewable by
+whatever reads that table); no diff/`changes` payload (the action codes carry the meaning); no
+audit of login/logout or ticket actions (this slice covers access grant/revoke only).

--- a/tests/Feature/Portal/PortalAuditTest.php
+++ b/tests/Feature/Portal/PortalAuditTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Portal;
+
+use App\Actions\Portal\InvitePortalCustomer;
+use App\Actions\Portal\RevokePortalCustomer;
+use App\Models\Contact;
+use App\Models\Team;
+use App\Models\User;
+use Database\Seeders\RolesSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Tests\TestCase;
+
+class PortalAuditTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolesSeeder::class);
+        Notification::fake();
+    }
+
+    private function actingStaff(Team $team): User
+    {
+        $staff = User::factory()->create(['email_verified_at' => now()]);
+        setPermissionsTeamId($team->id);
+        $staff->assignRole('manager');
+        $this->actingAs($staff);
+
+        return $staff;
+    }
+
+    public function test_invite_writes_an_audit_entry(): void
+    {
+        $team = Team::factory()->create();
+        $staff = $this->actingStaff($team);
+        $contact = Contact::factory()->create(['team_id' => $team->id, 'email' => 'c@example.com']);
+
+        $customer = app(InvitePortalCustomer::class)($contact);
+
+        $this->assertDatabaseHas('audit_logs', [
+            'user_id' => $staff->id,
+            'action' => 'portal.invited',
+            'auditable_type' => $customer->getMorphClass(),
+            'auditable_id' => $customer->id,
+        ]);
+    }
+
+    public function test_revoke_writes_an_audit_entry(): void
+    {
+        $team = Team::factory()->create();
+        $staff = $this->actingStaff($team);
+        $contact = Contact::factory()->create(['team_id' => $team->id, 'email' => 'c@example.com']);
+        $customer = app(InvitePortalCustomer::class)($contact);
+
+        app(RevokePortalCustomer::class)($contact);
+
+        $this->assertDatabaseHas('audit_logs', [
+            'user_id' => $staff->id,
+            'action' => 'portal.revoked',
+            'auditable_id' => $customer->id,
+        ]);
+    }
+
+    public function test_no_audit_entry_without_an_actor(): void
+    {
+        $team = Team::factory()->create();
+        $contact = Contact::factory()->create(['team_id' => $team->id, 'email' => 'c@example.com']);
+
+        // No actingAs — Auth::check() is false, so the entry is skipped.
+        app(InvitePortalCustomer::class)($contact);
+
+        $this->assertDatabaseMissing('audit_logs', ['action' => 'portal.invited']);
+    }
+}


### PR DESCRIPTION
Eleventh slice of the **G_5 customer portal** epic — a compliance trail for portal-access changes. Spec: `docs/superpowers/specs/2026-07-07-g5-portal-audit-design.md`.

## What
Records who granted or removed a customer's portal access, and when — closing the audit gap left by invite (#482) and revoke (#485).

## How
- **Reuses the existing `AuditLog` table** (no new table). `AuditLogService::record(action, description, ?auditable)` — a richer companion to the thin `log()`: sets `user_id = Auth::id()`, action/description/ip, and the affected customer as the `auditable` morph. **Skipped when there's no authenticated actor** (`audit_logs.user_id` is NOT NULL; an unattributable entry has no compliance value). `team_id` is stamped by `AuditLog`'s `IsTenantModel` hook.
- **`InvitePortalCustomer`** logs `portal.invited`; **`RevokePortalCustomer`** logs `portal.revoked` — both against the customer User, via a constructor-injected service.

## Verification
- New `tests/Feature/Portal/PortalAuditTest.php` — invite writes `portal.invited` (attributed to the staff actor, auditable = customer), revoke writes `portal.revoked`, and no entry is written without an actor. **3/3 green.**
- Full suite **837 passed / 1 skipped / 0 failed** (existing #482/#485 action tests intact).
- **MySQL 8.4-verified**; phpstan **0 new**; pint clean.

## Out of scope (ceilings)
No admin UI to browse the trail (entries live in `audit_logs`); no `changes` diff payload (action codes carry the meaning); covers access grant/revoke only, not login or ticket actions.