### PR TITLE
feat(portal): recent-tickets feed on dashboard (G_5)

### DIFF
--- a/app/Filament/Portal/Widgets/RecentTickets.php
+++ b/app/Filament/Portal/Widgets/RecentTickets.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Portal\Widgets;
+
+use App\Filament\Portal\Resources\TicketResource;
+use App\Models\Ticket;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Filament\Widgets\TableWidget;
+
+/**
+ * The customer's recent tickets on the portal dashboard. Reuses
+ * TicketResource::getEloquentQuery() (where user_id = auth), so the feed
+ * inherits the same per-user scoping as the rest of the portal — it can never
+ * surface a ticket the resource itself would hide.
+ */
+class RecentTickets extends TableWidget
+{
+    protected static ?string $heading = 'Recent tickets';
+
+    protected int|string|array $columnSpan = 'full';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(fn () => TicketResource::getEloquentQuery()->latest('updated_at')->limit(5))
+            ->columns([
+                TextColumn::make('subject')->limit(60)->searchable(),
+                TextColumn::make('status')->badge(),
+                TextColumn::make('updated_at')->dateTime()->since()->sortable(),
+            ])
+            ->recordUrl(fn (Ticket $record): string => TicketResource::getUrl('view', ['record' => $record]))
+            ->paginated(false)
+            ->emptyStateHeading('No tickets yet');
+    }
+}

--- a/app/Providers/Filament/PortalPanelProvider.php
+++ b/app/Providers/Filament/PortalPanelProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Providers\Filament;
 
 use App\Filament\Portal\Widgets\PortalOverview;
+use App\Filament\Portal\Widgets\RecentTickets;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\DisableBladeIconComponents;
 use Filament\Http\Middleware\DispatchServingFilamentEvent;
@@ -51,6 +52,7 @@ class PortalPanelProvider extends PanelProvider
             ])
             ->widgets([
                 PortalOverview::class,
+                RecentTickets::class,
             ])
             ->middleware([
                 EncryptCookies::class,

--- a/docs/superpowers/specs/2026-07-08-g5-portal-recent-tickets-design.md
+++ b/docs/superpowers/specs/2026-07-08-g5-portal-recent-tickets-design.md
@@ -1,0 +1,39 @@
+# G_5 polish — Recent-tickets feed on portal dashboard (design)
+
+**Date:** 2026-07-08
+**Status:** approved, implementing
+**Epic:** G_5 customer portal (polish). Extends the dashboard (#488).
+
+## Problem
+
+The portal dashboard (#488) shows only four stat **counts** (`PortalOverview`). A customer
+landing there sees numbers but no view of what actually changed — no list of their recent
+tickets to click into.
+
+## Fix
+
+`App\Filament\Portal\Widgets\RecentTickets` (a `TableWidget`): the customer's five
+most-recently-updated tickets — subject / status / updated_at — each row linking to the
+portal `ViewTicket`. **Reuses `TicketResource::getEloquentQuery()`** (already `where user_id
+= Auth::id()`), so the widget inherits the same one-source-of-truth scoping as
+`PortalOverview` — it can never show a ticket the resource itself would hide. Registered on
+the portal panel alongside `PortalOverview`.
+
+## Security / tenancy
+
+Scoping is inherited from `TicketResource::getEloquentQuery` (per-user). No new query surface,
+no cross-customer disclosure. `recordUrl` resolves to the portal `ViewTicket`, itself
+ownership-scoped (foreign id → 404, #480).
+
+## Testing (TDD, PHPUnit sqlite → MySQL-verify)
+
+1. The widget lists the customer's own recent tickets and **excludes a foreign user's**
+   (scoping) — `Livewire::test(RecentTickets::class)` under the portal panel as the customer.
+2. The widget is registered on the portal panel (`Filament::getPanel('portal')->getWidgets()`).
+
+phpstan 0-new, MySQL 8.4-verified, pint clean. Inline TDD, one PR to `main`.
+
+## Out of scope
+
+Cross-surface activity (documents/KB — tickets are the actionable one), real-time updates,
+configurable row count, per-status filtering.

--- a/tests/Feature/Portal/PortalRecentTicketsTest.php
+++ b/tests/Feature/Portal/PortalRecentTicketsTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Portal;
+
+use App\Filament\Portal\Widgets\RecentTickets;
+use App\Models\Ticket;
+use App\Models\User;
+use Database\Seeders\RolesSeeder;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class PortalRecentTicketsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function actingCustomer(): User
+    {
+        $this->seed(RolesSeeder::class);
+        $customer = User::factory()->create(['email_verified_at' => now()]);
+        setPermissionsTeamId(null);
+        $customer->assignRole('customer');
+        $this->actingAs($customer);
+        Filament::setCurrentPanel(Filament::getPanel('portal'));
+
+        return $customer;
+    }
+
+    public function test_widget_lists_only_the_customers_recent_tickets(): void
+    {
+        $customer = $this->actingCustomer();
+        $mine = Ticket::factory()->create(['user_id' => $customer->id, 'subject' => 'My recent issue']);
+        $foreign = Ticket::factory()->create(['subject' => 'Not mine']);
+
+        Livewire::test(RecentTickets::class)
+            ->assertCanSeeTableRecords([$mine])
+            ->assertCanNotSeeTableRecords([$foreign]);
+    }
+
+    public function test_widget_is_registered_on_the_portal_panel(): void
+    {
+        $this->assertContains(RecentTickets::class, Filament::getPanel('portal')->getWidgets());
+    }
+}


### PR DESCRIPTION
## What

The portal dashboard (#488) showed only four stat **counts** — no view of what changed. Adds a **recent-tickets feed**.

- `App\Filament\Portal\Widgets\RecentTickets` (`TableWidget`): the customer's five most-recently-updated tickets (subject / status / updated_at), each row linking to the portal `ViewTicket`.
- **Reuses `TicketResource::getEloquentQuery()`** (already `where user_id = Auth::id()`), so scoping is inherited from one source of truth — same can't-leak guarantee as `PortalOverview`. Registered on the portal panel.

## Verification

- New tests: 2 (widget lists own recent tickets and **excludes a foreign user's**; widget registered on the portal panel).
- Full suite **859 pass / 1 skip / 0 fail** (+2).
- phpstan **0-new** (22 == baseline `ignore.unmatched`).
- **MySQL 8.4-verified**, pint clean.

Spec: `docs/superpowers/specs/2026-07-08-g5-portal-recent-tickets-design.md`

## Out of scope

Cross-surface activity (docs/KB), real-time updates, configurable row count, per-status filtering.