### PR TITLE
feat(sso): OIDC login flow for team members (G2 slice 2)

### DIFF
--- a/app/Exceptions/SsoException.php
+++ b/app/Exceptions/SsoException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions;
+
+use Exception;
+
+class SsoException extends Exception {}

--- a/app/Http/Controllers/SsoLoginController.php
+++ b/app/Http/Controllers/SsoLoginController.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Models\SsoConnection;
+use App\Models\Team;
+use App\Models\User;
+use App\Services\Sso\OidcClient;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Str;
+
+/**
+ * OIDC login for a team's members (G2 slice 2). No just-in-time provisioning
+ * here — an email with no matching team member is denied (that is slice 3).
+ */
+class SsoLoginController extends Controller
+{
+    public function redirect(Team $team, OidcClient $oidc): RedirectResponse
+    {
+        $connection = $this->enabledConnection($team);
+
+        $state = Str::random(40);
+        session(['sso_state' => $state, 'sso_team' => $team->getKey()]);
+
+        return redirect()->away(
+            $oidc->authorizeUrl($connection, route('sso.callback', $team), $state)
+        );
+    }
+
+    public function callback(Team $team, Request $request, OidcClient $oidc): RedirectResponse
+    {
+        // CSRF: the state we minted on redirect must come back unchanged.
+        $state = $request->query('state');
+        abort_unless(is_string($state) && $state === session('sso_state'), 403, 'Invalid SSO state.');
+        $request->session()->forget(['sso_state', 'sso_team']);
+
+        $connection = $this->enabledConnection($team);
+
+        $accessToken = $oidc->exchangeCode($connection, (string) $request->query('code'), route('sso.callback', $team));
+        $email = $oidc->userinfo($connection, $accessToken)['email'] ?? null;
+
+        $user = is_string($email) ? User::where('email', $email)->first() : null;
+        abort_unless($user instanceof User && $user->belongsToTeam($team), 403, 'No access for this account.');
+
+        $user->forceFill(['current_team_id' => $team->getKey()])->save();
+        Auth::login($user);
+        $request->session()->regenerate();
+
+        return redirect()->intended('/app');
+    }
+
+    private function enabledConnection(Team $team): SsoConnection
+    {
+        // Login is pre-auth (no tenant context), so read the connection unscoped.
+        $connection = SsoConnection::withoutGlobalScope('tenant')
+            ->where('team_id', $team->getKey())
+            ->where('enabled', true)
+            ->first();
+
+        abort_unless($connection instanceof SsoConnection, 404);
+
+        return $connection;
+    }
+}

--- a/app/Services/Sso/OidcClient.php
+++ b/app/Services/Sso/OidcClient.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Sso;
+
+use App\Exceptions\SsoException;
+use App\Models\SsoConnection;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+
+/**
+ * Minimal OIDC authorization-code client, driven by a team's SsoConnection.
+ * Endpoints come from the provider's discovery document. The email is read from
+ * the userinfo endpoint using an access token obtained by our own authenticated
+ * token request — so no id_token signature handling is needed for this slice.
+ */
+class OidcClient
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function discover(SsoConnection $connection): array
+    {
+        $issuer = rtrim((string) $connection->getAttribute('issuer_url'), '/');
+
+        return Cache::remember("sso_discovery:{$issuer}", 3600, function () use ($issuer): array {
+            $response = Http::acceptJson()->get($issuer.'/.well-known/openid-configuration');
+
+            if (! $response->successful()) {
+                throw new SsoException('Could not load the identity provider configuration.');
+            }
+
+            $data = (array) $response->json();
+
+            foreach (['authorization_endpoint', 'token_endpoint', 'userinfo_endpoint'] as $key) {
+                if (empty($data[$key])) {
+                    throw new SsoException("Identity provider discovery is missing {$key}.");
+                }
+            }
+
+            return $data;
+        });
+    }
+
+    public function authorizeUrl(SsoConnection $connection, string $redirectUri, string $state): string
+    {
+        $endpoint = (string) $this->discover($connection)['authorization_endpoint'];
+
+        return $endpoint.'?'.http_build_query([
+            'client_id' => $connection->getAttribute('client_id'),
+            'redirect_uri' => $redirectUri,
+            'response_type' => 'code',
+            'scope' => 'openid email profile',
+            'state' => $state,
+        ]);
+    }
+
+    public function exchangeCode(SsoConnection $connection, string $code, string $redirectUri): string
+    {
+        $endpoint = (string) $this->discover($connection)['token_endpoint'];
+
+        $response = Http::asForm()->acceptJson()->post($endpoint, [
+            'grant_type' => 'authorization_code',
+            'code' => $code,
+            'redirect_uri' => $redirectUri,
+            'client_id' => $connection->getAttribute('client_id'),
+            'client_secret' => $connection->getAttribute('client_secret'),
+        ]);
+
+        $token = $response->json('access_token');
+
+        if (! $response->successful() || ! is_string($token)) {
+            throw new SsoException('The identity provider rejected the login.');
+        }
+
+        return $token;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function userinfo(SsoConnection $connection, string $accessToken): array
+    {
+        $endpoint = (string) $this->discover($connection)['userinfo_endpoint'];
+
+        $response = Http::withToken($accessToken)->acceptJson()->get($endpoint);
+
+        if (! $response->successful()) {
+            throw new SsoException('Could not read the profile from the identity provider.');
+        }
+
+        return (array) $response->json();
+    }
+}

