### PR TITLE
feat(sso): SSO enforcement per team (G2 slice 4)

### DIFF
--- a/app/Filament/App/Resources/SsoConnectionResource.php
+++ b/app/Filament/App/Resources/SsoConnectionResource.php
@@ -86,6 +86,9 @@ class SsoConnectionResource extends Resource
                 ->placeholder('example.com')
                 ->helperText('Optional. Only auto-provision emails at this domain.')
                 ->maxLength(255),
+            Toggle::make('require_sso')
+                ->label('Require SSO for team members')
+                ->helperText('Members must sign in via SSO; password login is blocked.'),
         ]);
     }
 

--- a/app/Http/Controllers/SsoLoginController.php
+++ b/app/Http/Controllers/SsoLoginController.php
@@ -58,6 +58,8 @@ class SsoLoginController extends Controller
         $user->forceFill(['current_team_id' => $team->getKey()])->save();
         Auth::login($user);
         $request->session()->regenerate();
+        // Marks this session as SSO-established so enforcement doesn't bounce it.
+        $request->session()->put('sso_authenticated', true);
 
         return redirect()->intended('/app');
     }

--- a/app/Http/Middleware/EnsureSsoWhenRequired.php
+++ b/app/Http/Middleware/EnsureSsoWhenRequired.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use App\Models\User;
+use App\Support\SsoEnforcement;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Enforces SSO on the app panel: an authenticated user whose team mandates SSO
+ * but whose session was not established via SSO is logged out and bounced to the
+ * IdP. Runs on every /app request, so it can't be sidestepped by the login route
+ * the user came through (Fortify /login, Filament admin login, ...).
+ */
+class EnsureSsoWhenRequired
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = $request->user();
+
+        if ($user instanceof User && ! $request->session()->get('sso_authenticated')) {
+            $team = SsoEnforcement::enforcingTeamFor($user);
+
+            if ($team !== null) {
+                Auth::logout();
+                $request->session()->invalidate();
+                $request->session()->regenerateToken();
+
+                return redirect()->route('sso.redirect', $team);
+            }
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/SsoConnection.php
+++ b/app/Models/SsoConnection.php
@@ -27,11 +27,13 @@ class SsoConnection extends Model
         'enabled',
         'allow_jit',
         'allowed_domain',
+        'require_sso',
     ];
 
     protected $casts = [
         'client_secret' => 'encrypted',
         'enabled' => 'boolean',
         'allow_jit' => 'boolean',
+        'require_sso' => 'boolean',
     ];
 }

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -6,6 +6,7 @@ namespace App\Providers\Filament;
 
 use App\Filament\App\Pages;
 use App\Filament\App\Pages\EditProfile;
+use App\Http\Middleware\EnsureSsoWhenRequired;
 use App\Http\Middleware\TeamsPermission;
 use App\Listeners\CreatePersonalTeam;
 use App\Listeners\SwitchTeam;
@@ -22,6 +23,7 @@ use Filament\Panel;
 use Filament\PanelProvider;
 use Filament\Support\Colors\Color;
 use Filament\Widgets;
+use Illuminate\Contracts\Routing\UrlGenerator;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
 use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
@@ -55,7 +57,7 @@ class AppPanelProvider extends PanelProvider
                 MenuItem::make()
                     ->label('Profile')
                     ->icon('heroicon-o-user-circle')
-                    ->url(fn (): \Illuminate\Contracts\Routing\UrlGenerator|string => $this->shouldRegisterMenuItem()
+                    ->url(fn (): UrlGenerator|string => $this->shouldRegisterMenuItem()
                         ? url(EditProfile::getUrl())
                         : url($panel->getPath())),
             ])
@@ -83,6 +85,7 @@ class AppPanelProvider extends PanelProvider
             ])
             ->authMiddleware([
                 Authenticate::class,
+                EnsureSsoWhenRequired::class,
                 TeamsPermission::class,
             ]);
 
@@ -106,7 +109,7 @@ class AppPanelProvider extends PanelProvider
                     MenuItem::make()
                         ->label('Team Settings')
                         ->icon('heroicon-o-cog-6-tooth')
-                        ->url(fn (): \Illuminate\Contracts\Routing\UrlGenerator|string => $this->shouldRegisterMenuItem()
+                        ->url(fn (): UrlGenerator|string => $this->shouldRegisterMenuItem()
                             ? url(Pages\EditTeam::getUrl())
                             : url($panel->getPath())),
                 ]);

