### PR TITLE
feat(rbac): team-admin member role management UI (F4 phase 2)

### DIFF
--- a/app/Filament/App/Resources/TeamMemberResource.php
+++ b/app/Filament/App/Resources/TeamMemberResource.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\App\Resources;
+
+use App\Enums\Role;
+use App\Filament\App\Resources\TeamMemberResource\Pages\ListTeamMembers;
+use App\Models\Team;
+use App\Models\User;
+use App\Services\TeamManagementService;
+use Filament\Actions\Action;
+use Filament\Facades\Filament;
+use Filament\Forms\Components\Select;
+use Filament\Notifications\Notification;
+use Filament\Resources\Resource;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Auth;
+
+/**
+ * Team-admin self-service role management (F4 phase 2). Team-scoped: a team admin
+ * sees and re-roles only their own team's members, and can only assign the four
+ * team roles — super_admin (global) and customer (portal) are never offered.
+ */
+class TeamMemberResource extends Resource
+{
+    protected static ?string $model = User::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-user-group';
+
+    protected static string|\UnitEnum|null $navigationGroup = 'Team';
+
+    protected static ?string $navigationLabel = 'Team roles';
+
+    protected static ?string $slug = 'team-roles';
+
+    // Model is User, which is a member of many teams — it has no `team`
+    // ownership relationship, so it can't use the app panel's automatic
+    // tenant scoping. Opt out and scope to the tenant's members manually in
+    // getEloquentQuery (else Filament throws resolving the `team` relationship).
+    protected static bool $isScopedToTenant = false;
+
+    public static function canAccess(): bool
+    {
+        $user = Auth::user();
+
+        return $user instanceof User && $user->hasRole([Role::Admin, Role::SuperAdmin]);
+    }
+
+    #[\Override]
+    public static function getEloquentQuery(): Builder
+    {
+        $tenant = Filament::getTenant();
+        $ids = $tenant instanceof Team ? $tenant->allUsers()->pluck('id')->all() : [];
+
+        return User::query()->whereKey($ids);
+    }
+
+    #[\Override]
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('name')->searchable(),
+                TextColumn::make('email')->searchable(),
+                TextColumn::make('team_role')
+                    ->label('Role')
+                    ->badge()
+                    // The request's permission team is the tenant, so getRoleNames()
+                    // returns this member's team-scoped role.
+                    ->getStateUsing(fn (User $record): string => $record->getRoleNames()->first() ?? '—'),
+            ])
+            ->recordActions([
+                Action::make('changeRole')
+                    ->label('Change role')
+                    ->icon('heroicon-o-key')
+                    // Self-guard: an admin can't re-role their own row (no self-lockout).
+                    ->visible(fn (User $record): bool => $record->getKey() !== Auth::id())
+                    ->schema([
+                        Select::make('role')
+                            ->options([
+                                Role::Admin->value => 'Admin',
+                                Role::Manager->value => 'Manager',
+                                Role::SalesRep->value => 'Sales rep',
+                                Role::Free->value => 'Free',
+                            ])
+                            ->required(),
+                    ])
+                    ->action(function (User $record, array $data, TeamManagementService $service): void {
+                        $tenant = Filament::getTenant();
+                        if ($tenant instanceof Team) {
+                            $service->changeTeamRole($record, $tenant, Role::from($data['role']));
+                            Notification::make()->title('Role updated')->success()->send();
+                        }
+                    }),
+            ])
+            ->defaultSort('name');
+    }
+
+    #[\Override]
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListTeamMembers::route('/'),
+        ];
+    }
+}

--- a/app/Filament/App/Resources/TeamMemberResource/Pages/ListTeamMembers.php
+++ b/app/Filament/App/Resources/TeamMemberResource/Pages/ListTeamMembers.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\App\Resources\TeamMemberResource\Pages;
+
+use App\Filament\App\Resources\TeamMemberResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListTeamMembers extends ListRecords
+{
+    protected static string $resource = TeamMemberResource::class;
+}

