### PR TITLE
feat(portal): staff share documents with portal customers (G_5)

### DIFF
--- a/app/Actions/Portal/ShareDocumentWithContact.php
+++ b/app/Actions/Portal/ShareDocumentWithContact.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Portal;
+
+use App\Models\Contact;
+use App\Models\Document;
+use App\Services\DocumentService;
+use Illuminate\Http\UploadedFile;
+
+/**
+ * Attaches a staff-uploaded file to a Contact so it surfaces in that customer's
+ * portal document browse (#484), which filters team_id + documentable=Contact and
+ * displays name/type. Reuses DocumentService::upload for the mime-allowlist check
+ * and disk/path convention download reads back; upload() omits team_id/name/type
+ * (Document is not IsTenantModel, so nothing auto-stamps them) — patch them here.
+ */
+class ShareDocumentWithContact
+{
+    public function __construct(private DocumentService $documents) {}
+
+    public function __invoke(Contact $contact, UploadedFile $file, string $name, ?string $type = null): Document
+    {
+        $document = $this->documents->upload($file, $contact, ['title' => $name]);
+
+        $document->forceFill([
+            'team_id' => $contact->getAttribute('team_id'),
+            'name' => $name,
+            'type' => $type,
+        ])->save();
+
+        return $document;
+    }
+}

--- a/app/Filament/App/Resources/ContactResource.php
+++ b/app/Filament/App/Resources/ContactResource.php
@@ -8,6 +8,7 @@ use App\Exceptions\PortalOnboardingException;
 use App\Filament\App\Resources\ContactResource\Pages\CreateContact;
 use App\Filament\App\Resources\ContactResource\Pages\EditContact;
 use App\Filament\App\Resources\ContactResource\Pages\ListContacts;
+use App\Filament\App\Resources\ContactResource\RelationManagers\DocumentsRelationManager;
 use App\Models\Company;
 use App\Models\Contact;
 use App\Services\TwilioService;
@@ -264,6 +265,14 @@ class ContactResource extends Resource
                             ->send();
                     }),
             ]);
+    }
+
+    #[\Override]
+    public static function getRelations(): array
+    {
+        return [
+            DocumentsRelationManager::class,
+        ];
     }
 
     #[\Override]

--- a/app/Filament/App/Resources/ContactResource/RelationManagers/DocumentsRelationManager.php
+++ b/app/Filament/App/Resources/ContactResource/RelationManagers/DocumentsRelationManager.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\App\Resources\ContactResource\RelationManagers;
+
+use App\Actions\Portal\ShareDocumentWithContact;
+use App\Models\Contact;
+use App\Models\Document;
+use App\Services\DocumentService;
+use Filament\Actions\Action;
+use Filament\Actions\DeleteAction;
+use Filament\Forms\Components\FileUpload;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+/**
+ * Staff attach documents to a Contact; they surface in that customer's portal
+ * document browse (#484). Lives on the tenant-scoped app panel, so staff only
+ * reach their own team's Contacts.
+ */
+class DocumentsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'documents';
+
+    protected static ?string $title = 'Documents';
+
+    protected static ?string $recordTitleAttribute = 'name';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('name')->searchable(),
+                TextColumn::make('type')->badge(),
+                TextColumn::make('updated_at')->dateTime()->sortable(),
+            ])
+            ->headerActions([
+                Action::make('share')
+                    ->label('Share document')
+                    ->icon('heroicon-o-arrow-up-tray')
+                    ->schema([
+                        // storeFiles(false) hands the raw upload to the action so
+                        // DocumentService::upload runs its mime allowlist + storeFile.
+                        FileUpload::make('file')->storeFiles(false)->required(),
+                        TextInput::make('name')->required()->maxLength(255),
+                        TextInput::make('type')->maxLength(255),
+                    ])
+                    ->action(function (array $data, ShareDocumentWithContact $share): void {
+                        /** @var Contact $contact */
+                        $contact = $this->getOwnerRecord();
+                        $share($contact, $data['file'], $data['name'], $data['type'] ?? null);
+                    }),
+            ])
+            ->recordActions([
+                Action::make('download')
+                    ->label('Download')
+                    ->icon('heroicon-o-arrow-down-tray')
+                    ->action(fn (Document $record, DocumentService $service) => $service->download($record)),
+                DeleteAction::make()
+                    ->using(fn (Document $record, DocumentService $service): bool => tap(true, fn () => $service->delete($record))),
+            ]);
+    }
+}