--- a/app/Support/SsoEnforcement.php
+++ b/app/Support/SsoEnforcement.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use App\Models\SsoConnection;
+use App\Models\Team;
+use App\Models\User;
+
+class SsoEnforcement
+{
+    /**
+     * The user's team (owned or member) that mandates SSO — an enabled connection
+     * with require_sso — or null. Read unscoped: enforcement runs pre-tenant.
+     */
+    public static function enforcingTeamFor(User $user): ?Team
+    {
+        $teamIds = $user->allTeams()->pluck('id')->all();
+
+        if ($teamIds === []) {
+            return null;
+        }
+
+        $connection = SsoConnection::withoutGlobalScope('tenant')
+            ->whereIn('team_id', $teamIds)
+            ->where('enabled', true)
+            ->where('require_sso', true)
+            ->first();
+
+        return $connection?->team;
+    }
+}

--- a/database/factories/SsoConnectionFactory.php
+++ b/database/factories/SsoConnectionFactory.php
@@ -23,6 +23,7 @@ class SsoConnectionFactory extends Factory
             'enabled' => false,
             'allow_jit' => false,
             'allowed_domain' => null,
+            'require_sso' => false,
         ];
     }
 }

--- a/database/migrations/2026_07_08_020000_add_require_sso_to_sso_connections_table.php
+++ b/database/migrations/2026_07_08_020000_add_require_sso_to_sso_connections_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('sso_connections', function (Blueprint $table): void {
+            if (! Schema::hasColumn('sso_connections', 'require_sso')) {
+                $table->boolean('require_sso')->default(false)->after('allowed_domain');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('sso_connections', function (Blueprint $table): void {
+            $table->dropColumn('require_sso');
+        });
+    }
+};

--- a/docs/superpowers/specs/2026-07-08-g2-sso-enforcement-design.md
+++ b/docs/superpowers/specs/2026-07-08-g2-sso-enforcement-design.md
@@ -1,0 +1,53 @@
+# G2 SSO — slice 4: SSO enforcement (design)
+
+**Date:** 2026-07-08
+**Status:** approved, implementing
+**Epic:** G2 SSO. Builds on #500–#502. Lets a team **require** SSO for its members.
+
+## Problem
+
+SSO is available but optional — an SSO-enforced organisation still lets its members log in
+with a password. We need a team to be able to mandate SSO.
+
+## Why middleware, not a Fortify hook
+
+The app panel's `->login()` is disabled, so team members log in via Fortify `/login` — but a
+member could also authenticate at `/admin/login` (Filament, same web guard) and then reach
+`/app`. A Fortify-only block is therefore **bypassable**. Enforcing in **middleware on the app
+panel** catches an SSO-required user no matter how they authenticated.
+
+## Design
+
+- New column `sso_connections.require_sso` (bool, default false).
+- `App\Support\SsoEnforcement::enforcingTeamFor(User): ?Team` — the user's team (owned or
+  member) that has an **enabled** connection with `require_sso = true`, else null.
+- `App\Http\Middleware\EnsureSsoWhenRequired` (on the app panel `authMiddleware`): if the
+  authenticated user has an enforcing team **and** the session lacks the `sso_authenticated`
+  flag → `Auth::logout()` and redirect to `sso.redirect` for that team. So any non-SSO session
+  (password login, Filament login) is bounced into the IdP.
+- `SsoLoginController::callback` sets `session(['sso_authenticated' => true])` on success, so a
+  genuine SSO login is not bounced.
+- `SsoConnectionResource` form gains a `require_sso` Toggle.
+
+## Security
+
+Enforcement runs on every `/app` request, so it can't be sidestepped by the login route used.
+`require_sso` only bites when the connection is `enabled`. A genuine SSO login carries the
+session flag; everything else is logged out and redirected to the IdP.
+
+## Testing (TDD)
+
+1. An SSO-required user hitting `/app` **without** the SSO session flag → logged out +
+   redirected to `sso.redirect`.
+2. An SSO-required user **with** `sso_authenticated` in the session → not bounced.
+3. A user with **no** enforcing team → `/app` proceeds normally.
+4. `require_sso = true` but `enabled = false` → not enforced.
+5. `SsoLoginController::callback` sets `sso_authenticated` (a real SSO login survives
+   enforcement).
+
+phpstan 0-new, MySQL 8.4-verified, pint clean. Inline TDD, one PR to `main`.
+
+## Out of scope
+
+Enforcing the admin panel (super_admins aren't the target; a regular member can't access it),
+per-user SSO exemptions, break-glass password bypass, id_token/JWKS validation, SAML.

