### PR TITLE
feat(sso): per-team SSO connection config (G2 slice 1)

### DIFF
--- a/app/Filament/App/Resources/SsoConnectionResource.php
+++ b/app/Filament/App/Resources/SsoConnectionResource.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\App\Resources;
+
+use App\Enums\Role;
+use App\Filament\App\Resources\SsoConnectionResource\Pages\CreateSsoConnection;
+use App\Filament\App\Resources\SsoConnectionResource\Pages\EditSsoConnection;
+use App\Filament\App\Resources\SsoConnectionResource\Pages\ListSsoConnections;
+use App\Models\SsoConnection;
+use App\Models\User;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Illuminate\Support\Facades\Auth;
+
+/**
+ * A team admin manages their team's SSO (OIDC) connection (G2 slice 1). Team is
+ * the tenant, so SsoConnection (IsTenantModel) auto-scopes and stamps team_id.
+ * One connection per team. The client secret is encrypted at rest and never
+ * rendered back into the form after it is saved.
+ */
+class SsoConnectionResource extends Resource
+{
+    protected static ?string $model = SsoConnection::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-finger-print';
+
+    protected static string|\UnitEnum|null $navigationGroup = 'Team';
+
+    protected static ?string $navigationLabel = 'Single sign-on';
+
+    protected static ?string $slug = 'sso';
+
+    public static function canAccess(): bool
+    {
+        $user = Auth::user();
+
+        return $user instanceof User && $user->hasRole([Role::SuperAdmin, Role::Admin]);
+    }
+
+    #[\Override]
+    public static function canCreate(): bool
+    {
+        // One connection per team.
+        return static::getEloquentQuery()->count() === 0;
+    }
+
+    #[\Override]
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            Select::make('provider')
+                ->options([
+                    'oidc' => 'OpenID Connect',
+                    'okta' => 'Okta',
+                    'azure' => 'Azure AD',
+                    'auth0' => 'Auth0',
+                ])
+                ->default('oidc')
+                ->required(),
+            TextInput::make('client_id')->required()->maxLength(255),
+            TextInput::make('client_secret')
+                ->password()
+                ->revealable()
+                ->maxLength(1000)
+                // Never render the stored secret back into the form...
+                ->afterStateHydrated(fn (TextInput $component) => $component->state(''))
+                // ...require it on create, and on edit save it only when a new
+                // value is entered (blank = keep the stored secret).
+                ->required(fn (string $operation): bool => $operation === 'create')
+                ->dehydrated(fn (?string $state): bool => filled($state)),
+            TextInput::make('issuer_url')->url()->required()->maxLength(255),
+            Toggle::make('enabled'),
+        ]);
+    }
+
+    #[\Override]
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('provider')->badge(),
+                TextColumn::make('issuer_url')->searchable(),
+                IconColumn::make('enabled')->boolean(),
+                TextColumn::make('updated_at')->dateTime()->sortable(),
+            ]);
+    }
+
+    #[\Override]
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListSsoConnections::route('/'),
+            'create' => CreateSsoConnection::route('/create'),
+            'edit' => EditSsoConnection::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/App/Resources/SsoConnectionResource/Pages/CreateSsoConnection.php
+++ b/app/Filament/App/Resources/SsoConnectionResource/Pages/CreateSsoConnection.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\App\Resources\SsoConnectionResource\Pages;
+
+use App\Filament\App\Resources\SsoConnectionResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateSsoConnection extends CreateRecord
+{
+    protected static string $resource = SsoConnectionResource::class;
+}

