### PR TITLE
feat(sso): JIT provisioning on first SSO login (G2 slice 3)

### DIFF
--- a/app/Actions/Sso/ProvisionSsoUser.php
+++ b/app/Actions/Sso/ProvisionSsoUser.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Sso;
+
+use App\Enums\Role;
+use App\Models\Team;
+use App\Models\User;
+use App\Services\TeamManagementService;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+
+/**
+ * Just-in-time provisioning of an SSO user into a team (G2 slice 3). The caller
+ * (SsoLoginController) has already checked allow_jit + the domain allowlist.
+ * Idempotent: reuses an existing user, attaches once, roles once.
+ */
+class ProvisionSsoUser
+{
+    public function __construct(private TeamManagementService $teams) {}
+
+    public function __invoke(Team $team, string $email, ?string $name): User
+    {
+        $user = User::firstOrCreate(
+            ['email' => $email],
+            [
+                'name' => $name ?: Str::before($email, '@'),
+                // Random unusable password — this account signs in via SSO only.
+                'password' => Hash::make(Str::random(40)),
+                // The IdP verified the address.
+                'email_verified_at' => now(),
+            ],
+        );
+
+        if (! $user->belongsToTeam($team)) {
+            $team->users()->attach($user);
+        }
+
+        setPermissionsTeamId($team->getKey());
+        if ($user->getRoleNames()->isEmpty()) {
+            // Least privilege: a JIT user lands as Free, never admin.
+            $this->teams->assignTeamRole($user, $team, Role::Free);
+        }
+
+        return $user;
+    }
+}

--- a/app/Filament/App/Resources/SsoConnectionResource.php
+++ b/app/Filament/App/Resources/SsoConnectionResource.php
@@ -78,6 +78,14 @@ class SsoConnectionResource extends Resource
                 ->dehydrated(fn (?string $state): bool => filled($state)),
             TextInput::make('issuer_url')->url()->required()->maxLength(255),
             Toggle::make('enabled'),
+            Toggle::make('allow_jit')
+                ->label('Auto-provision new users (JIT)')
+                ->helperText('Create an account on first SSO login for users not yet on the team.'),
+            TextInput::make('allowed_domain')
+                ->label('Restrict JIT to email domain')
+                ->placeholder('example.com')
+                ->helperText('Optional. Only auto-provision emails at this domain.')
+                ->maxLength(255),
         ]);
     }
 

--- a/app/Http/Controllers/SsoLoginController.php
+++ b/app/Http/Controllers/SsoLoginController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Actions\Sso\ProvisionSsoUser;
 use App\Models\SsoConnection;
 use App\Models\Team;
 use App\Models\User;
@@ -41,16 +42,38 @@ class SsoLoginController extends Controller
         $connection = $this->enabledConnection($team);
 
         $accessToken = $oidc->exchangeCode($connection, (string) $request->query('code'), route('sso.callback', $team));
-        $email = $oidc->userinfo($connection, $accessToken)['email'] ?? null;
+        $claims = $oidc->userinfo($connection, $accessToken);
+        $email = $claims['email'] ?? null;
+        $name = $claims['name'] ?? null;
 
         $user = is_string($email) ? User::where('email', $email)->first() : null;
-        abort_unless($user instanceof User && $user->belongsToTeam($team), 403, 'No access for this account.');
+
+        if (! ($user instanceof User && $user->belongsToTeam($team))) {
+            // Not already a member — provision just-in-time if the connection
+            // allows it and the email is in the allowed domain, else deny.
+            abort_unless(is_string($email) && $this->jitAllowed($connection, $email), 403, 'No access for this account.');
+            $user = app(ProvisionSsoUser::class)($team, $email, is_string($name) ? $name : null);
+        }
 
         $user->forceFill(['current_team_id' => $team->getKey()])->save();
         Auth::login($user);
         $request->session()->regenerate();
 
         return redirect()->intended('/app');
