### PR TITLE
feat(portal): surface notification bell + notify on doc share (G_5)

### DIFF
--- a/app/Actions/Portal/ShareDocumentWithContact.php
+++ b/app/Actions/Portal/ShareDocumentWithContact.php
@@ -6,7 +6,9 @@ namespace App\Actions\Portal;
 
 use App\Models\Contact;
 use App\Models\Document;
+use App\Notifications\DocumentSharedNotification;
 use App\Services\DocumentService;
+use App\Support\PortalCustomer;
 use Illuminate\Http\UploadedFile;
 
 /**
@@ -29,6 +31,11 @@ class ShareDocumentWithContact
             'name' => $name,
             'type' => $type,
         ])->save();
+
+        // Tell the customer, if this Contact has a portal account. Null-safe:
+        // a Contact with no portal user notifies no one.
+        PortalCustomer::forEmail($contact->getAttribute('email'))
+            ?->notify(new DocumentSharedNotification($document));
 
         return $document;
     }

--- a/app/Notifications/DocumentSharedNotification.php
+++ b/app/Notifications/DocumentSharedNotification.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notifications;
+
+use App\Models\Document;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class DocumentSharedNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(public Document $document) {}
+
+    /** @return array<int, string> */
+    public function via(object $notifiable): array
+    {
+        return ['mail', 'database'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('A document was shared with you')
+            ->line('A new document is available in your customer portal: '.$this->document->getAttribute('name'))
+            // Fixed portal path (panel path 'portal', documents slug); avoids
+            // panel-context URL generation inside a queued notification.
+            ->action('View documents', url('/portal/documents'))
+            ->line('Log in to your customer portal to download it.');
+    }
+
+    /** @return array<string, mixed> */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'document_id' => $this->document->getKey(),
+            'name' => $this->document->getAttribute('name'),
+            'message' => 'A document was shared with you',
+        ];
+    }
+}

--- a/app/Providers/Filament/PortalPanelProvider.php
+++ b/app/Providers/Filament/PortalPanelProvider.php
@@ -35,6 +35,9 @@ class PortalPanelProvider extends PanelProvider
             ->path('portal')
             ->login()
             ->passwordReset()
+            // Surfaces the notification bell so customers see in-portal alerts
+            // (ticket replies #492, document shares) — not just the email copy.
+            ->databaseNotifications()
             // Customer-facing branding: a configurable name and top navigation so
             // the portal reads as a product, not the staff admin chrome.
             ->brandName(fn (): string => (string) config('portal.brand_name'))

