### PR TITLE
feat(rbac): audit team role changes (F4 phase 2)

### DIFF
--- a/app/Filament/App/Resources/TeamRoleLogResource.php
+++ b/app/Filament/App/Resources/TeamRoleLogResource.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\App\Resources;
+
+use App\Enums\Role;
+use App\Filament\App\Resources\TeamRoleLogResource\Pages\ListTeamRoleLogs;
+use App\Models\AuditLog;
+use App\Models\User;
+use Filament\Resources\Resource;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Auth;
+
+/**
+ * Team-scoped, read-only view of team role changes (the `team.*` audit entries
+ * from changeTeamRole). AuditLog is IsTenantModel, so on the team-scoped app
+ * panel this shows only the current team's history — letting a team's own
+ * admins see who re-roled whom (the admin panel's AuditLogResource is global).
+ */
+class TeamRoleLogResource extends Resource
+{
+    protected static ?string $model = AuditLog::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-clipboard-document-list';
+
+    protected static string|\UnitEnum|null $navigationGroup = 'Team';
+
+    protected static ?string $navigationLabel = 'Role change log';
+
+    protected static ?string $slug = 'team-role-log';
+
+    public static function canAccess(): bool
+    {
+        $user = Auth::user();
+
+        return $user instanceof User && $user->hasRole([Role::SuperAdmin, Role::Admin]);
+    }
+
+    #[\Override]
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+
+    #[\Override]
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()->where('action', 'like', 'team.%');
+    }
+
+    #[\Override]
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('created_at')->dateTime()->sortable(),
+                TextColumn::make('user.name')->label('By')->searchable(),
+                TextColumn::make('action')->badge(),
+                TextColumn::make('description')->wrap()->searchable(),
+            ])
+            ->defaultSort('created_at', 'desc');
+    }
+
+    #[\Override]
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListTeamRoleLogs::route('/'),
+        ];
+    }
+}

--- a/app/Filament/App/Resources/TeamRoleLogResource/Pages/ListTeamRoleLogs.php
+++ b/app/Filament/App/Resources/TeamRoleLogResource/Pages/ListTeamRoleLogs.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\App\Resources\TeamRoleLogResource\Pages;
+
+use App\Filament\App\Resources\TeamRoleLogResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListTeamRoleLogs extends ListRecords
+{
+    protected static string $resource = TeamRoleLogResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [];
+    }
+}

--- a/app/Services/TeamManagementService.php
+++ b/app/Services/TeamManagementService.php
@@ -30,6 +30,8 @@ class TeamManagementService
         setPermissionsTeamId($team->getKey());
         SpatieRole::firstOrCreate(['name' => $role->value, 'guard_name' => 'web', 'team_id' => null]);
 
+        $previous = $user->getRoleNames()->first() ?? 'none';
+
         foreach (self::TEAM_ROLES as $existing) {
             if ($user->hasRole($existing->value)) {
                 $user->removeRole($existing->value);
@@ -37,6 +39,12 @@ class TeamManagementService
         }
 
         $user->assignRole($role->value);
+
+        app(AuditLogService::class)->record(
+            'team.role_changed',
+            "Changed {$user->getAttribute('email')} from {$previous} to {$role->value}",
+            $user,
+        );
     }
 
     public function createDefaultTeamForUser(User $user): Team

