### PR TITLE
feat(portal): staff knowledge-base authoring (G_5)

### DIFF
--- a/app/Filament/App/Resources/KnowledgeBaseArticleResource.php
+++ b/app/Filament/App/Resources/KnowledgeBaseArticleResource.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\App\Resources;
+
+use App\Enums\Role;
+use App\Filament\App\Resources\KnowledgeBaseArticleResource\Pages\CreateKnowledgeBaseArticle;
+use App\Filament\App\Resources\KnowledgeBaseArticleResource\Pages\EditKnowledgeBaseArticle;
+use App\Filament\App\Resources\KnowledgeBaseArticleResource\Pages\ListKnowledgeBaseArticles;
+use App\Models\KnowledgeBaseArticle;
+use App\Models\User;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Illuminate\Support\Facades\Auth;
+
+/**
+ * Staff-facing authoring for the customer portal knowledge base (#483 is the
+ * read-only portal browse). On the team-scoped app panel, KnowledgeBaseArticle
+ * (IsTenantModel) auto-filters reads to the current team and auto-stamps team_id
+ * on create — so articles a team authors here are exactly what its customers
+ * browse in the portal (which scopes team_id + is_published).
+ */
+class KnowledgeBaseArticleResource extends Resource
+{
+    protected static ?string $model = KnowledgeBaseArticle::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-book-open';
+
+    protected static string|\UnitEnum|null $navigationGroup = 'Help Desk';
+
+    protected static ?string $navigationLabel = 'Knowledge base';
+
+    protected static ?string $slug = 'knowledge-base';
+
+    public static function canAccess(): bool
+    {
+        $user = Auth::user();
+
+        return $user instanceof User && $user->hasRole([Role::SuperAdmin, Role::Admin, Role::Manager]);
+    }
+
+    #[\Override]
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            TextInput::make('title')->required()->maxLength(255),
+            TextInput::make('category')->maxLength(255),
+            Textarea::make('content')->required()->rows(12)->columnSpanFull(),
+            Toggle::make('is_published')
+                ->default(true)
+                ->helperText('Unpublished articles are hidden from the customer portal.'),
+        ]);
+    }
+
+    #[\Override]
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('title')->searchable(),
+                TextColumn::make('category')->badge()->sortable(),
+                IconColumn::make('is_published')->boolean()->label('Published'),
+                TextColumn::make('helpful_count')->label('Helpful')->sortable(),
+                TextColumn::make('not_helpful_count')->label('Not helpful')->sortable(),
+                TextColumn::make('updated_at')->dateTime()->sortable(),
+            ])
+            ->filters([
+                SelectFilter::make('category')
+                    ->options(fn (): array => KnowledgeBaseArticle::query()
+                        ->whereNotNull('category')
+                        ->distinct()
+                        ->pluck('category', 'category')
+                        ->all()),
+            ])
+            ->recordActions([
+                EditAction::make(),
+            ])
+            ->toolbarActions([
+                DeleteBulkAction::make(),
+            ])
+            ->defaultSort('updated_at', 'desc');
+    }
+
+    #[\Override]
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListKnowledgeBaseArticles::route('/'),
+            'create' => CreateKnowledgeBaseArticle::route('/create'),
+            'edit' => EditKnowledgeBaseArticle::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/App/Resources/KnowledgeBaseArticleResource/Pages/CreateKnowledgeBaseArticle.php
+++ b/app/Filament/App/Resources/KnowledgeBaseArticleResource/Pages/CreateKnowledgeBaseArticle.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\App\Resources\KnowledgeBaseArticleResource\Pages;
+
+use App\Filament\App\Resources\KnowledgeBaseArticleResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateKnowledgeBaseArticle extends CreateRecord
+{
+    protected static string $resource = KnowledgeBaseArticleResource::class;
+}

