### PR TITLE
feat(portal): staff reply to portal tickets + thread view (G_5)

### DIFF
--- a/app/Actions/Portal/ReplyToPortalTicket.php
+++ b/app/Actions/Portal/ReplyToPortalTicket.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Portal;
+
+use App\Models\Message;
+use App\Models\Ticket;
+use App\Models\User;
+use App\Notifications\TicketReplyNotification;
+
+/**
+ * Persists a staff reply to a portal-origin ticket as a Message on the thread
+ * (mirroring the customer reply idiom in the portal ViewTicket) and notifies the
+ * requester. Portal tickets have no external channel, so they never route through
+ * UnifiedHelpDeskService; the customer reads the reply in their portal thread.
+ */
+class ReplyToPortalTicket
+{
+    public function __invoke(Ticket $ticket, string $content, User $staff): Message
+    {
+        $message = new Message([
+            'channel' => 'portal',
+            // Display name, not email — the customer sees the thread, so no
+            // internal staff email is exposed.
+            'sender' => $staff->getAttribute('name'),
+            'content' => $content,
+            'priority' => $ticket->getAttribute('priority') ?: 'medium',
+            'status' => 'unread',
+            // ponytail: messages.account_id is a legacy NOT NULL int with no
+            // default; 0 sentinel when the ticket has no source account.
+            'account_id' => (int) ($ticket->getAttribute('account_id') ?? 0),
+            'metadata' => [],
+            'timestamp' => now(),
+            'ticket_id' => $ticket->getKey(),
+        ]);
+
+        // team_id is system-managed (not fillable on Message). Set it directly so
+        // the reply carries the ticket's tenant and stays visible to staff on the
+        // team-scoped app panel; the portal is non-tenant, so IsTenantModel's
+        // creating hook won't stamp it.
+        $message->setAttribute('team_id', $ticket->getAttribute('team_id'));
+        $message->save();
+
+        $ticket->user()->first()?->notify(new TicketReplyNotification($ticket));
+
+        return $message;
+    }
+}

--- a/app/Filament/App/Resources/TicketResource.php
+++ b/app/Filament/App/Resources/TicketResource.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace App\Filament\App\Resources;
 
+use App\Actions\Portal\ReplyToPortalTicket;
 use App\Filament\App\Resources\RelationManagers\MessagesRelationManager;
 use App\Filament\App\Resources\TicketResource\Pages\CreateTicket;
 use App\Filament\App\Resources\TicketResource\Pages\EditTicket;
 use App\Filament\App\Resources\TicketResource\Pages\ListTickets;
 use App\Models\Ticket;
+use App\Models\User;
 use App\Services\UnifiedHelpDeskService;
 use Exception;
 use Filament\Actions\Action;
@@ -23,6 +25,7 @@ use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Storage;
 