--- a/app/Services/TeamManagementService.php
+++ b/app/Services/TeamManagementService.php
@@ -8,10 +8,37 @@ use App\Models\Team;
 use App\Models\User;
 use Exception;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use InvalidArgumentException;
 use Spatie\Permission\Models\Role as SpatieRole;
 
 class TeamManagementService
 {
+    /** Roles a team admin may assign to a member (super_admin is global, customer is portal). */
+    public const TEAM_ROLES = [Role::Admin, Role::Manager, Role::SalesRep, Role::Free];
+
+    /**
+     * Replace a member's team-scoped role. Removes any of the four team roles the
+     * user holds in this team, then assigns the new one — never touching global
+     * super_admin/customer. Guards the role so the UI Select can't be bypassed.
+     */
+    public function changeTeamRole(User $user, Team $team, Role $role): void
+    {
+        if (! in_array($role, self::TEAM_ROLES, true)) {
+            throw new InvalidArgumentException("Role {$role->value} is not assignable to a team member.");
+        }
+
+        setPermissionsTeamId($team->getKey());
+        SpatieRole::firstOrCreate(['name' => $role->value, 'guard_name' => 'web', 'team_id' => null]);
+
+        foreach (self::TEAM_ROLES as $existing) {
+            if ($user->hasRole($existing->value)) {
+                $user->removeRole($existing->value);
+            }
+        }
+
+        $user->assignRole($role->value);
+    }
+
     public function createDefaultTeamForUser(User $user): Team
     {
         try {

--- a/docs/superpowers/specs/2026-07-08-f4-phase2-team-role-ui-design.md
+++ b/docs/superpowers/specs/2026-07-08-f4-phase2-team-role-ui-design.md
@@ -1,0 +1,71 @@
+# F4 phase-2 — Team member role management UI (design)
+
+**Date:** 2026-07-08
+**Status:** approved, implementing
+**Epic:** F4 per-team RBAC. The self-service role UI deferred from #465 (mechanism-only).
+
+## Problem
+
+#465 shipped spatie teams-mode RBAC (per-team roles, `setPermissionsTeamId` per request,
+team-scoped `hasRole`). But there is **no UI for a team admin to manage their own team's
+member roles** — role assignment only happens implicitly at registration
+(`CreateNewUser` → `Free`) or via `TeamManagementService`. This is F4 phase 2.
+
+## Scope (slice 1)
+
+Assign the **existing** five roles to team members from the app panel. Creating custom
+per-team roles/permissions stays out (a later slice / G3).
+
+## Architecture
+
+### `App\Filament\App\Resources\TeamMemberResource` (app panel, model `User`)
+
+- **`getEloquentQuery()`** = `User::whereIn('id', Filament::getTenant()->allUsers()->pluck('id'))`
+  — the current tenant team's members (owner + members). List-only (index page only).
+- **`canAccess()`** → team `admin` or `super_admin` (`hasRole([Admin, SuperAdmin])`, team-scoped
+  on the app panel). Managers/reps/free cannot manage roles.
+- **Table:** name, email, current team-role badge (`getStateUsing` →
+  `$record->getRoleNames()->first()`; the request's permission team is the tenant, so this is
+  the team-scoped role).
+- **Change-role row action:** a `Select` of **`admin`/`manager`/`sales_rep`/`free` only** →
+  `TeamManagementService::changeTeamRole($member, tenant, $role)`. `super_admin` (global) and
+  `customer` (portal) are never offered — no escalation out of the team.
+- **Self-guard:** the action is hidden on the acting admin's own row
+  (`visible(fn ($record) => $record->id !== Auth::id())`) — a lone admin can't self-demote into
+  lockout.
+
+### `TeamManagementService::changeTeamRole(User $user, Team $team, Role $role): void`
+
+Guards `$role ∈ {admin, manager, sales_rep, free}` (throws otherwise — defense in depth behind
+the Select). Then, in the team's permission context, removes any of the four team roles the
+user holds and assigns the new one — **never touches global `super_admin`/`customer`**:
+
+```php
+if (! in_array($role, self::TEAM_ROLES, true)) throw new InvalidArgumentException(...);
+setPermissionsTeamId($team->getKey());
+foreach (self::TEAM_ROLES as $r) { $user->removeRole($r->value); } // no-op if absent
+$user->assignRole($role->value);
+```
+
+## Security / tenancy
+
+Team-scoped throughout: the resource query and role writes are bound to the current tenant
+team; a team admin only sees and changes their own team's members. `super_admin`/`customer`
+are unassignable. Self-demotion blocked.
+
+## Testing (TDD, PHPUnit sqlite → MySQL-verify)
+
+1. A team admin sees only their own team's members (scoping; a member of another team is
+   excluded).
+2. Changing a member to `manager` writes the team-scoped role and does **not** leak to another
+   team (member has `manager` in team A context, not in team B).
+3. `changeTeamRole` **rejects** a non-team role (`super_admin`) — throws.
+4. `canAccess`: team admin ✓, manager ✗.
+5. The change-role action is **hidden on the admin's own row** (self-guard).
+
+phpstan 0-new, MySQL 8.4-verified, pint clean. Inline TDD, one PR to `main`.
+
+## Out of scope (later slices)
+
+Custom per-team roles/permissions, bulk role changes, invite-with-role, last-admin protection
+beyond the self-guard, territory/field-level ABAC (G3), a Shield permission-matrix UI.

--- a/tests/Feature/Filament/TeamRoleManagementTest.php
+++ b/tests/Feature/Filament/TeamRoleManagementTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament;
+
+use App\Enums\Role;
+use App\Filament\App\Resources\TeamMemberResource;
+use App\Filament\App\Resources\TeamMemberResource\Pages\ListTeamMembers;
+use App\Models\Team;
+use App\Models\User;
+use App\Services\TeamManagementService;
+use Database\Seeders\RolesSeeder;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use InvalidArgumentException;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class TeamRoleManagementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $admin;
+
+    private $team;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolesSeeder::class);
+        $this->admin = User::factory()->withPersonalTeam()->create(['email_verified_at' => now()]);
+        $this->team = $this->admin->currentTeam;
+        setPermissionsTeamId($this->team->id);
+        $this->admin->assignRole('admin');
+        $this->actingAs($this->admin);
+        Filament::setCurrentPanel(Filament::getPanel('app'));
+        Filament::setTenant($this->team);
+    }
+
+    private function member(): User
+    {
+        $member = User::factory()->create(['email_verified_at' => now()]);
+        $this->team->users()->attach($member);
+
+        return $member;
+    }
+
+    public function test_admin_sees_only_their_own_teams_members(): void
+    {
+        $mine = $this->member();
+        $otherTeam = Team::factory()->create();
+        $stranger = User::factory()->create();
+        $otherTeam->users()->attach($stranger);
+
+        Livewire::test(ListTeamMembers::class)
+            ->assertCanSeeTableRecords([$mine, $this->admin])
+            ->assertCanNotSeeTableRecords([$stranger]);
+    }
+
+    public function test_changing_a_role_writes_the_team_scoped_role(): void
+    {
+        $member = $this->member();
+
+        Livewire::test(ListTeamMembers::class)
+            ->callTableAction('changeRole', $member, data: ['role' => Role::Manager->value]);
+
+        setPermissionsTeamId($this->team->id);
+        $this->assertTrue($member->fresh()->hasRole(Role::Manager->value));
+
+        // Not leaked to a different team's context.
+        $otherTeam = Team::factory()->create();
+        setPermissionsTeamId($otherTeam->id);
+        $this->assertFalse($member->fresh()->hasRole(Role::Manager->value));
+    }
+
+    public function test_change_team_role_rejects_a_non_team_role(): void
+    {
+        $member = $this->member();
+
+        $this->expectException(InvalidArgumentException::class);
+        app(TeamManagementService::class)->changeTeamRole($member, $this->team, Role::SuperAdmin);
+    }
+
+    public function test_only_admins_can_access(): void
+    {
+        $this->assertTrue(TeamMemberResource::canAccess());
+
+        $manager = User::factory()->withPersonalTeam()->create(['email_verified_at' => now()]);
+        setPermissionsTeamId($manager->currentTeam->id);
+        $manager->assignRole('manager');
+        $this->actingAs($manager);
+
+        $this->assertFalse(TeamMemberResource::canAccess());
+    }
+
+    public function test_change_role_action_is_hidden_on_own_row(): void
+    {
+        $member = $this->member();
+
+        Livewire::test(ListTeamMembers::class)
+            ->assertTableActionHidden('changeRole', $this->admin)
+            ->assertTableActionVisible('changeRole', $member);
+    }
+}