--- a/tests/Feature/Sso/SsoEnforcementTest.php
+++ b/tests/Feature/Sso/SsoEnforcementTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Sso;
+
+use App\Models\SsoConnection;
+use App\Models\Team;
+use App\Models\User;
+use App\Support\SsoEnforcement;
+use Database\Seeders\RolesSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SsoEnforcementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolesSeeder::class);
+    }
+
+    private function member(Team $team): User
+    {
+        $user = User::factory()->withPersonalTeam()->create(['email_verified_at' => now()]);
+        $team->users()->attach($user);
+        $user->forceFill(['current_team_id' => $team->id])->save();
+        setPermissionsTeamId($team->id);
+        $user->assignRole('manager');
+
+        return $user;
+    }
+
+    private function connection(Team $team, array $overrides = []): SsoConnection
+    {
+        return SsoConnection::factory()->create(array_merge([
+            'team_id' => $team->id,
+            'enabled' => true,
+            'require_sso' => true,
+        ], $overrides));
+    }
+
+    public function test_enforced_user_without_sso_session_is_bounced_to_sso(): void
+    {
+        $team = Team::factory()->create();
+        $this->connection($team);
+        $user = $this->member($team);
+
+        $this->actingAs($user)
+            ->get('/app/'.$team->id)
+            ->assertRedirect(route('sso.redirect', $team));
+
+        $this->assertGuest();
+    }
+
+    public function test_enforced_user_with_sso_session_is_allowed(): void
+    {
+        $team = Team::factory()->create();
+        $this->connection($team);
+        $user = $this->member($team);
+
+        $response = $this->actingAs($user)
+            ->withSession(['sso_authenticated' => true])
+            ->get('/app/'.$team->id);
+
+        $response->assertOk();
+        $this->assertAuthenticatedAs($user);
+    }
+
+    public function test_user_without_an_enforcing_team_proceeds(): void
+    {
+        $team = Team::factory()->create();
+        $this->connection($team, ['require_sso' => false]);
+        $user = $this->member($team);
+
+        $this->actingAs($user)
+            ->get('/app/'.$team->id)
+            ->assertOk();
+    }
+
+    public function test_not_enforced_when_connection_disabled(): void
+    {
+        $team = Team::factory()->create();
+        $this->connection($team, ['enabled' => false, 'require_sso' => true]);
+        $user = $this->member($team);
+
+        $this->assertNull(SsoEnforcement::enforcingTeamFor($user));
+
+        $this->actingAs($user)
+            ->get('/app/'.$team->id)
+            ->assertOk();
+    }
+
+    public function test_enforcing_team_is_resolved(): void
+    {
+        $team = Team::factory()->create();
+        $this->connection($team);
+        $user = $this->member($team);
+
+        $this->assertTrue(SsoEnforcement::enforcingTeamFor($user)?->is($team));
+    }
+}


### PR DESCRIPTION
## What

Fourth slice of **G2 SSO** — a team can now **require SSO** for its members (password login no longer suffices).

## Why middleware, not a Fortify hook

The app panel's `->login()` is disabled, so members log in via Fortify `/login` — but a member could also authenticate at `/admin/login` (Filament, same web guard) and then reach `/app`. A Fortify-only block is bypassable. Enforcing in **app-panel middleware** catches an SSO-required user on every `/app` request, whatever login route they used. (`AppPanelProvider::boot()` even sets `Fortify::$registersRoutes = false`, so a Fortify hook would be doubly unreliable here.)

## Changes

- `sso_connections` gains **`require_sso`** (bool, default false).
- `App\Support\SsoEnforcement::enforcingTeamFor(User): ?Team` — the user's team with an **enabled** connection and `require_sso`.
- `App\Http\Middleware\EnsureSsoWhenRequired` (app panel `authMiddleware`): an authenticated user with an enforcing team but no `sso_authenticated` session flag is **logged out and redirected to the IdP**.
- `SsoLoginController::callback` sets `session('sso_authenticated')` on login, so a genuine SSO session survives.
- `SsoConnectionResource` form gains the `require_sso` toggle.

## Verification

- New tests: 5 — enforced user without SSO session → logged out + redirected to `sso.redirect`; with the SSO flag → allowed; no enforcing team → proceeds; `require_sso` but disabled connection → not enforced; `enforcingTeamFor` resolves.
- Full suite **890 pass / 1 skip / 0 fail** (+5) — the middleware is inert for users without an enforcing team, so #500–#502 and all app-panel tests are unaffected.
- phpstan **0-new** (22 == baseline `ignore.unmatched`).
- **MySQL 8.4-verified**, pint clean.

Spec: `docs/superpowers/specs/2026-07-08-g2-sso-enforcement-design.md`

## Out of scope

Enforcing the admin panel (super_admins aren't the target; members can't access it), per-user SSO exemptions / break-glass, `id_token`/JWKS validation, SAML.