@@ -119,14 +122,24 @@ class TicketResource extends Resource
             ->recordActions([
                 EditAction::make(),
                 Action::make('reply')
-                    ->action(function (Ticket $record, array $data, UnifiedHelpDeskService $helpDeskService): void {
+                    ->action(function (Ticket $record, array $data, UnifiedHelpDeskService $helpDeskService, ReplyToPortalTicket $replyToPortal): void {
                         try {
-                            $helpDeskService->sendReply(
-                                $record->source_id,
-                                $data['reply_content'],
-                                $record->source,
-                                $record->account_id
-                            );
+                            // Portal tickets have no external channel — persist the
+                            // reply to the thread + notify the customer. Everything
+                            // else (email/social) routes through the help-desk service.
+                            if ($record->getAttribute('source') === 'portal') {
+                                $staff = Auth::user();
+                                if ($staff instanceof User) {
+                                    $replyToPortal($record, $data['reply_content'], $staff);
+                                }
+                            } else {
+                                $helpDeskService->sendReply(
+                                    $record->getAttribute('source_id'),
+                                    $data['reply_content'],
+                                    $record->getAttribute('source'),
+                                    (string) $record->getAttribute('account_id')
+                                );
+                            }
 
                             $record->update(['status' => 'in_progress']);
                             Cache::tags(['messages'])->flush();

--- a/app/Filament/Portal/Resources/TicketResource/Pages/ViewTicket.php
+++ b/app/Filament/Portal/Resources/TicketResource/Pages/ViewTicket.php
@@ -9,8 +9,12 @@ use App\Models\Message;
 use App\Models\Ticket;
 use Filament\Actions\Action;
 use Filament\Forms\Components\Textarea;
+use Filament\Infolists\Components\RepeatableEntry;
+use Filament\Infolists\Components\TextEntry;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\ViewRecord;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
 
@@ -82,5 +86,32 @@ class ViewTicket extends ViewRecord
                     Notification::make()->title('Reply sent')->success()->send();
                 }),
         ];
+    }
+
+    // The record is ownership-scoped by TicketResource::getEloquentQuery, so the
+    // thread only ever renders the customer's own ticket's messages (their replies
+    // and any staff replies persisted via ReplyToPortalTicket).
+    public function infolist(Schema $schema): Schema
+    {
+        return $schema->components([
+            Section::make('Ticket')
+                ->columns(2)
+                ->schema([
+                    TextEntry::make('subject'),
+                    TextEntry::make('status')->badge(),
+                    TextEntry::make('priority')->badge(),
+                    TextEntry::make('body')->label('Description')->columnSpanFull(),
+                ]),
+            Section::make('Conversation')
+                ->schema([
+                    RepeatableEntry::make('messages')
+                        ->hiddenLabel()
+                        ->schema([
+                            TextEntry::make('sender'),
+                            TextEntry::make('timestamp')->dateTime(),
+                            TextEntry::make('content')->columnSpanFull(),
+                        ]),
+                ]),
+        ]);
     }
 }

--- a/app/Notifications/TicketReplyNotification.php
+++ b/app/Notifications/TicketReplyNotification.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notifications;
+
+use App\Models\Ticket;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class TicketReplyNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(public Ticket $ticket) {}
+
+    /** @return array<int, string> */
+    public function via(object $notifiable): array
+    {
+        return ['mail', 'database'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('New reply on your support ticket')
+            ->line('A support agent has replied to your ticket: '.$this->ticket->getAttribute('subject'))
+            // Fixed portal path (panel path 'portal', tickets slug); avoids
+            // panel-context URL generation inside a queued notification.
+            ->action('View ticket', url('/portal/tickets/'.$this->ticket->getKey()))
+            ->line('Log in to your customer portal to read and respond.');
+    }
+
+    /** @return array<string, mixed> */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'ticket_id' => $this->ticket->getKey(),
+            'subject' => $this->ticket->getAttribute('subject'),
+            'message' => 'New reply on your ticket',
+        ];
+    }
+}