--- a/docs/superpowers/specs/2026-07-08-g2-sso-login-design.md
+++ b/docs/superpowers/specs/2026-07-08-g2-sso-login-design.md
@@ -1,0 +1,68 @@
+# G2 SSO — slice 2: OIDC login flow (design)
+
+**Date:** 2026-07-08
+**Status:** approved, implementing
+**Epic:** G2 SSO. Builds on #500 (per-team SSO connection). The payoff slice — a team's
+users actually sign in via their IdP.
+
+## Scope
+
+Authenticate an **existing team member** through the team's OIDC connection. Just-in-time
+user provisioning (create the user on first login) is **slice 3** — here an email with no
+matching team member is denied.
+
+## Flow (OIDC authorization-code + userinfo)
+
+Raw OIDC over Laravel's HTTP client — no id_token crypto to hand-roll, no new dependency. The
+email comes from the IdP's **userinfo** endpoint, fetched server-side with an access token the
+IdP issued to our authenticated token request.
+
+- `GET /sso/{team}/redirect` → `SsoLoginController@redirect`
+  - Load the team's `SsoConnection` (must be `enabled`, else 404).
+  - Discover endpoints from `{issuer}/.well-known/openid-configuration` (cached).
+  - Generate a random `state`, store it (+ team id) in the session (**CSRF**).
+  - Redirect to `authorization_endpoint` with `client_id`, `redirect_uri` (= the callback
+    route), `response_type=code`, `scope=openid email profile`, `state`.
+- `GET /sso/{team}/callback` → `SsoLoginController@callback`
+  - **Verify** `state` matches the session (else 403); forget it.
+  - Exchange `code` at `token_endpoint` (`grant_type=authorization_code`, `client_id`,
+    `client_secret`, `redirect_uri`) → `access_token`.
+  - `GET userinfo_endpoint` with the bearer token → `email`.
+  - Find the `User` by email; if they **belong to this team** (`belongsToTeam`) → `Auth::login`,
+    **regenerate the session**, set `current_team_id`, redirect to `/app`. Otherwise **403**
+    (no JIT in this slice).
+
+## Components
+
+- `App\Services\Sso\OidcClient` — `discover()` (cached), `authorizeUrl()`, `exchangeCode()`,
+  `userinfo()`. All via `Http::` (fakeable). Throws `App\Exceptions\SsoException` on failure.
+- `App\Http\Controllers\SsoLoginController` — `redirect` / `callback`.
+- Routes in `web.php` (web/session middleware, **unauthenticated**): `sso.redirect`,
+  `sso.callback`.
+
+## Security
+
+- `state` CSRF: minted on redirect, stored server-side (session), verified on callback.
+- `client_secret` only ever sent server-to-server to the token endpoint (`client_secret_post`).
+- Only existing **team members** are logged in (no JIT here); session regenerated on login.
+- The `SsoConnection` is read with `withoutGlobalScope('tenant')` (login is pre-auth, no
+  tenant context).
+
+## Testing (TDD, PHPUnit + `Http::fake()`)
+
+1. `redirect` → 302 to the `authorization_endpoint` carrying `client_id`/`state`/`redirect_uri`;
+   the session holds the state.
+2. `callback` with a valid code and a **matching team member** → authenticated + redirected.
+3. `callback` with a **mismatched state** → 403, not authenticated.
+4. `callback` whose userinfo email is **not a team member** → 403 (no JIT).
+5. `redirect` for a **disabled/absent** connection → 404.
+
+phpstan 0-new, MySQL 8.4-verified, pint clean. Inline TDD, one PR to `main`.
+
+## Out of scope / ceilings (stated)
+
+- **JIT provisioning** (create the user + team membership on first login) — slice 3.
+- `id_token` signature / JWKS validation (we trust userinfo via the server-side token
+  exchange) — a hardening slice later.
+- `client_secret_basic` token auth (only `client_secret_post` here), PKCE, multiple providers,
+  SSO-enforcement (require SSO for a team), SAML.

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\KnowledgeBaseController;
 use App\Http\Controllers\LeadFormController;
 use App\Http\Controllers\OAuthConfigurationController;
 use App\Http\Controllers\QuoteRequestController;