### PR DESCRIPTION
## What

Ships the **self-service role UI deferred from #465** (which shipped the RBAC mechanism only). A team admin manages their own team's member roles from the app panel.

- `App\Filament\App\Resources\TeamMemberResource` (model `User`), list-only, scoped to the current tenant team's members (`Filament::getTenant()->allUsers()`).
- **Change-role row action:** a Select of `admin` / `manager` / `sales_rep` / `free` only — `super_admin` (global) and `customer` (portal) are never offered, so no escalation out of the team.
- `TeamManagementService::changeTeamRole()` replaces the member's team-scoped role (removes the four team roles, assigns the new one) within the team's permission context; guards against non-team roles behind the Select.
- **Access:** `canAccess` → team `admin` / `super_admin` (managers/reps can't). **Self-guard:** the action is hidden on the acting admin's own row (no self-lockout).

## Notable

`User` has no `team` ownership relationship, so the resource **opts out of the app panel's automatic tenancy** (`$isScopedToTenant = false`) and scopes manually — otherwise Filament throws resolving the `team` relationship. The existing resource-mount **sweep tests caught exactly this** before it shipped.

## Verification

- New tests: 5 (own-team member scoping · role change writes team-scoped + doesn't leak to another team · `changeTeamRole` rejects a non-team role · `canAccess` admin✓/manager✗ · self-row action hidden).
- Full suite **862 pass / 1 skip / 0 fail** (+5).
- phpstan **0-new** (22 == baseline `ignore.unmatched`).
- **MySQL 8.4-verified**, pint clean.

Spec: `docs/superpowers/specs/2026-07-08-f4-phase2-team-role-ui-design.md`

## Out of scope

Custom per-team roles/permissions, bulk changes, invite-with-role, last-admin protection beyond the self-guard, territory/field ABAC (G3).