+    }
+
+    private function jitAllowed(SsoConnection $connection, string $email): bool
+    {
+        if (! $connection->getAttribute('allow_jit')) {
+            return false;
+        }
+
+        $domain = $connection->getAttribute('allowed_domain');
+        if (blank($domain)) {
+            return true;
+        }
+
+        return Str::endsWith(Str::lower($email), '@'.Str::lower((string) $domain));
     }
 
     private function enabledConnection(Team $team): SsoConnection

--- a/app/Models/SsoConnection.php
+++ b/app/Models/SsoConnection.php
@@ -25,10 +25,13 @@ class SsoConnection extends Model
         'client_secret',
         'issuer_url',
         'enabled',
+        'allow_jit',
+        'allowed_domain',
     ];
 
     protected $casts = [
         'client_secret' => 'encrypted',
         'enabled' => 'boolean',
+        'allow_jit' => 'boolean',
     ];
 }

--- a/database/factories/SsoConnectionFactory.php
+++ b/database/factories/SsoConnectionFactory.php
@@ -21,6 +21,8 @@ class SsoConnectionFactory extends Factory
             'client_secret' => 'secret-'.$this->faker->uuid(),
             'issuer_url' => 'https://idp.example.com',
             'enabled' => false,
+            'allow_jit' => false,
+            'allowed_domain' => null,
         ];
     }
 }