+use App\Http\Controllers\SsoLoginController;
 use App\Http\Controllers\TeamInvitationController;
 use App\Http\Controllers\TicketController;
 use App\Http\Controllers\TwilioController;
@@ -28,6 +29,10 @@ Route::get('/health/ready', function () {
         return response()->json(['status' => 'not ready', 'error' => 'Database unavailable'], 503);
     }
 })->name('health.ready');
+
+// Per-team SSO (OIDC) login — unauthenticated; state stored in the session.
+Route::get('/sso/{team}/redirect', [SsoLoginController::class, 'redirect'])->name('sso.redirect');
+Route::get('/sso/{team}/callback', [SsoLoginController::class, 'callback'])->name('sso.callback');
 
 // Contact list API routes (no auth required for testing and public access)
 // Specific routes must be defined before the wildcard {created_at?} route to avoid conflicts

--- a/tests/Feature/Sso/SsoLoginTest.php
+++ b/tests/Feature/Sso/SsoLoginTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Sso;
+
+use App\Models\SsoConnection;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class SsoLoginTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function connection(Team $team, bool $enabled = true): SsoConnection
+    {
+        return SsoConnection::factory()->create([
+            'team_id' => $team->id,
+            'issuer_url' => 'https://idp.example.com',
+            'client_id' => 'client-abc',
+            'client_secret' => 'shhh',
+            'enabled' => $enabled,
+        ]);
+    }
+
+    private function fakeIdp(string $email = 'member@example.com'): void
+    {
+        Http::fake([
+            '*/.well-known/openid-configuration' => Http::response([
+                'authorization_endpoint' => 'https://idp.example.com/authorize',
+                'token_endpoint' => 'https://idp.example.com/token',
+                'userinfo_endpoint' => 'https://idp.example.com/userinfo',
+            ]),
+            'https://idp.example.com/token' => Http::response(['access_token' => 'access-123']),
+            'https://idp.example.com/userinfo' => Http::response(['email' => $email]),
+        ]);
+    }
+
+    public function test_redirect_sends_the_user_to_the_idp_with_state(): void
+    {
+        $this->fakeIdp();
+        $team = Team::factory()->create();
+        $this->connection($team);
+
+        $response = $this->get(route('sso.redirect', $team));
+
+        $response->assertRedirect();
+        $location = $response->headers->get('Location');
+        $this->assertStringStartsWith('https://idp.example.com/authorize', $location);
+        $this->assertStringContainsString('client_id=client-abc', $location);
+        $this->assertStringContainsString('state=', $location);
+        $response->assertSessionHas('sso_state');
+    }
+
+    public function test_callback_logs_in_a_matching_team_member(): void
+    {
+        $this->fakeIdp('member@example.com');
+        $team = Team::factory()->create();
+        $this->connection($team);
+        $member = User::factory()->create(['email' => 'member@example.com', 'email_verified_at' => now()]);
+        $team->users()->attach($member);
+
+        $response = $this->withSession(['sso_state' => 'st-1', 'sso_team' => $team->id])
+            ->get(route('sso.callback', $team).'?code=auth-code&state=st-1');
+
+        $response->assertRedirect();
+        $this->assertAuthenticatedAs($member);
+        $this->assertSame($team->id, $member->fresh()->current_team_id);
+    }
+
+    public function test_callback_rejects_a_mismatched_state(): void
+    {
+        $this->fakeIdp();
+        $team = Team::factory()->create();
+        $this->connection($team);
+
+        $this->withSession(['sso_state' => 'expected', 'sso_team' => $team->id])
+            ->get(route('sso.callback', $team).'?code=auth-code&state=forged')
+            ->assertForbidden();
+
+        $this->assertGuest();
+    }
+
+    public function test_callback_rejects_a_non_member_email(): void
+    {
+        $this->fakeIdp('stranger@example.com');
+        $team = Team::factory()->create();
+        $this->connection($team);
+        User::factory()->create(['email' => 'stranger@example.com']); // exists but not in team
+
+        $this->withSession(['sso_state' => 'st-1', 'sso_team' => $team->id])
+            ->get(route('sso.callback', $team).'?code=auth-code&state=st-1')
+            ->assertForbidden();
+
+        $this->assertGuest();
+    }
+
+    public function test_redirect_404s_for_a_disabled_connection(): void
+    {
+        $team = Team::factory()->create();
+        $this->connection($team, enabled: false);
+
+        $this->get(route('sso.redirect', $team))->assertNotFound();
+    }
+}