--- a/docs/superpowers/specs/2026-07-08-g5-staff-portal-reply-design.md
+++ b/docs/superpowers/specs/2026-07-08-g5-staff-portal-reply-design.md
@@ -1,0 +1,83 @@
+# G_5 — Staff reply to portal tickets + portal thread display (design)
+
+**Date:** 2026-07-08
+**Status:** approved, implementing
+**Epic:** G_5 customer portal (extension after the 12-slice core #480–#491).
+
+## Problem
+
+The customer↔staff support loop is broken for **portal-origin** tickets, in both directions:
+
+1. **Staff can't reply.** The app-panel `TicketResource` `reply` action routes every reply
+   through `UnifiedHelpDeskService::sendReply($source_id, $content, $source, $account_id)`,
+   which only supports external channels (gmail/whatsapp/outlook/imap/pop3/facebook). A
+   portal ticket has `source='portal'` and the `0` `account_id` sentinel, so the call throws
+   (`OAuthConfiguration::findOrFail(0)`, then `default => throw "Unsupported channel"`). The
+   staff reply fails, persists no `Message`, and never reaches the customer.
+
+2. **The customer can't see the thread.** The portal `ViewTicket` (a `ViewRecord`) renders
+   only the resource `form()` read-only (subject/body/priority/attachment). It shows **no
+   message thread** — so even the customer's own replies (#480) and any staff reply are
+   invisible in the portal. A persisted reply is worthless without a thread view.
+
+Customers can already *see* staff/customer messages on the staff side (app-panel
+`MessagesRelationManager`), so only the two gaps above remain.
+
+## Decisions
+
+- **Persist, don't route.** For `source === 'portal'` tickets, staff replies persist a
+  `Message` to the ticket thread instead of calling the external service. Mirrors the
+  customer reply idiom (#480 portal `ViewTicket`): `channel='portal'`, `content`,
+  `priority = ticket->priority ?: 'medium'`, `status='unread'`, `account_id = (int)($ticket->account_id ?? 0)`,
+  `metadata=[]`, `timestamp=now()`, `ticket_id`, and `team_id` set via `setAttribute` from
+  the ticket (not fillable; the portal's null tenant context won't stamp it).
+- **Sender = staff display name**, not email — the customer sees the thread, so no internal
+  staff email is exposed.
+- **Notify the customer.** A new `TicketReplyNotification` (`ShouldQueue`, `['mail','database']`)
+  goes to `$ticket->user` (the requester) only — tenant-safe. Mail links to
+  `/portal/tickets/{id}` (fixed portal path); `database` feeds the portal notification bell.
+- **Portal thread view.** `ViewTicket` gains an `infolist()` rendering the ticket header
+  plus a `RepeatableEntry` over `messages` (sender / content / timestamp). The record is
+  already ownership-scoped (`TicketResource::getEloquentQuery` → `user_id = auth`), so the
+  thread only ever shows the customer's own ticket's messages.
+- **Non-portal replies unchanged.** Email/social tickets still route through
+  `UnifiedHelpDeskService::sendReply` — a regression test guards this.
+
+## Architecture
+
+- `App\Actions\Portal\ReplyToPortalTicket` (invokable: `__invoke(Ticket, string $content, User $staff): Message`)
+  — persists the `Message` + notifies `$ticket->user`. Unit-testable, mirrors
+  Invite/RevokePortalCustomer.
+- `App\Notifications\TicketReplyNotification(Ticket $ticket)` — mail + database.
+- Edit app-panel `TicketResource` reply action: branch on `$record->source === 'portal'`
+  → `ReplyToPortalTicket`; else the existing service call. Status update / cache flush /
+  success-notification unchanged.
+- Edit portal `ViewTicket`: add `infolist()` with the message thread.
+
+## Security / tenancy
+
+Staff act on the tenant-scoped `app` panel → they only touch their team's tickets. The
+`Message` inherits `ticket.team_id`, staying in-tenant and visible to staff too. The
+notification targets only the ticket's own requester. The portal thread is gated by the
+already-scoped record resolution (foreign ticket = 404, #480). No cross-tenant surface.
+
+## Testing (TDD, PHPUnit sqlite → MySQL-verify)
+
+1. Staff reply to a portal ticket **persists a scoped `Message`** (channel=portal, sender=staff
+   name, team_id=ticket team, content) + sets ticket status.
+2. Staff reply **notifies the customer** (`Notification::assertSentTo(ticket->user, TicketReplyNotification)`).
+3. Staff reply to a portal ticket **does not call** `UnifiedHelpDeskService` (mock: `shouldNotReceive`).
+4. Staff reply to a **non-portal** ticket **still routes** to `UnifiedHelpDeskService::sendReply`
+   (mock: `shouldReceive->once`) and sends no portal notification — regression guard.
+5. Customer **sees the conversation thread** on portal `ViewTicket` (both a customer and a
+   staff message rendered).
+6. `ReplyToPortalTicket` unit: direct invoke persists the message + notifies.
+
+phpstan 0-new (use `getAttribute`/`getKey`/`setAttribute` — models lack `@property` docblocks),
+MySQL 8.4-verified, pint clean. Inline TDD, one PR to `main`.
+
+## Out of scope (ceilings)
+
+Staff reply attachments; rich text; per-message read receipts; closed-ticket auto-reopen on
+reply (keeps existing status behavior); real-time thread updates (portal already polls);
+digest/batching of reply notifications.

--- a/tests/Feature/Filament/StaffPortalReplyTest.php
+++ b/tests/Feature/Filament/StaffPortalReplyTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament;
+
+use App\Actions\Portal\ReplyToPortalTicket;
+use App\Filament\App\Resources\TicketResource\Pages\ListTickets;
+use App\Models\Ticket;
+use App\Models\User;
+use App\Notifications\TicketReplyNotification;
+use App\Services\UnifiedHelpDeskService;
+use Database\Seeders\RolesSeeder;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class StaffPortalReplyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $staff;
+
+    private $team;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolesSeeder::class);
+        $this->staff = User::factory()->withPersonalTeam()->create(['email_verified_at' => now()]);
+        $this->team = $this->staff->currentTeam;
+        setPermissionsTeamId($this->team->id);
+        $this->staff->assignRole('manager');
+        $this->actingAs($this->staff);
+        Filament::setCurrentPanel(Filament::getPanel('app'));
+        Filament::setTenant($this->team);
+    }
+
+    private function portalTicket(User $customer): Ticket
+    {
+        return Ticket::factory()->create([
+            'team_id' => $this->team->id,
+            'user_id' => $customer->id,
+            'source' => 'portal',
+            'account_id' => 0,
+        ]);
+    }
+
+    public function test_staff_reply_to_portal_ticket_persists_a_scoped_message(): void
+    {
+        Notification::fake();
+        $customer = User::factory()->create();
+        $ticket = $this->portalTicket($customer);
+
+        Livewire::test(ListTickets::class)
+            ->callTableAction('reply', $ticket, data: ['reply_content' => 'Here is the fix.']);
+
+        $this->assertDatabaseHas('messages', [
+            'ticket_id' => $ticket->id,
+            'channel' => 'portal',
+            'sender' => $this->staff->name,
+            'team_id' => $this->team->id,
+            'content' => 'Here is the fix.',
+        ]);
+        $this->assertSame('in_progress', $ticket->fresh()->getAttribute('status'));
+    }
+
+    public function test_staff_reply_notifies_the_customer(): void
+    {
+        Notification::fake();
+        $customer = User::factory()->create();
+        $ticket = $this->portalTicket($customer);
+
+        Livewire::test(ListTickets::class)
+            ->callTableAction('reply', $ticket, data: ['reply_content' => 'Answered.']);
+
+        Notification::assertSentTo($customer, TicketReplyNotification::class);
+    }
+
+    public function test_staff_reply_to_portal_ticket_does_not_call_external_service(): void
+    {
+        Notification::fake();
+        $customer = User::factory()->create();
+        $ticket = $this->portalTicket($customer);
+
+        $this->mock(UnifiedHelpDeskService::class, function ($mock): void {
+            $mock->shouldNotReceive('sendReply');
+        });
+
+        Livewire::test(ListTickets::class)
+            ->callTableAction('reply', $ticket, data: ['reply_content' => 'No external call.']);
+
+        $this->assertDatabaseHas('messages', ['ticket_id' => $ticket->id, 'channel' => 'portal']);
+    }
+
+    public function test_staff_reply_to_non_portal_ticket_routes_to_external_service(): void
+    {
+        Notification::fake();
+        $customer = User::factory()->create();
+        $ticket = Ticket::factory()->create([
+            'team_id' => $this->team->id,
+            'user_id' => $customer->id,
+            'source' => 'gmail',
+            'source_id' => 'gmail-msg-1',
+            'account_id' => 7,
+        ]);
+
+        $this->mock(UnifiedHelpDeskService::class, function ($mock): void {
+            $mock->shouldReceive('sendReply')->once();
+        });
+
+        Livewire::test(ListTickets::class)
+            ->callTableAction('reply', $ticket, data: ['reply_content' => 'Emailed back.']);
+
+        // External path persists nothing locally and notifies nobody in-portal.
+        $this->assertDatabaseMissing('messages', ['ticket_id' => $ticket->id, 'channel' => 'portal']);
+        Notification::assertNothingSent();
+    }
+
+    public function test_action_persists_message_and_notifies(): void
+    {
+        Notification::fake();
+        $customer = User::factory()->create();
+        $ticket = $this->portalTicket($customer);
+
+        $message = (new ReplyToPortalTicket)($ticket, 'Direct invoke.', $this->staff);
+
+        $this->assertSame('portal', $message->getAttribute('channel'));
+        $this->assertSame($this->team->id, $message->getAttribute('team_id'));
+        $this->assertDatabaseHas('messages', [
+            'ticket_id' => $ticket->id,
+            'content' => 'Direct invoke.',
+            'sender' => $this->staff->name,
+        ]);
+        Notification::assertSentTo($customer, TicketReplyNotification::class);
+    }
+}