--- a/app/Filament/App/Resources/SsoConnectionResource/Pages/EditSsoConnection.php
+++ b/app/Filament/App/Resources/SsoConnectionResource/Pages/EditSsoConnection.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\App\Resources\SsoConnectionResource\Pages;
+
+use App\Filament\App\Resources\SsoConnectionResource;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditSsoConnection extends EditRecord
+{
+    protected static string $resource = SsoConnectionResource::class;
+
+    #[\Override]
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/App/Resources/SsoConnectionResource/Pages/ListSsoConnections.php
+++ b/app/Filament/App/Resources/SsoConnectionResource/Pages/ListSsoConnections.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\App\Resources\SsoConnectionResource\Pages;
+
+use App\Filament\App\Resources\SsoConnectionResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListSsoConnections extends ListRecords
+{
+    protected static string $resource = SsoConnectionResource::class;
+
+    #[\Override]
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Models/SsoConnection.php
+++ b/app/Models/SsoConnection.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Traits\IsTenantModel;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * A team's SSO (OIDC) identity-provider connection. IsTenantModel gives the
+ * team scope, team_id auto-stamp, and team() relationship. client_secret is
+ * encrypted at rest.
+ */
+class SsoConnection extends Model
+{
+    use HasFactory;
+    use IsTenantModel;
+
+    protected $fillable = [
+        'team_id',
+        'provider',
+        'client_id',
+        'client_secret',
+        'issuer_url',
+        'enabled',
+    ];
+
+    protected $casts = [
+        'client_secret' => 'encrypted',
+        'enabled' => 'boolean',
+    ];
+}

--- a/database/factories/SsoConnectionFactory.php
+++ b/database/factories/SsoConnectionFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\SsoConnection;
+use App\Models\Team;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class SsoConnectionFactory extends Factory
+{
+    protected $model = SsoConnection::class;
+
+    public function definition(): array
+    {
+        return [
+            'team_id' => Team::factory(),
+            'provider' => 'oidc',
+            'client_id' => $this->faker->uuid(),
+            'client_secret' => 'secret-'.$this->faker->uuid(),
+            'issuer_url' => 'https://idp.example.com',
+            'enabled' => false,
+        ];
+    }
+}

--- a/database/migrations/2026_07_08_000000_create_sso_connections_table.php
+++ b/database/migrations/2026_07_08_000000_create_sso_connections_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('sso_connections')) {
+            return;
+        }
+
+        Schema::create('sso_connections', function (Blueprint $table): void {
+            $table->id();
+            // One connection per team.
+            $table->foreignId('team_id')->unique()->constrained()->cascadeOnDelete();
+            $table->string('provider')->default('oidc');
+            $table->string('client_id');
+            // Encrypted at rest -> ciphertext is longer than the plaintext.
+            $table->text('client_secret');
+            $table->string('issuer_url');
+            $table->boolean('enabled')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('sso_connections');
+    }
+};

--- a/docs/superpowers/specs/2026-07-08-g2-sso-connection-design.md
+++ b/docs/superpowers/specs/2026-07-08-g2-sso-connection-design.md
@@ -1,0 +1,64 @@
+# G2 SSO — slice 1: per-team SSO connection config (design)
+
+**Date:** 2026-07-08
+**Status:** approved, implementing
+**Epic:** G2 SSO (SAML/Okta/Auth0). First slice — the config foundation, no auth flow yet.
+
+## Epic decomposition
+
+1. **Per-team SSO connection config** (this slice) — store + manage a team's OIDC connection,
+   secret encrypted at rest. No login flow.
+2. OIDC login flow — redirect → callback via Socialite generic OIDC, match/login the user.
+3. JIT provisioning — first SSO login provisions the user into the team with a default role.
+4. Enforcement / SAML / discovery metadata.
+
+Socialstream (→ Laravel Socialite) is already installed, so slice 2 rides Socialite. This
+slice is greenfield (the existing `oauth_configurations`/`connected_accounts` are for
+helpdesk/social integrations, not team login).
+
+## Slice 1 architecture
+
+### `sso_connections` table
+
+`team_id` (FK, **unique** — one connection per team), `provider` (oidc/okta/azure/auth0),
+`client_id`, `client_secret` (encrypted at rest), `issuer_url`, `enabled` (bool, default
+false), timestamps. Guarded create (`Schema::hasTable`), `constrained()->cascadeOnDelete()`.
+
+### `App\Models\SsoConnection`
+
+`IsTenantModel` (gives the global team scope, `team_id` auto-stamp, and the `team()`
+relationship the app panel's tenancy needs) + casts `client_secret => 'encrypted'`,
+`enabled => 'boolean'`. The encrypted cast means the secret is ciphertext in the DB and
+decrypted transparently by the model.
+
+### `App\Filament\App\Resources\SsoConnectionResource` (app panel, team-scoped)
+
+- `canAccess` → team admin / super_admin.
+- Form: provider (Select), client_id, client_secret, issuer_url (url), enabled (Toggle).
+- **Secret handling (trust boundary):** the field is a password input, **blanked on form
+  load** (never re-displays the stored secret), **required on create**, and **dehydrated only
+  when filled** — so submitting an edit with the secret left blank preserves the stored one.
+- One connection per team: `canCreate` returns false once the team already has one.
+- Team scoping is automatic (IsTenantModel + the app panel tenant), like other app resources.
+
+## Security
+
+`client_secret` is encrypted at rest (Laravel `encrypted` cast, APP_KEY) and never rendered
+back into the form after save. The connection is team-scoped; a team admin only manages their
+own team's connection.
+
+## Testing (TDD, PHPUnit sqlite → MySQL-verify)
+
+1. Admin creates a connection → `team_id` stamped; the stored `client_secret` column is
+   **ciphertext (≠ the plaintext)** and the model decrypts it back.
+2. Team-scoped: team A's admin doesn't see team B's connection.
+3. `canAccess`: admin ✓, sales_rep ✗.
+4. Editing with the secret field left blank **preserves** the stored secret.
+5. `canCreate` is false once the team has a connection (one per team).
+
+phpstan 0-new, MySQL 8.4-verified, pint clean. Inline TDD, one PR to `main`.
+
+## Out of scope (later slices)
+
+The OIDC redirect/callback login flow, JIT provisioning, SAML, SSO enforcement (require-SSO
+per team), live discovery-URL/metadata validation, multiple providers per team.

--- a/tests/Feature/Filament/SsoConnectionTest.php
+++ b/tests/Feature/Filament/SsoConnectionTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament;
+
+use App\Filament\App\Resources\SsoConnectionResource;
+use App\Filament\App\Resources\SsoConnectionResource\Pages\CreateSsoConnection;
+use App\Filament\App\Resources\SsoConnectionResource\Pages\EditSsoConnection;
+use App\Filament\App\Resources\SsoConnectionResource\Pages\ListSsoConnections;
+use App\Models\SsoConnection;
+use App\Models\Team;
+use App\Models\User;
+use Database\Seeders\RolesSeeder;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class SsoConnectionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $admin;
+
+    private $team;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolesSeeder::class);
+        $this->admin = User::factory()->withPersonalTeam()->create(['email_verified_at' => now()]);
+        $this->team = $this->admin->currentTeam;
+        setPermissionsTeamId($this->team->id);
+        $this->admin->assignRole('admin');
+        $this->actingAs($this->admin);
+        Filament::setCurrentPanel(Filament::getPanel('app'));
+        Filament::setTenant($this->team);
+    }
+
+    public function test_admin_creates_a_connection_with_encrypted_secret(): void
+    {
+        Livewire::test(CreateSsoConnection::class)
+            ->fillForm([
+                'provider' => 'oidc',
+                'client_id' => 'client-abc',
+                'client_secret' => 'super-secret-value',
+                'issuer_url' => 'https://idp.example.com',
+                'enabled' => true,
+            ])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        $connection = SsoConnection::withoutGlobalScope('tenant')->where('team_id', $this->team->id)->first();
+        $this->assertNotNull($connection);
+        $this->assertSame('super-secret-value', $connection->client_secret);
+
+        // Ciphertext at rest — the raw DB value is not the plaintext.
+        $raw = DB::table('sso_connections')->where('id', $connection->id)->value('client_secret');
+        $this->assertNotSame('super-secret-value', $raw);
+    }
+
+    public function test_connection_is_team_scoped(): void
+    {
+        $mine = SsoConnection::factory()->create(['team_id' => $this->team->id]);
+        $other = SsoConnection::factory()->create(['team_id' => Team::factory()->create()->id]);
+
+        Livewire::test(ListSsoConnections::class)
+            ->assertCanSeeTableRecords([$mine])
+            ->assertCanNotSeeTableRecords([$other]);
+    }
+
+    public function test_access_is_admin_only(): void
+    {
+        $this->assertTrue(SsoConnectionResource::canAccess());
+
+        $rep = User::factory()->withPersonalTeam()->create(['email_verified_at' => now()]);
+        setPermissionsTeamId($rep->currentTeam->id);
+        $rep->assignRole('sales_rep');
+        $this->actingAs($rep);
+
+        $this->assertFalse(SsoConnectionResource::canAccess());
+    }
+
+    public function test_editing_without_a_new_secret_preserves_the_stored_one(): void
+    {
+        $connection = SsoConnection::factory()->create([
+            'team_id' => $this->team->id,
+            'client_secret' => 'original-secret',
+        ]);
+
+        Livewire::test(EditSsoConnection::class, ['record' => $connection->getKey()])
+            ->fillForm(['client_id' => 'rotated-client', 'client_secret' => ''])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        $fresh = $connection->fresh();
+        $this->assertSame('rotated-client', $fresh->client_id);
+        $this->assertSame('original-secret', $fresh->client_secret);
+    }
+
+    public function test_only_one_connection_per_team(): void
+    {
+        SsoConnection::factory()->create(['team_id' => $this->team->id]);
+
+        $this->assertFalse(SsoConnectionResource::canCreate());
+    }
+}