### PR DESCRIPTION
## What

Second slice of **G2 SSO** — the payoff. A team's **members sign in through their IdP** using the connection stored in #500. **No just-in-time provisioning yet:** an email with no matching team member is denied (that's slice 3).

## Flow (OIDC authorization-code + userinfo)

Raw OIDC over Laravel's HTTP client — no id_token crypto, no new dependency. The email comes from the IdP's **userinfo** endpoint, fetched server-side with an access token from our own authenticated token request.

- `GET /sso/{team}/redirect` → load the team's enabled `SsoConnection`, discover endpoints (`/.well-known/openid-configuration`, cached), mint a `state` into the session, redirect to the IdP.
- `GET /sso/{team}/callback` → verify `state`, exchange `code` → token (`client_secret_post`), read `userinfo.email`, match a **team member**, `Auth::login` + session regenerate, redirect to `/app`.

## Changes

- `App\Services\Sso\OidcClient` — `discover` / `authorizeUrl` / `exchangeCode` / `userinfo` (all `Http::`-fakeable); `App\Exceptions\SsoException`.
- `App\Http\Controllers\SsoLoginController` — `redirect` / `callback`.
- Routes `sso.redirect` / `sso.callback` (web/session, unauthenticated).

## Security

- **state CSRF**: minted on redirect, stored server-side, verified on callback.
- `client_secret` sent only server-to-server to the token endpoint.
- Only existing **team members** are logged in; **session regenerated** on login.
- Connection read `withoutGlobalScope('tenant')` (login is pre-auth).

## Verification

- New tests (`Http::fake`): 5 — redirect carries client_id/state/redirect_uri + sets session state; callback logs in a matching member; **mismatched state → 403**; **non-member email → 403**; disabled connection → 404.
- Full suite **880 pass / 1 skip / 0 fail** (+5).
- phpstan **0-new** (22 == baseline `ignore.unmatched`).
- **MySQL 8.4-verified**, pint clean.

Spec: `docs/superpowers/specs/2026-07-08-g2-sso-login-design.md`

## Out of scope / ceilings

JIT provisioning (slice 3), `id_token`/JWKS signature validation, `client_secret_basic`, PKCE, SSO enforcement (require-SSO per team), SAML.