--- a/database/migrations/2026_07_08_010000_add_jit_to_sso_connections_table.php
+++ b/database/migrations/2026_07_08_010000_add_jit_to_sso_connections_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('sso_connections', function (Blueprint $table): void {
+            if (! Schema::hasColumn('sso_connections', 'allow_jit')) {
+                $table->boolean('allow_jit')->default(false)->after('enabled');
+            }
+            if (! Schema::hasColumn('sso_connections', 'allowed_domain')) {
+                $table->string('allowed_domain')->nullable()->after('allow_jit');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('sso_connections', function (Blueprint $table): void {
+            $table->dropColumn(['allow_jit', 'allowed_domain']);
+        });
+    }
+};

--- a/docs/superpowers/specs/2026-07-08-g2-sso-jit-design.md
+++ b/docs/superpowers/specs/2026-07-08-g2-sso-jit-design.md
@@ -1,0 +1,63 @@
+# G2 SSO — slice 3: JIT provisioning (design)
+
+**Date:** 2026-07-08
+**Status:** approved, implementing
+**Epic:** G2 SSO. Builds on #501 (OIDC login). Completes "a new hire's first SSO login just
+works".
+
+## Problem
+
+#501 logs in **existing** team members; an authenticated email with no matching team member
+is denied. So a new employee whose IdP account exists but who was never manually added to the
+CRM team can't get in.
+
+## Fix — opt-in, domain-restricted, least-privilege JIT
+
+Two new columns on `sso_connections`:
+- `allow_jit` (bool, default **false**) — JIT is off unless a team admin turns it on.
+- `allowed_domain` (nullable string) — when set, only userinfo emails ending in
+  `@{allowed_domain}` are provisioned (guards against the IdP asserting arbitrary emails).
+
+On callback, when the email is **not** already a team member:
+- **Deny (403)** unless `allow_jit` is true **and** (`allowed_domain` is null **or** the email
+  matches it).
+- Otherwise **provision** via `App\Actions\Sso\ProvisionSsoUser`:
+  - `firstOrCreate` the `User` by email (name from userinfo or the email local-part; a random
+    unusable password — SSO only; `email_verified_at = now()`, the IdP verified it),
+  - attach to the team if not already a member,
+  - assign the **least-privilege** default role `Role::Free` (via
+    `TeamManagementService::assignTeamRole`) only when the user has no team role yet.
+- Then log in exactly as #501 (session regenerate, `current_team_id`, redirect).
+
+Idempotent: a repeat JIT login reuses the user, doesn't double-attach or re-role.
+
+## Components
+
+- Migration: add `allow_jit` + `allowed_domain` (guarded `Schema::hasColumn`).
+- `SsoConnection`: `allow_jit`/`allowed_domain` fillable, `allow_jit` boolean cast.
+- `SsoConnectionResource` form: `allow_jit` Toggle + `allowed_domain` TextInput.
+- `App\Actions\Sso\ProvisionSsoUser::__invoke(Team, string $email, ?string $name): User`.
+- `SsoLoginController::callback` — JIT branch when membership check fails.
+
+## Security
+
+JIT is **off by default**; when on, the optional domain allowlist bounds who can be
+auto-created; provisioned users land as `Free` (never admin). The `state` CSRF, server-side
+token exchange, and session regeneration from #501 are unchanged.
+
+## Testing (TDD, `Http::fake()`)
+
+1. `allow_jit` **off** + non-member email → 403 (unchanged).
+2. `allow_jit` **on** + new email (matching `allowed_domain`) → user created, attached, role
+   `Free`, logged in.
+3. `allow_jit` on + email domain **not** in `allowed_domain` → 403, guest.
+4. `allow_jit` on + `allowed_domain` **null** + any email → provisioned.
+5. Idempotent: an existing global user (not in the team) with JIT on → attached once + logged
+   in; no duplicate user.
+
+phpstan 0-new, MySQL 8.4-verified, pint clean. Inline TDD, one PR to `main`.
+
+## Out of scope
+
+Configurable default role (fixed to `Free`), group/role mapping from IdP claims, deprovision on
+IdP removal, multiple allowed domains, id_token/JWKS validation (still deferred).

--- a/tests/Feature/Sso/SsoJitProvisioningTest.php
+++ b/tests/Feature/Sso/SsoJitProvisioningTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Sso;
+
+use App\Enums\Role;
+use App\Models\SsoConnection;
+use App\Models\Team;
+use App\Models\User;
+use Database\Seeders\RolesSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Testing\TestResponse;
+use Tests\TestCase;
+
+class SsoJitProvisioningTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolesSeeder::class);
+    }
+
+    private function connection(Team $team, array $overrides = []): SsoConnection
+    {
+        return SsoConnection::factory()->create(array_merge([
+            'team_id' => $team->id,
+            'issuer_url' => 'https://idp.example.com',
+            'client_id' => 'client-abc',
+            'client_secret' => 'shhh',
+            'enabled' => true,
+        ], $overrides));
+    }
+
+    private function fakeIdp(string $email): void
+    {
+        Http::fake([
+            '*/.well-known/openid-configuration' => Http::response([
+                'authorization_endpoint' => 'https://idp.example.com/authorize',
+                'token_endpoint' => 'https://idp.example.com/token',
+                'userinfo_endpoint' => 'https://idp.example.com/userinfo',
+            ]),
+            'https://idp.example.com/token' => Http::response(['access_token' => 'access-123']),
+            'https://idp.example.com/userinfo' => Http::response(['email' => $email, 'name' => 'New Hire']),
+        ]);
+    }
+
+    private function hitCallback(Team $team): TestResponse
+    {
+        return $this->withSession(['sso_state' => 'st-1', 'sso_team' => $team->id])
+            ->get(route('sso.callback', $team).'?code=auth-code&state=st-1');
+    }
+
+    public function test_non_member_denied_when_jit_off(): void
+    {
+        $this->fakeIdp('newhire@acme.com');
+        $team = Team::factory()->create();
+        $this->connection($team, ['allow_jit' => false]);
+
+        $this->hitCallback($team)->assertForbidden();
+        $this->assertGuest();
+    }
+
+    public function test_jit_provisions_and_logs_in_new_user_matching_domain(): void
+    {
+        $this->fakeIdp('newhire@acme.com');
+        $team = Team::factory()->create();
+        $this->connection($team, ['allow_jit' => true, 'allowed_domain' => 'acme.com']);
+
+        $this->hitCallback($team)->assertRedirect();
+
+        $user = User::where('email', 'newhire@acme.com')->first();
+        $this->assertNotNull($user);
+        $this->assertTrue($user->belongsToTeam($team));
+        $this->assertAuthenticatedAs($user);
+        setPermissionsTeamId($team->id);
+        $this->assertTrue($user->fresh()->hasRole(Role::Free->value));
+    }
+
+    public function test_jit_rejects_email_outside_allowed_domain(): void
+    {
+        $this->fakeIdp('outsider@evil.com');
+        $team = Team::factory()->create();
+        $this->connection($team, ['allow_jit' => true, 'allowed_domain' => 'acme.com']);
+
+        $this->hitCallback($team)->assertForbidden();
+        $this->assertGuest();
+        $this->assertNull(User::where('email', 'outsider@evil.com')->first());
+    }
+
+    public function test_jit_allows_any_domain_when_unset(): void
+    {
+        $this->fakeIdp('anyone@whatever.com');
+        $team = Team::factory()->create();
+        $this->connection($team, ['allow_jit' => true, 'allowed_domain' => null]);
+
+        $this->hitCallback($team)->assertRedirect();
+        $this->assertNotNull(User::where('email', 'anyone@whatever.com')->first());
+    }
+
+    public function test_jit_is_idempotent_for_existing_non_member_user(): void
+    {
+        $this->fakeIdp('existing@acme.com');
+        $team = Team::factory()->create();
+        $this->connection($team, ['allow_jit' => true, 'allowed_domain' => 'acme.com']);
+        User::factory()->create(['email' => 'existing@acme.com']);
+
+        $this->hitCallback($team)->assertRedirect();
+
+        $this->assertSame(1, User::where('email', 'existing@acme.com')->count());
+        $user = User::where('email', 'existing@acme.com')->first();
+        $this->assertTrue($user->belongsToTeam($team));
+        $this->assertAuthenticatedAs($user);
+    }
+}


