### PR TITLE
feat(rbac): protect the team owner's role (F4 phase 2)

### DIFF
--- a/app/Filament/App/Resources/TeamMemberResource.php
+++ b/app/Filament/App/Resources/TeamMemberResource.php
@@ -76,8 +76,15 @@ class TeamMemberResource extends Resource
                 Action::make('changeRole')
                     ->label('Change role')
                     ->icon('heroicon-o-key')
-                    // Self-guard: an admin can't re-role their own row (no self-lockout).
-                    ->visible(fn (User $record): bool => $record->getKey() !== Auth::id())
+                    // Hidden on the acting admin's own row (no self-lockout) and on
+                    // the team owner's row (their role is immutable — changeTeamRole
+                    // rejects it too).
+                    ->visible(function (User $record): bool {
+                        $tenant = Filament::getTenant();
+                        $ownerId = $tenant instanceof Team ? $tenant->getAttribute('user_id') : null;
+
+                        return $record->getKey() !== Auth::id() && $record->getKey() !== $ownerId;
+                    })
                     ->schema([
                         Select::make('role')
                             ->options([

--- a/app/Services/TeamManagementService.php
+++ b/app/Services/TeamManagementService.php
@@ -27,6 +27,12 @@ class TeamManagementService
             throw new InvalidArgumentException("Role {$role->value} is not assignable to a team member.");
         }
 
+        // The owner manages the team; their role is immutable here, so a team can
+        // never be left without its owner as a stable admin.
+        if ($user->getKey() === $team->getAttribute('user_id')) {
+            throw new InvalidArgumentException("The team owner's role cannot be changed.");
+        }
+
         setPermissionsTeamId($team->getKey());
         SpatieRole::firstOrCreate(['name' => $role->value, 'guard_name' => 'web', 'team_id' => null]);
 

--- a/docs/superpowers/specs/2026-07-08-f4-owner-role-guard-design.md
+++ b/docs/superpowers/specs/2026-07-08-f4-owner-role-guard-design.md
@@ -1,0 +1,37 @@
+# F4 phase-2 — Protect the team owner's role (design)
+
+**Date:** 2026-07-08
+**Status:** approved, implementing
+**Epic:** F4 per-team RBAC, phase 2. Follows #497 (role UI) / #498 (audit).
+
+## Problem
+
+#497's self-guard stops an admin re-rolling **their own** row, so the acting admin always
+stays admin — the team can't lose all admins that way. But the **team owner** is unprotected:
+admin A can demote owner B (B ≠ A) to `free`, leaving the owner without the admin role while
+still owning the team — a broken governance state.
+
+## Fix
+
+Make the team owner's role immutable through this surface:
+
+1. `TeamManagementService::changeTeamRole` throws `InvalidArgumentException` when
+   `$user` is the team owner (`$user->getKey() === $team->getAttribute('user_id')`) —
+   defense in depth behind the UI.
+2. `TeamMemberResource` change-role row action is hidden on the owner's row (in addition to
+   the acting admin's own row): `visible = $record !== auth && $record !== tenant.user_id`.
+
+Combined with #497's self-guard, every team keeps at least its owner as a stable admin.
+
+## Testing (TDD, PHPUnit sqlite → MySQL-verify)
+
+1. `changeTeamRole` **rejects** changing the team owner's role (throws) — using a team whose
+   owner is not the acting admin.
+2. The change-role action is **hidden on the owner's row** and visible on a regular member's.
+
+phpstan 0-new, MySQL 8.4-verified, pint clean. Inline TDD, one PR to `main`.
+
+## Out of scope
+
+Guaranteeing the owner *holds* the admin role (ownership vs role is a Jetstream concern),
+transferring ownership, last-admin math beyond the owner invariant.

--- a/tests/Feature/Filament/TeamOwnerRoleGuardTest.php
+++ b/tests/Feature/Filament/TeamOwnerRoleGuardTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament;
+
+use App\Enums\Role;
+use App\Filament\App\Resources\TeamMemberResource\Pages\ListTeamMembers;
+use App\Models\User;
+use App\Services\TeamManagementService;
+use Database\Seeders\RolesSeeder;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use InvalidArgumentException;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class TeamOwnerRoleGuardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $owner;
+
+    private User $admin;
+
+    private $team;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolesSeeder::class);
+
+        // A team owned by $owner; $admin is a (non-owner) admin member acting.
+        $this->owner = User::factory()->withPersonalTeam()->create(['email_verified_at' => now()]);
+        $this->team = $this->owner->currentTeam;
+        $this->admin = User::factory()->create(['email_verified_at' => now()]);
+        $this->team->users()->attach($this->admin);
+
+        setPermissionsTeamId($this->team->id);
+        $this->owner->assignRole('admin');
+        $this->admin->assignRole('admin');
+
+        $this->actingAs($this->admin);
+        Filament::setCurrentPanel(Filament::getPanel('app'));
+        Filament::setTenant($this->team);
+    }
+
+    public function test_change_team_role_rejects_changing_the_owner(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        app(TeamManagementService::class)->changeTeamRole($this->owner, $this->team, Role::Manager);
+    }
+
+    public function test_change_action_hidden_on_owner_row_visible_on_member(): void
+    {
+        $member = User::factory()->create(['email_verified_at' => now()]);
+        $this->team->users()->attach($member);
+
+        Livewire::test(ListTeamMembers::class)
+            ->assertTableActionHidden('changeRole', $this->owner)
+            ->assertTableActionVisible('changeRole', $member);
+    }
+}


### PR DESCRIPTION
## What

#497's self-guard stops an admin re-rolling their own row, but the **team owner** was unprotected: admin A could demote owner B to `free`, leaving the owner without the admin role while still owning the team — a broken governance state.

- `TeamManagementService::changeTeamRole` throws when the target is the team owner (`$user->getKey() === $team->getAttribute('user_id')`) — defense in depth.
- The change-role row action is now hidden on the owner's row too (alongside the acting admin's own row).

Combined with the self-guard, every team keeps its owner as a stable admin.

## Verification

- New tests: 2 (`changeTeamRole` rejects changing the owner; the action is hidden on the owner's row, visible on a regular member).
- Full suite **869 pass / 1 skip / 0 fail** (+2) — #497/#498 tests intact.
- phpstan **0-new** (22 == baseline `ignore.unmatched`).
- **MySQL 8.4-verified**, pint clean.

Spec: `docs/superpowers/specs/2026-07-08-f4-owner-role-guard-design.md`

## Out of scope

Guaranteeing the owner *holds* admin (ownership vs role is a Jetstream concern), ownership transfer, last-admin math beyond the owner invariant.