### PR TITLE
feat(portal): team-scoped portal access-log resource (G_5)

### DIFF
--- a/app/Filament/App/Resources/PortalAccessLogResource.php
+++ b/app/Filament/App/Resources/PortalAccessLogResource.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\App\Resources;
+
+use App\Enums\Role;
+use App\Filament\App\Resources\PortalAccessLogResource\Pages\ListPortalAccessLogs;
+use App\Models\AuditLog;
+use App\Models\User;
+use Filament\Resources\Resource;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Auth;
+
+/**
+ * Team-scoped, read-only view of portal access grants/revocations (the
+ * `portal.*` audit entries from #490). AuditLog is IsTenantModel, so on the
+ * team-scoped app panel this shows only the current team's history — letting a
+ * team's own managers see who invited or revoked their customers (the admin
+ * panel's AuditLogResource is super_admin/global).
+ */
+class PortalAccessLogResource extends Resource
+{
+    protected static ?string $model = AuditLog::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-clipboard-document-list';
+
+    protected static string|\UnitEnum|null $navigationGroup = 'Help Desk';
+
+    protected static ?string $navigationLabel = 'Portal access log';
+
+    protected static ?string $slug = 'portal-access-log';
+
+    public static function canAccess(): bool
+    {
+        $user = Auth::user();
+
+        return $user instanceof User && $user->hasRole([Role::SuperAdmin, Role::Admin, Role::Manager]);
+    }
+
+    #[\Override]
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+
+    #[\Override]
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()->where('action', 'like', 'portal.%');
+    }
+
+    #[\Override]
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('created_at')->dateTime()->sortable(),
+                TextColumn::make('user.name')->label('By')->searchable(),
+                TextColumn::make('action')->badge(),
+                TextColumn::make('description')->wrap()->searchable(),
+            ])
+            ->defaultSort('created_at', 'desc');
+    }
+
+    #[\Override]
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListPortalAccessLogs::route('/'),
+        ];
+    }
+}

--- a/app/Filament/App/Resources/PortalAccessLogResource/Pages/ListPortalAccessLogs.php
+++ b/app/Filament/App/Resources/PortalAccessLogResource/Pages/ListPortalAccessLogs.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\App\Resources\PortalAccessLogResource\Pages;
+
+use App\Filament\App\Resources\PortalAccessLogResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListPortalAccessLogs extends ListRecords
+{
+    protected static string $resource = PortalAccessLogResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [];
+    }
+}