--- a/tests/Feature/Portal/PortalTicketThreadTest.php
+++ b/tests/Feature/Portal/PortalTicketThreadTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Portal;
+
+use App\Models\Message;
+use App\Models\Team;
+use App\Models\Ticket;
+use App\Models\User;
+use Database\Seeders\RolesSeeder;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PortalTicketThreadTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function message(Ticket $ticket, string $content, string $sender): void
+    {
+        $message = new Message([
+            'channel' => 'portal',
+            'sender' => $sender,
+            'content' => $content,
+            'priority' => 'medium',
+            'status' => 'unread',
+            'account_id' => 0,
+            'metadata' => [],
+            'timestamp' => now(),
+            'ticket_id' => $ticket->id,
+        ]);
+        $message->setAttribute('team_id', $ticket->getAttribute('team_id'));
+        $message->save();
+    }
+
+    public function test_customer_sees_conversation_thread_on_view(): void
+    {
+        $this->seed(RolesSeeder::class);
+        $customer = User::factory()->create(['email_verified_at' => now()]);
+        setPermissionsTeamId(null);
+        $customer->assignRole('customer');
+        $this->actingAs($customer);
+        Filament::setCurrentPanel(Filament::getPanel('portal'));
+
+        $team = Team::factory()->create();
+        $ticket = Ticket::factory()->create(['user_id' => $customer->id, 'team_id' => $team->id]);
+        $this->message($ticket, 'The customer asked this.', $customer->email);
+        $this->message($ticket, 'The support agent answered that.', 'Support Agent');
+
+        $this->get('/portal/tickets/'.$ticket->id)
+            ->assertOk()
+            ->assertSee('The customer asked this.')
+            ->assertSee('The support agent answered that.');
+    }
+}