### PR DESCRIPTION
## What

Third slice of **G2 SSO** — completes the login story. #501 only logged in *existing* team members; now a team's IdP user who was never manually added to the CRM can sign in on first SSO login. **Opt-in, domain-restricted, least-privilege.**

## Changes

- `sso_connections` gains **`allow_jit`** (bool, default **false**) + **`allowed_domain`** (nullable).
- `App\Actions\Sso\ProvisionSsoUser` — `firstOrCreate`s the user (random unusable password, `email_verified_at` set), attaches to the team, assigns **`Role::Free`** (never admin). Idempotent (reuses the user, attaches/roles once).
- `SsoLoginController::callback` — on the membership-miss path, provisions **only when** `allow_jit` is on **and** the email matches `allowed_domain` (null = any); otherwise **403**.
- `SsoConnectionResource` form exposes the JIT toggle + allowed domain.

## Security

JIT is **off by default**; the optional domain allowlist bounds who the IdP can auto-create; provisioned users land as `Free`. The state-CSRF, server-side token exchange, and session regeneration from #501 are unchanged.

## Verification

- New tests (`Http::fake`): 5 — JIT off + non-member → 403; JIT on + matching domain → user created/attached/`Free`/logged in; domain mismatch → 403 (no user created); null domain → any email provisioned; **idempotent** for an existing non-member (no dup, attached once).
- Full suite **885 pass / 1 skip / 0 fail** (+5) — #500/#501 SSO tests intact.
- phpstan **0-new** (22 == baseline `ignore.unmatched`).
- **MySQL 8.4-verified**, pint clean.

Spec: `docs/superpowers/specs/2026-07-08-g2-sso-jit-design.md`

## Out of scope

Configurable default role, IdP group/role mapping, deprovision on IdP removal, multiple domains, `id_token`/JWKS validation.