--- a/docs/superpowers/specs/2026-07-07-g5-portal-audit-ui-design.md
+++ b/docs/superpowers/specs/2026-07-07-g5-portal-audit-ui-design.md
@@ -1,0 +1,41 @@
+# G_5 slice 12 — Browse the portal audit trail (design)
+
+**Date:** 2026-07-07
+**Status:** approved, implementing
+**Epic:** G_5 customer portal, slice 12. Surfaces the `portal.*` audit entries (#490) to the
+team's own staff.
+
+## Problem
+
+Invite/revoke now write audit entries (#490), but the only place to read them is the **admin**
+panel's `AuditLogResource` — super_admin, global. A team's own managers can't see who invited or
+revoked *their* customers.
+
+## Decision
+
+A team-scoped, read-only **`PortalAccessLogResource`** on the **app** panel. `AuditLog` is
+`IsTenantModel`, so on the tenant-scoped app panel it already filters to the current team; the
+resource additionally narrows to `action like 'portal.%'` so it shows only portal grants/revokes,
+not unrelated audit noise.
+
+## Architecture
+
+- `App\Filament\App\Resources\PortalAccessLogResource` over `AuditLog`, list-only, read-only
+  (`canCreate = false`, no create/edit/delete/view pages).
+- `getEloquentQuery()` → `parent()->where('action', 'like', 'portal.%')` (parent applies the
+  IsTenantModel team scope).
+- `canAccess()` gates to management roles (`super_admin` / `admin` / `manager`) — the same people
+  who manage access; sales_rep / free / customer are denied.
+- Columns: timestamp, actor (`user.name`), action badge, description.
+
+## Testing (TDD)
+
+- A manager sees their team's `portal.invited` / `portal.revoked` entries; a non-portal action
+  (`login`) and another team's portal entry are excluded.
+- `canAccess()` is true for a manager, false for a sales_rep.
+- MySQL 8.4 verify; phpstan 0-new; pint clean.
+
+## Out of scope (ceilings)
+
+No per-entry detail/diff view (list only); no export; covers `portal.*` actions only; the
+super_admin global view remains the admin `AuditLogResource`.

--- a/tests/Feature/Filament/PortalAccessLogResourceTest.php
+++ b/tests/Feature/Filament/PortalAccessLogResourceTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament;
+
+use App\Filament\App\Resources\PortalAccessLogResource;
+use App\Filament\App\Resources\PortalAccessLogResource\Pages\ListPortalAccessLogs;
+use App\Models\AuditLog;
+use App\Models\Team;
+use App\Models\User;
+use Database\Seeders\RolesSeeder;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class PortalAccessLogResourceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolesSeeder::class);
+    }
+
+    private function entry(string $action, int $teamId, int $userId): AuditLog
+    {
+        return AuditLog::create([
+            'user_id' => $userId,
+            'action' => $action,
+            'description' => $action.' entry',
+            'ip_address' => '127.0.0.1',
+            'team_id' => $teamId,
+        ]);
+    }
+
+    public function test_lists_only_own_team_portal_entries(): void
+    {
+        $manager = User::factory()->withPersonalTeam()->create(['email_verified_at' => now()]);
+        $team = $manager->currentTeam;
+        setPermissionsTeamId($team->id);
+        $manager->assignRole('manager');
+        $this->actingAs($manager);
+        Filament::setCurrentPanel(Filament::getPanel('app'));
+        Filament::setTenant($team);
+
+        $invited = $this->entry('portal.invited', $team->id, $manager->id);
+        $revoked = $this->entry('portal.revoked', $team->id, $manager->id);
+        $nonPortal = $this->entry('login', $team->id, $manager->id);
+        $otherTeam = $this->entry('portal.invited', Team::factory()->create()->id, $manager->id);
+
+        Livewire::test(ListPortalAccessLogs::class)
+            ->assertCanSeeTableRecords([$invited, $revoked])
+            ->assertCanNotSeeTableRecords([$nonPortal, $otherTeam]);
+    }
+
+    public function test_access_gated_to_managers(): void
+    {
+        $team = Team::factory()->create();
+
+        $manager = User::factory()->create();
+        setPermissionsTeamId($team->id);
+        $manager->assignRole('manager');
+        $this->actingAs($manager);
+        $this->assertTrue(PortalAccessLogResource::canAccess());
+
+        $rep = User::factory()->create();
+        setPermissionsTeamId($team->id);
+        $rep->assignRole('sales_rep');
+        $this->actingAs($rep);
+        $this->assertFalse(PortalAccessLogResource::canAccess());
+    }
+}


### PR DESCRIPTION
Twelfth slice of the **G_5 customer portal** epic — surfaces the invite/revoke audit trail (#490) to a team's own staff. Spec: `docs/superpowers/specs/2026-07-07-g5-portal-audit-ui-design.md`.

## Why
#490 writes `portal.invited` / `portal.revoked` audit entries, but the only reader is the **admin** panel's `AuditLogResource` (super_admin, global). A team's own managers couldn't see who invited or revoked *their* customers.

## How
- **`PortalAccessLogResource`** on the **app** panel, read-only, list-only. `AuditLog` is `IsTenantModel`, so on the team-scoped app panel it already filters to the current team; `getEloquentQuery()` additionally narrows to `action like 'portal.%'` (portal grants/revokes only, not unrelated audit noise).
- **`canAccess()`** gates to management roles (`super_admin` / `admin` / `manager`); sales_rep / free / customer are denied.
- Columns: timestamp, actor, action badge, description. The admin global `AuditLogResource` is untouched.

## Verification
- New `tests/Feature/Filament/PortalAccessLogResourceTest.php` — a manager sees their team's portal entries (a non-portal `login` action and another team's entry excluded); `canAccess()` true for manager, false for sales_rep. **2/2 green.**
- Full suite **839 passed / 1 skipped / 0 failed** (no regressions).
- **MySQL 8.4-verified**; phpstan **0 new**; pint clean.

## Out of scope (ceilings)
No per-entry detail/diff view (list only); no export; `portal.*` actions only; super_admin global view stays the admin `AuditLogResource`.