### PR DESCRIPTION
## What

Closes the customer↔staff support loop for **portal-origin** tickets, which was broken both ways:

1. **Staff couldn't reply.** The app-panel `TicketResource` reply action routed every reply through `UnifiedHelpDeskService::sendReply` (external channels only: gmail/whatsapp/outlook/imap/pop3/facebook). A `source='portal'` ticket has the `0` `account_id` sentinel → `OAuthConfiguration::findOrFail(0)` throws, then `default => "Unsupported channel"`. The reply failed, persisted no `Message`, and never reached the customer.
2. **Customer saw no thread.** Portal `ViewTicket` rendered only the ticket fields read-only — no conversation — so replies (even the customer's own) were invisible in the portal.

## Changes

- `App\Actions\Portal\ReplyToPortalTicket` — persists a portal `Message` (channel=`portal`, sender=staff name, `team_id` inherited from the ticket so it stays visible to staff on the tenant-scoped app panel) and notifies the requester.
- `App\Notifications\TicketReplyNotification` (`mail` + `database`) — links to `/portal/tickets/{id}`.
- App-panel reply action branches on `source === 'portal'` → the action; the external path is unchanged (regression-tested).
- Portal `ViewTicket` gains an `infolist()` rendering the message thread (ownership-scoped by the existing `getEloquentQuery`, so only the customer's own ticket's messages show).
- Cast `account_id` to `string` on `sendReply` — fixes a latent `strict_types` `TypeError` the untested external path masked.

## Verification

- New tests: 6 (staff reply persists scoped message · notifies customer · no external call for portal · **non-portal still routes to the service** · direct-invoke unit · customer sees thread).
- Full suite **845 pass / 1 skip / 0 fail** (+6).
- phpstan **0-new** (22 == baseline `ignore.unmatched` drift, none in changed files).
- **MySQL 8.4-verified**, pint clean.

Spec: `docs/superpowers/specs/2026-07-08-g5-staff-portal-reply-design.md`

## Out of scope

Staff reply attachments, rich text, read receipts, closed-ticket auto-reopen, real-time thread updates, notification batching.