--- a/docs/superpowers/specs/2026-07-08-f4-role-audit-design.md
+++ b/docs/superpowers/specs/2026-07-08-f4-role-audit-design.md
@@ -1,0 +1,46 @@
+# F4 phase-2 — Audit team role changes (design)
+
+**Date:** 2026-07-08
+**Status:** approved, implementing
+**Epic:** F4 per-team RBAC, phase 2. Follows #497 (team-admin role UI).
+
+## Problem
+
+#497 lets a team admin change members' roles, but the change leaves **no audit trail** — a
+security/governance gap (who granted whom which role, when).
+
+## Fix (reuse #490 audit infra + #491 browse pattern)
+
+1. `TeamManagementService::changeTeamRole` records a `team.role_changed` audit via
+   `AuditLogService::record(action, description, ?auditable)` (#490): auditable = the member,
+   description = `"Changed {email} from {old} to {new}"`. `team_id` auto-stamps (AuditLog is
+   IsTenantModel, tenant set on the app panel). `AuditLogService` is resolved inline via
+   `app(AuditLogService::class)` — no constructor change to `TeamManagementService`, so
+   `new TeamManagementService` callers are untouched. `AuditLogService::record` already guards
+   `Auth::check()`, so the pure-unit reject test (no actingAs) is unaffected.
+2. `App\Filament\App\Resources\TeamRoleLogResource` (app panel, model `AuditLog`, read-only):
+   `getEloquentQuery` = `parent()->where('action', 'like', 'team.%')` (parent applies AuditLog's
+   IsTenantModel team scope → current team only). `canAccess` → admin / super_admin. Columns:
+   created_at / by (user.name) / action / description. Nav group "Team". Mirrors
+   `PortalAccessLogResource` (#491).
+
+## Security / tenancy
+
+Team-scoped throughout (AuditLog IsTenantModel + the `team.%` filter). A team admin sees only
+their own team's role-change history; the global super_admin `AuditLogResource` still shows
+everything.
+
+## Testing (TDD, PHPUnit sqlite → MySQL-verify)
+
+1. `changeTeamRole` records a `team.role_changed` AuditLog (auditable = the member, `team_id`
+   stamped to the team).
+2. `TeamRoleLogResource` lists the team's `team.%` entries and **excludes** a `portal.%` entry
+   and another team's entry.
+3. `canAccess`: admin ✓, sales_rep ✗.
+
+phpstan 0-new, MySQL 8.4-verified, pint clean. Inline TDD, one PR to `main`.
+
+## Out of scope
+
+Old/new role diff payload beyond the description string, export, auditing member invite/remove
+(no such flows yet), a combined portal+team audit view.

--- a/tests/Feature/Filament/TeamRoleAuditTest.php
+++ b/tests/Feature/Filament/TeamRoleAuditTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament;
+
+use App\Enums\Role;
+use App\Filament\App\Resources\TeamRoleLogResource;
+use App\Filament\App\Resources\TeamRoleLogResource\Pages\ListTeamRoleLogs;
+use App\Models\AuditLog;
+use App\Models\Team;
+use App\Models\User;
+use App\Services\TeamManagementService;
+use Database\Seeders\RolesSeeder;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class TeamRoleAuditTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $admin;
+
+    private $team;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolesSeeder::class);
+        $this->admin = User::factory()->withPersonalTeam()->create(['email_verified_at' => now()]);
+        $this->team = $this->admin->currentTeam;
+        setPermissionsTeamId($this->team->id);
+        $this->admin->assignRole('admin');
+        $this->actingAs($this->admin);
+        Filament::setCurrentPanel(Filament::getPanel('app'));
+        Filament::setTenant($this->team);
+    }
+
+    public function test_changing_a_role_records_an_audit_entry(): void
+    {
+        $member = User::factory()->create();
+        $this->team->users()->attach($member);
+
+        app(TeamManagementService::class)->changeTeamRole($member, $this->team, Role::Manager);
+
+        $this->assertDatabaseHas('audit_logs', [
+            'action' => 'team.role_changed',
+            'auditable_type' => User::class,
+            'auditable_id' => $member->id,
+            'team_id' => $this->team->id,
+            'user_id' => $this->admin->id,
+        ]);
+    }
+
+    private function audit(string $action, int $teamId): AuditLog
+    {
+        $log = new AuditLog([
+            'action' => $action,
+            'description' => 'x',
+            'user_id' => $this->admin->id,
+            'ip_address' => '0.0.0.0',
+        ]);
+        $log->setAttribute('team_id', $teamId);
+        $log->save();
+
+        return $log;
+    }
+
+    public function test_resource_shows_only_team_role_entries_for_this_team(): void
+    {
+        $mine = $this->audit('team.role_changed', $this->team->id);
+        $portal = $this->audit('portal.invited', $this->team->id);
+        $otherTeam = $this->audit('team.role_changed', Team::factory()->create()->id);
+
+        Livewire::test(ListTeamRoleLogs::class)
+            ->assertCanSeeTableRecords([$mine])
+            ->assertCanNotSeeTableRecords([$portal, $otherTeam]);
+    }
+
+    public function test_access_is_admin_only(): void
+    {
+        $this->assertTrue(TeamRoleLogResource::canAccess());
+
+        $rep = User::factory()->withPersonalTeam()->create(['email_verified_at' => now()]);
+        setPermissionsTeamId($rep->currentTeam->id);
+        $rep->assignRole('sales_rep');
+        $this->actingAs($rep);
+
+        $this->assertFalse(TeamRoleLogResource::canAccess());
+    }
+}


### PR DESCRIPTION
## What

Role changes from #497 left **no audit trail** — a governance gap for RBAC. This adds one, reusing the existing audit infra (#490) and team-scoped browse pattern (#491).

- `TeamManagementService::changeTeamRole` now records a `team.role_changed` `AuditLog` via `AuditLogService::record` — auditable = the member, description = `"Changed {email} from {old} to {new}"`. `team_id` auto-stamps (AuditLog is `IsTenantModel`). Resolved inline via `app(AuditLogService::class)`, so no constructor change to `TeamManagementService` (existing `new` callers untouched).
- `App\Filament\App\Resources\TeamRoleLogResource` (app panel, `AuditLog`, read-only): `getEloquentQuery` filters `action like 'team.%'`, team-scoped via AuditLog's IsTenantModel scope; `canAccess` → admin/super_admin; nav group "Team". Mirrors `PortalAccessLogResource`.

## Verification

- New tests: 3 (change records the audit with auditable + team_id; the resource lists the team's `team.%` entries and excludes a `portal.%` entry + another team's; `canAccess` admin✓/sales_rep✗).
- Full suite **867 pass / 1 skip / 0 fail** (+5) — #497's role tests and the resource-mount sweeps still green.
- phpstan **0-new** (22 == baseline `ignore.unmatched`).
- **MySQL 8.4-verified**, pint clean.

Spec: `docs/superpowers/specs/2026-07-08-f4-role-audit-design.md`

## Out of scope

Old/new role diff payload beyond the description, export, auditing member invite/remove (no such flows yet), a combined portal+team audit view.