--- a/docs/superpowers/specs/2026-07-08-g5-staff-share-document-design.md
+++ b/docs/superpowers/specs/2026-07-08-g5-staff-share-document-design.md
@@ -1,0 +1,66 @@
+# G_5 — Staff share document with a portal customer (design)
+
+**Date:** 2026-07-08
+**Status:** approved, implementing
+**Epic:** G_5 customer portal (extension). Complements #484 (portal document browse).
+
+## Problem
+
+The portal document browse (#484) is an **empty shelf**: it shows the documents attached to
+the customer's Contact (`documentable_type=Contact`, matched by email+team), but **no staff
+surface attaches a document to a Contact**. There is no `documents` relation manager on the
+app `ContactResource`; the only writer is the legacy Blade `DocumentController`.
+
+`DocumentService::upload()` exists but is **insufficient on its own** for the portal: it sets
+`file_path`/`original_filename`/`mime_type`/`title` but **not `team_id`, `name`, or `type`** —
+the exact fields the portal browse filters (`where team_id`) and displays (`name`, `type`).
+A document uploaded via `upload()` alone has `team_id = null` → the customer never sees it.
+
+## Solution
+
+`App\Filament\App\Resources\ContactResource\RelationManagers\DocumentsRelationManager`
+(relationship `documents`, a `MorphMany`). A **Share document** action:
+
+- `FileUpload->storeFiles(false)` yields the raw `TemporaryUploadedFile` (a subclass of
+  `UploadedFile`) →
+- `DocumentService::upload($file, $contact, ['title' => $name])` — **reuses** `storeFile`'s
+  mime allowlist (`config('documents.allowed_mimes')`, aborts 422 on disallowed content) and
+  disk/path convention that `DocumentService::download` reads back →
+- patch the returned `Document`: `team_id = contact.team_id`, `name`, `type` (the portal
+  fields `upload()` omits). `documentable` is auto-pinned to the Contact via the relation.
+
+Result: the document appears in that customer's portal browse (#484), matched by email+team.
+
+Table mirrors the portal: `name` / `type` / `updated_at`, with **download**
+(`DocumentService::download`) and **delete** (`DocumentService::delete`, removes file+row)
+row actions. Registered via `ContactResource::getRelations()` (added — none today).
+
+## Security / tenancy
+
+- File validation reused from `DocumentService::storeFile` (content-sniffed mime allowlist) —
+  not bypassed.
+- Stored on the private/default disk `DocumentService` already uses; never a public URL.
+- `documentable` is pinned to the Contact the staffer is on; `team_id` pinned to that
+  Contact's team. The relation manager lives on the tenant-scoped app panel, so staff only
+  reach their own team's Contacts.
+
+## Testing (TDD, PHPUnit sqlite → MySQL-verify)
+
+Uploads use `UploadedFile::fake()->image('x.png')` (real PNG content so the Finfo allowlist
+passes; `image/png` is in `config/documents.php`).
+
+1. Staff share a document with a Contact → `Document` created with `team_id = contact.team_id`,
+   `documentable_type = Contact`, `documentable_id`, `name`, `type`, `file_path` set.
+2. The matching portal customer (email+team) sees it in
+   `Portal\DocumentResource::getEloquentQuery` — ties the share to #484.
+3. A document on a **different** Contact is not visible to that customer (scoping).
+4. Delete removes the row (and the stored file).
+
+phpstan 0-new (`getAttribute`/`setAttribute` idioms), MySQL 8.4-verified, pint clean.
+Inline TDD, one PR to `main`.
+
+## Out of scope
+
+Version UI (`uploadNewVersion` exists, unsurfaced), documents on Deal/Company (Contact only,
+per #484), customer-side upload from the portal, bulk share, per-document access controls
+beyond the Contact link.

--- a/tests/Feature/Filament/StaffShareDocumentTest.php
+++ b/tests/Feature/Filament/StaffShareDocumentTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament;
+
+use App\Actions\Portal\ShareDocumentWithContact;
+use App\Filament\App\Resources\ContactResource\Pages\EditContact;
+use App\Filament\App\Resources\ContactResource\RelationManagers\DocumentsRelationManager;
+use App\Filament\Portal\Resources\DocumentResource as PortalDocumentResource;
+use App\Models\Contact;
+use App\Models\Document;
+use App\Models\Team;
+use App\Models\User;
+use App\Services\DocumentService;
+use Database\Seeders\RolesSeeder;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class StaffShareDocumentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function share(Contact $contact, string $name = 'Q3 Report', string $type = 'report'): Document
+    {
+        return (new ShareDocumentWithContact(app(DocumentService::class)))(
+            $contact,
+            UploadedFile::fake()->image('doc.png'),
+            $name,
+            $type,
+        );
+    }
+
+    private function actAsPortalCustomer(string $email, Team $team): void
+    {
+        $customer = User::factory()->create(['email' => $email, 'email_verified_at' => now()]);
+        $customer->forceFill(['current_team_id' => $team->id])->save();
+        setPermissionsTeamId(null);
+        $customer->assignRole('customer');
+        $this->actingAs($customer);
+        Filament::setCurrentPanel(Filament::getPanel('portal'));
+    }
+
+    public function test_sharing_creates_a_portal_visible_document_row(): void
+    {
+        Storage::fake();
+        $team = Team::factory()->create();
+        $contact = Contact::factory()->create(['team_id' => $team->id, 'email' => 'cust@example.com']);
+
+        $doc = $this->share($contact);
+
+        $this->assertDatabaseHas('documents', [
+            'id' => $doc->id,
+            'team_id' => $team->id,
+            'documentable_type' => Contact::class,
+            'documentable_id' => $contact->id,
+            'name' => 'Q3 Report',
+            'type' => 'report',
+        ]);
+        $this->assertNotNull($doc->getAttribute('file_path'));
+    }
+
+    public function test_shared_document_appears_in_the_portal_browse(): void
+    {
+        Storage::fake();
+        $this->seed(RolesSeeder::class);
+        $team = Team::factory()->create();
+        $contact = Contact::factory()->create(['team_id' => $team->id, 'email' => 'cust@example.com']);
+        $doc = $this->share($contact);
+
+        $this->actAsPortalCustomer('cust@example.com', $team);
+
+        $this->assertTrue(PortalDocumentResource::getEloquentQuery()->pluck('id')->contains($doc->id));
+    }
+
+    public function test_document_on_another_contact_is_not_visible(): void
+    {
+        Storage::fake();
+        $this->seed(RolesSeeder::class);
+        $team = Team::factory()->create();
+        $other = Contact::factory()->create(['team_id' => $team->id, 'email' => 'someone-else@example.com']);
+        $doc = $this->share($other);
+
+        $this->actAsPortalCustomer('cust@example.com', $team);
+
+        $this->assertFalse(PortalDocumentResource::getEloquentQuery()->pluck('id')->contains($doc->id));
+    }
+
+    public function test_staff_can_share_via_the_relation_manager(): void
+    {
+        Storage::fake();
+        $this->seed(RolesSeeder::class);
+        $staff = User::factory()->withPersonalTeam()->create(['email_verified_at' => now()]);
+        $team = $staff->currentTeam;
+        setPermissionsTeamId($team->id);
+        $staff->assignRole('manager');
+        $this->actingAs($staff);
+        Filament::setCurrentPanel(Filament::getPanel('app'));
+        Filament::setTenant($team);
+
+        $contact = Contact::factory()->create(['team_id' => $team->id, 'email' => 'cust@example.com']);
+
+        Livewire::test(DocumentsRelationManager::class, [
+            'ownerRecord' => $contact,
+            'pageClass' => EditContact::class,
+        ])->callTableAction('share', data: [
+            'file' => UploadedFile::fake()->image('shared.png'),
+            'name' => 'Signed contract',
+            'type' => 'contract',
+        ]);
+
+        $this->assertDatabaseHas('documents', [
+            'documentable_id' => $contact->id,
+            'documentable_type' => Contact::class,
+            'team_id' => $team->id,
+            'name' => 'Signed contract',
+            'type' => 'contract',
+        ]);
+    }
+}


### PR DESCRIPTION
## What

The portal document browse (#484) was an **empty shelf** — no staff surface attaches a `Document` to a Contact, so customers browsed nothing. This adds the staff share surface.

Reusing `DocumentService::upload()` alone was insufficient: it sets `title`/`mime_type`/`file_path` but **not `team_id`/`name`/`type`** — the exact fields the portal browse filters (`where team_id`) and displays (`name`, `type`). A doc from `upload()` alone has `team_id = null` → the customer never sees it (`Document` isn't `IsTenantModel`, so nothing auto-stamps it).

## Changes

- `App\Actions\Portal\ShareDocumentWithContact` — reuses `DocumentService::upload` (keeps its content-sniffed **mime allowlist** and disk/path convention that `download` reads back), then patches `team_id = contact.team_id`, `name`, `type`.
- `DocumentsRelationManager` on the app `ContactResource` (`documents` morphMany): **Share** header action (`FileUpload->storeFiles(false)` hands the raw upload to the action) + **download**/**delete** via `DocumentService`. Registered via a new `ContactResource::getRelations()`.

## Verification

- New tests: 4 (share → `Document` with `team_id`+`documentable=Contact`+`name`/`type`/`file_path` · **appears in the matching customer's portal browse** · a doc on another contact stays invisible · shares via the relation-manager UI).
- Full suite **854 pass / 1 skip / 0 fail** (+4).
- phpstan **0-new** (22 == baseline `ignore.unmatched`, none in changed files).
- **MySQL 8.4-verified**, pint clean.

Spec: `docs/superpowers/specs/2026-07-08-g5-staff-share-document-design.md`

## Security

Reuses `DocumentService::storeFile`'s mime allowlist (not bypassed); private/default disk (never a public URL); `documentable` pinned to the Contact, `team_id` to its team; the relation manager lives on the tenant-scoped app panel.

## Out of scope

Version UI, docs on Deal/Company (Contact only, per #484), customer-side upload, bulk share.