--- a/app/Filament/App/Resources/KnowledgeBaseArticleResource/Pages/EditKnowledgeBaseArticle.php
+++ b/app/Filament/App/Resources/KnowledgeBaseArticleResource/Pages/EditKnowledgeBaseArticle.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\App\Resources\KnowledgeBaseArticleResource\Pages;
+
+use App\Filament\App\Resources\KnowledgeBaseArticleResource;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditKnowledgeBaseArticle extends EditRecord
+{
+    protected static string $resource = KnowledgeBaseArticleResource::class;
+
+    #[\Override]
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/App/Resources/KnowledgeBaseArticleResource/Pages/ListKnowledgeBaseArticles.php
+++ b/app/Filament/App/Resources/KnowledgeBaseArticleResource/Pages/ListKnowledgeBaseArticles.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\App\Resources\KnowledgeBaseArticleResource\Pages;
+
+use App\Filament\App\Resources\KnowledgeBaseArticleResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListKnowledgeBaseArticles extends ListRecords
+{
+    protected static string $resource = KnowledgeBaseArticleResource::class;
+
+    #[\Override]
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/docs/superpowers/specs/2026-07-08-g5-staff-kb-authoring-design.md
+++ b/docs/superpowers/specs/2026-07-08-g5-staff-kb-authoring-design.md
@@ -1,0 +1,55 @@
+# G_5 — Staff knowledge-base authoring (app panel) design
+
+**Date:** 2026-07-08
+**Status:** approved, implementing
+**Epic:** G_5 customer portal (extension). Complements #483 (portal KB browse).
+
+## Problem
+
+The only `KnowledgeBaseArticleResource` is the **portal** read-only browse (#483). There is
+**no staff-facing UI to author KB articles**, so the portal KB is an empty shelf — customers
+browse content nobody can create. (A legacy global `KnowledgeBaseController` exists but is
+un-scoped Blade, left untouched by #483.)
+
+## Solution
+
+`App\Filament\App\Resources\KnowledgeBaseArticleResource` on the **app panel**, which is
+Jetstream-Team-tenant-scoped. `KnowledgeBaseArticle` is `IsTenantModel`, so on the app panel:
+
+- reads auto-filter to the current team (global `tenant` scope, keyed on `Filament::getTenant()`),
+- `creating()` auto-stamps `team_id` from the active tenant.
+
+No explicit `team_id` handling needed (unlike the portal resource, which is non-tenant and
+filters manually). This closes the loop with #483: **staff author → their team's customers
+browse** (portal KB scopes `team_id` + `is_published`).
+
+## Components
+
+- **Form:** `title` (required), `category` (nullable text), `content` (Textarea — not
+  RichEditor, per the #466 LandingPage RichEditor drift), `is_published` Toggle (default true
+  → a draft/publish workflow). `helpful_count`/`not_helpful_count` are read-only stats, not
+  form fields.
+- **Table:** title (searchable), category (badge), `is_published` (badge/boolean),
+  helpful/not-helpful counts, updated_at; category `SelectFilter`. Nav group "Help Desk".
+- **Pages:** List / Create / Edit (full CRUD + Delete), mirroring the app `TicketResource`.
+- **Access:** `canAccess` → `super_admin` / `admin` / `manager` (content management, not
+  `sales_rep` / `free`) — mirrors #491's role idiom.
+
+## Testing (TDD, PHPUnit sqlite → MySQL-verify)
+
+1. Manager creates an article → `team_id` auto-stamped to their team, `is_published`
+   defaults true.
+2. Team-scoped: a manager in team A does not see team B's article (list scoping).
+3. `canAccess`: manager ✓, `sales_rep` ✗.
+4. **A draft (`is_published=false`) authored here is NOT visible in the portal browse**
+   (cross-checks `Portal\KnowledgeBaseArticleResource::getEloquentQuery` — proves the publish
+   gate ties authoring to #483).
+5. Edit updates a field (e.g. publish a draft).
+
+phpstan 0-new (`getAttribute`/`hasRole` idioms), MySQL 8.4-verified, pint clean. Inline TDD,
+one PR to `main`.
+
+## Out of scope
+
+RichEditor / media uploads, article versioning, per-customer vote dedup, a managed category
+taxonomy, manual ordering, moving the legacy `KnowledgeBaseController` off Blade.

--- a/tests/Feature/Filament/StaffKbAuthoringTest.php
+++ b/tests/Feature/Filament/StaffKbAuthoringTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament;
+
+use App\Filament\App\Resources\KnowledgeBaseArticleResource as StaffResource;
+use App\Filament\App\Resources\KnowledgeBaseArticleResource\Pages\CreateKnowledgeBaseArticle;
+use App\Filament\App\Resources\KnowledgeBaseArticleResource\Pages\EditKnowledgeBaseArticle;
+use App\Filament\App\Resources\KnowledgeBaseArticleResource\Pages\ListKnowledgeBaseArticles;
+use App\Filament\Portal\Resources\KnowledgeBaseArticleResource as PortalResource;
+use App\Models\KnowledgeBaseArticle;
+use App\Models\Team;
+use App\Models\User;
+use Database\Seeders\RolesSeeder;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class StaffKbAuthoringTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $manager;
+
+    private $team;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolesSeeder::class);
+        $this->manager = User::factory()->withPersonalTeam()->create(['email_verified_at' => now()]);
+        $this->team = $this->manager->currentTeam;
+        setPermissionsTeamId($this->team->id);
+        $this->manager->assignRole('manager');
+        $this->actingAs($this->manager);
+        Filament::setCurrentPanel(Filament::getPanel('app'));
+        Filament::setTenant($this->team);
+    }
+
+    public function test_manager_creates_article_scoped_to_team_and_published_by_default(): void
+    {
+        Livewire::test(CreateKnowledgeBaseArticle::class)
+            ->fillForm([
+                'title' => 'How to reset your password',
+                'category' => 'Account',
+                'content' => 'Click forgot password and follow the emailed link.',
+            ])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        $this->assertDatabaseHas('knowledge_base_articles', [
+            'title' => 'How to reset your password',
+            'team_id' => $this->team->id,
+            'is_published' => 1,
+        ]);
+    }
+
+    public function test_list_is_team_scoped(): void
+    {
+        $mine = KnowledgeBaseArticle::factory()->create(['team_id' => $this->team->id]);
+        $other = KnowledgeBaseArticle::factory()->create(['team_id' => Team::factory()->create()->id]);
+
+        Livewire::test(ListKnowledgeBaseArticles::class)
+            ->assertCanSeeTableRecords([$mine])
+            ->assertCanNotSeeTableRecords([$other]);
+    }
+
+    public function test_manager_can_access_sales_rep_cannot(): void
+    {
+        $this->assertTrue(StaffResource::canAccess());
+
+        $rep = User::factory()->withPersonalTeam()->create(['email_verified_at' => now()]);
+        setPermissionsTeamId($rep->currentTeam->id);
+        $rep->assignRole('sales_rep');
+        $this->actingAs($rep);
+
+        $this->assertFalse(StaffResource::canAccess());
+    }
+
+    public function test_draft_is_hidden_from_the_portal_browse(): void
+    {
+        $draft = KnowledgeBaseArticle::factory()->create(['team_id' => $this->team->id, 'is_published' => false]);
+        $published = KnowledgeBaseArticle::factory()->create(['team_id' => $this->team->id, 'is_published' => true]);
+
+        // A customer of the same team, on the (non-tenant) portal panel.
+        $customer = User::factory()->create(['email_verified_at' => now()]);
+        $customer->forceFill(['current_team_id' => $this->team->id])->save();
+        setPermissionsTeamId(null);
+        $customer->assignRole('customer');
+        $this->actingAs($customer);
+        Filament::setCurrentPanel(Filament::getPanel('portal'));
+
+        $visible = PortalResource::getEloquentQuery()->pluck('id');
+
+        $this->assertFalse($visible->contains($draft->id));
+        $this->assertTrue($visible->contains($published->id));
+    }
+
+    public function test_edit_publishes_a_draft(): void
+    {
+        $draft = KnowledgeBaseArticle::factory()->create(['team_id' => $this->team->id, 'is_published' => false]);
+
+        Livewire::test(EditKnowledgeBaseArticle::class, ['record' => $draft->getKey()])
+            ->fillForm(['is_published' => true])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        $this->assertTrue((bool) $draft->fresh()->getAttribute('is_published'));
+    }
+}


### PR DESCRIPTION
## What

The portal KB browse (#483) had **no staff authoring UI** — the only `KnowledgeBaseArticleResource` was the portal read-only browse, so customers browsed an empty shelf because nobody could create articles. This adds the missing staff surface.

## Changes

- `App\Filament\App\Resources\KnowledgeBaseArticleResource` on the **app panel** (Team-tenant-scoped). `KnowledgeBaseArticle` is `IsTenantModel`, so team_id is auto-stamped on create and reads auto-filter to the current team — a team authors exactly what its customers browse in the portal (which scopes `team_id` + `is_published`).
- Form: `title`, `category`, `content` (Textarea, not RichEditor per the #466 drift lesson), `is_published` toggle (default true → draft/publish workflow). Full CRUD (List/Create/Edit/Delete).
- `canAccess` gated to `super_admin`/`admin`/`manager` (content management, not `sales_rep`/`free`).

## Verification

- New tests: 5 (create → team_id stamped + published-by-default · list team-scoped · canAccess manager✓ / sales_rep✗ · **a draft stays hidden from the portal browse** · edit publishes a draft).
- Full suite **850 pass / 1 skip / 0 fail** (+5).
- phpstan **0-new** (22 == baseline `ignore.unmatched`, none in changed files).
- **MySQL 8.4-verified**, pint clean.

Spec: `docs/superpowers/specs/2026-07-08-g5-staff-kb-authoring-design.md`

## Out of scope

RichEditor / media, article versioning, per-customer vote dedup, managed category taxonomy, ordering, moving the legacy `KnowledgeBaseController` off Blade.