--- a/docs/superpowers/specs/2026-07-08-g5-portal-notifications-design.md
+++ b/docs/superpowers/specs/2026-07-08-g5-portal-notifications-design.md
@@ -1,0 +1,49 @@
+# G_5 — Portal customer notifications (design)
+
+**Date:** 2026-07-08
+**Status:** approved, implementing
+**Epic:** G_5 customer portal (extension). Completes the notification story from #492/#494.
+
+## Problem
+
+Two loose ends in customer awareness:
+
+1. **The portal notification bell was never enabled.** #492 sends the customer a
+   `TicketReplyNotification` on `['mail', 'database']`, but `PortalPanelProvider` never calls
+   `->databaseNotifications()`, so the `database` channel is **write-only** — rows land in
+   `notifications` but no bell renders in the portal.
+2. **Document shares are silent.** #494 lets staff share a document with a Contact, but the
+   customer is never told.
+
+## Fix
+
+1. Add `->databaseNotifications()` to the portal panel. Surfaces the bell for every portal DB
+   notification — retroactively lighting up #492's ticket replies. (`notifications` table
+   already exists.)
+2. New `App\Notifications\DocumentSharedNotification` (`ShouldQueue`, `['mail', 'database']`,
+   links `/portal/documents`). Fired from `App\Actions\Portal\ShareDocumentWithContact` after
+   the document is saved:
+   `PortalCustomer::forEmail($contact->email)?->notify(new DocumentSharedNotification($document))`.
+   `PortalCustomer::forEmail` (#485) resolves the active portal customer (global `customer`
+   role) by email; **null-safe** — a Contact with no portal account notifies no one, and never
+   mutates permission-team context.
+
+## Security / tenancy
+
+The document share is already tenant-safe (#494). The notification targets only the one
+portal customer whose email matches the Contact — no broadcast, no cross-tenant reach.
+
+## Testing (TDD, PHPUnit sqlite → MySQL-verify)
+
+1. `Filament::getPanel('portal')->hasDatabaseNotifications()` is true.
+2. Sharing a document with a Contact that **is** a portal customer sends
+   `DocumentSharedNotification` to that user (`Notification::assertSentTo`).
+3. Sharing with a Contact that is **not** a portal customer sends nothing and does not error
+   (`Notification::assertNothingSent`).
+
+phpstan 0-new, MySQL 8.4-verified, pint clean. Inline TDD, one PR to `main`.
+
+## Out of scope
+
+Notification preferences / digest / per-channel opt-out; notifying on ticket close/reopen or
+KB changes; real-time (websocket) delivery; unread-count badges beyond Filament's built-in.

--- a/tests/Feature/Portal/PortalNotificationsTest.php
+++ b/tests/Feature/Portal/PortalNotificationsTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Portal;
+
+use App\Actions\Portal\ShareDocumentWithContact;
+use App\Models\Contact;
+use App\Models\Team;
+use App\Models\User;
+use App\Notifications\DocumentSharedNotification;
+use App\Services\DocumentService;
+use Database\Seeders\RolesSeeder;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class PortalNotificationsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function share(Contact $contact): void
+    {
+        (new ShareDocumentWithContact(app(DocumentService::class)))(
+            $contact,
+            UploadedFile::fake()->image('doc.png'),
+            'Shared file',
+            'report',
+        );
+    }
+
+    private function portalCustomer(string $email, Team $team): User
+    {
+        $customer = User::factory()->create(['email' => $email, 'email_verified_at' => now()]);
+        $customer->forceFill(['current_team_id' => $team->id])->save();
+        setPermissionsTeamId(null);
+        $customer->assignRole('customer');
+
+        return $customer;
+    }
+
+    public function test_portal_panel_shows_the_notification_bell(): void
+    {
+        $this->assertTrue(Filament::getPanel('portal')->hasDatabaseNotifications());
+    }
+
+    public function test_sharing_a_document_notifies_the_portal_customer(): void
+    {
+        Storage::fake();
+        Notification::fake();
+        $this->seed(RolesSeeder::class);
+        $team = Team::factory()->create();
+        $customer = $this->portalCustomer('cust@example.com', $team);
+        $contact = Contact::factory()->create(['team_id' => $team->id, 'email' => 'cust@example.com']);
+
+        $this->share($contact);
+
+        Notification::assertSentTo($customer, DocumentSharedNotification::class);
+    }
+
+    public function test_sharing_with_a_non_customer_contact_notifies_no_one(): void
+    {
+        Storage::fake();
+        Notification::fake();
+        $this->seed(RolesSeeder::class);
+        $team = Team::factory()->create();
+        $contact = Contact::factory()->create(['team_id' => $team->id, 'email' => 'not-a-customer@example.com']);
+
+        $this->share($contact);
+
+        Notification::assertNothingSent();
+    }
+}


### PR DESCRIPTION
## What

Completes the customer-awareness loop from #492/#494:

1. **The portal notification bell was never enabled.** #492 sends the customer a `TicketReplyNotification` on `['mail','database']`, but `PortalPanelProvider` never called `->databaseNotifications()` — so the `database` channel was **write-only** (rows in `notifications`, no bell).
2. **Document shares were silent.** #494 lets staff share a document with a Contact, but the customer was never told.

## Changes

- `PortalPanelProvider->databaseNotifications()` — surfaces the bell for every portal DB notification, retroactively lighting up #492's ticket replies.
- `App\Notifications\DocumentSharedNotification` (`mail`+`database`, links `/portal/documents`) fired from `ShareDocumentWithContact` to the Contact's portal customer via `PortalCustomer::forEmail($contact->email)?->notify(...)` — **null-safe**: a Contact with no portal account notifies no one, and the lookup never mutates permission-team context.

## Verification

- New tests: 3 (portal panel `hasDatabaseNotifications()` true · doc-share to a portal customer sends the notification · share to a non-customer contact sends nothing and doesn't error).
- Full suite **857 pass / 1 skip / 0 fail** (+3) — #494's share tests unaffected (they share before any customer exists → null-safe path).
- phpstan **0-new** (22 == baseline `ignore.unmatched`, none in changed files).
- **MySQL 8.4-verified**, pint clean.

Spec: `docs/superpowers/specs/2026-07-08-g5-portal-notifications-design.md`

## Out of scope

Notification preferences / digest / opt-out, notifying on ticket close/reopen or KB changes, websocket delivery.