### PR DESCRIPTION
## What

First slice of the **G2 SSO** epic — the config foundation, **no login flow yet**. A team admin stores their team's OIDC identity-provider connection, with the client secret encrypted at rest.

### Epic decomposition
1. **Per-team SSO connection config** (this PR)
2. OIDC login flow (redirect → callback via Socialite → match/login) — Socialstream/Socialite already installed
3. JIT provisioning (first SSO login → into the team + default role)
4. Enforcement / SAML / discovery metadata

## Changes

- `sso_connections` table: `team_id` **unique** (one per team), `provider`, `client_id`, **encrypted** `client_secret` (text), `issuer_url`, `enabled`.
- `App\Models\SsoConnection` — `IsTenantModel` (team scope + `team_id` auto-stamp + `team()` relationship for app-panel tenancy); `client_secret` `encrypted` cast, `enabled` boolean.
- `SsoConnectionResource` (app panel, `canAccess` admin/super_admin, one per team). **Secret handling:** blanked on form load (never re-displayed), required on create, **dehydrated only when re-entered** — a blank edit keeps the stored secret.

## Verification

- New tests: 5 (create stamps team_id + **secret is ciphertext at rest**, model decrypts; team-scoped; `canAccess` admin✓/sales_rep✗; blank-secret edit preserves it; one-per-team `canCreate`).
- Full suite **875 pass / 1 skip / 0 fail** (+6) — the `CrossTenantLeakageTest` auto-covers the new IsTenantModel, and the resource-mount sweeps pass.
- phpstan **0-new** (22 == baseline `ignore.unmatched`).
- **MySQL 8.4-verified**, pint clean.

Spec: `docs/superpowers/specs/2026-07-08-g2-sso-connection-design.md`

## Security

`client_secret` encrypted at rest (Laravel `encrypted` cast / APP_KEY), never rendered back into the form after save. Team-scoped — an admin manages only their own team's connection.

## Out of scope (later slices)

The OIDC redirect/callback login flow, JIT provisioning, SAML, SSO enforcement, live discovery/metadata validation.