### PR TITLE
feat(sso): validate the OIDC id_token signature (G2 slice 5)

### DIFF
--- a/app/Http/Controllers/SsoLoginController.php
+++ b/app/Http/Controllers/SsoLoginController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Controllers;
 
 use App\Actions\Sso\ProvisionSsoUser;
+use App\Exceptions\SsoException;
 use App\Models\SsoConnection;
 use App\Models\Team;
 use App\Models\User;
@@ -25,10 +26,11 @@ class SsoLoginController extends Controller
         $connection = $this->enabledConnection($team);
 
         $state = Str::random(40);
-        session(['sso_state' => $state, 'sso_team' => $team->getKey()]);
+        $nonce = Str::random(40);
+        session(['sso_state' => $state, 'sso_nonce' => $nonce, 'sso_team' => $team->getKey()]);
 
         return redirect()->away(
-            $oidc->authorizeUrl($connection, route('sso.callback', $team), $state)
+            $oidc->authorizeUrl($connection, route('sso.callback', $team), $state, $nonce)
         );
     }
 
@@ -37,12 +39,27 @@ class SsoLoginController extends Controller
         // CSRF: the state we minted on redirect must come back unchanged.
         $state = $request->query('state');
         abort_unless(is_string($state) && $state === session('sso_state'), 403, 'Invalid SSO state.');
-        $request->session()->forget(['sso_state', 'sso_team']);
+        $nonce = (string) session('sso_nonce');
+        $request->session()->forget(['sso_state', 'sso_nonce', 'sso_team']);
 
         $connection = $this->enabledConnection($team);
 
-        $accessToken = $oidc->exchangeCode($connection, (string) $request->query('code'), route('sso.callback', $team));
-        $claims = $oidc->userinfo($connection, $accessToken);
+        try {
+            $tokens = $oidc->exchangeCode($connection, (string) $request->query('code'), route('sso.callback', $team));
+
+            // Prefer the cryptographically verified id_token; fall back to userinfo
+            // for providers/flows that don't return one (keeps older configs working).
+            $idToken = $tokens['id_token'] ?? null;
+            if (is_string($idToken) && $idToken !== '') {
+                $claims = $oidc->validateIdToken($connection, $idToken, $nonce);
+            } else {
+                $accessToken = $tokens['access_token'] ?? null;
+                $claims = is_string($accessToken) ? $oidc->userinfo($connection, $accessToken) : [];
+            }
+        } catch (SsoException) {
+            abort(403, 'SSO verification failed.');
+        }
+
         $email = $claims['email'] ?? null;
         $name = $claims['name'] ?? null;
 

--- a/app/Services/Sso/OidcClient.php
+++ b/app/Services/Sso/OidcClient.php
@@ -6,8 +6,11 @@ namespace App\Services\Sso;
 
 use App\Exceptions\SsoException;
 use App\Models\SsoConnection;
+use Firebase\JWT\JWK;
+use Firebase\JWT\JWT;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
+use Throwable;
 
 /**
  * Minimal OIDC authorization-code client, driven by a team's SsoConnection.
@@ -43,7 +46,7 @@ class OidcClient
         });
     }
 
-    public function authorizeUrl(SsoConnection $connection, string $redirectUri, string $state): string
+    public function authorizeUrl(SsoConnection $connection, string $redirectUri, string $state, string $nonce): string
     {
         $endpoint = (string) $this->discover($connection)['authorization_endpoint'];
 
@@ -53,10 +56,14 @@ class OidcClient
             'response_type' => 'code',
             'scope' => 'openid email profile',
             'state' => $state,
+            'nonce' => $nonce,
         ]);
     }
 
-    public function exchangeCode(SsoConnection $connection, string $code, string $redirectUri): string
+    /**
+     * @return array<string, mixed> the full token response (access_token, id_token, ...)
+     */
+    public function exchangeCode(SsoConnection $connection, string $code, string $redirectUri): array
     {
         $endpoint = (string) $this->discover($connection)['token_endpoint'];
 
@@ -68,13 +75,66 @@ class OidcClient
             'client_secret' => $connection->getAttribute('client_secret'),
         ]);
 
-        $token = $response->json('access_token');
-
-        if (! $response->successful() || ! is_string($token)) {
+        if (! $response->successful() || ! is_string($response->json('access_token'))) {
             throw new SsoException('The identity provider rejected the login.');
         }
 
-        return $token;
+        return (array) $response->json();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jwks(SsoConnection $connection): array
+    {
+        $uri = (string) ($this->discover($connection)['jwks_uri'] ?? '');
+        if ($uri === '') {
+            throw new SsoException('Identity provider discovery is missing jwks_uri.');
+        }
+
+        $issuer = rtrim((string) $connection->getAttribute('issuer_url'), '/');
+
+        return Cache::remember("sso_jwks:{$issuer}", 3600, function () use ($uri): array {
+            $response = Http::acceptJson()->get($uri);
+            if (! $response->successful()) {
+                throw new SsoException('Could not load the identity provider keys.');
+            }
+
+            return (array) $response->json();
+        });
+    }
+
+    /**
+     * Validates the id_token: RS256 signature against the JWKS (+ exp), then
+     * issuer / audience / nonce. Returns the verified claims.
+     *
+     * @return array<string, mixed>
+     */
+    public function validateIdToken(SsoConnection $connection, string $idToken, string $expectedNonce): array
+    {
+        try {
+            $claims = (array) JWT::decode($idToken, JWK::parseKeySet($this->jwks($connection)));
+        } catch (Throwable) {
+            throw new SsoException('The identity provider token could not be verified.');
+        }
+
+        $issuer = rtrim((string) $connection->getAttribute('issuer_url'), '/');
+        if (rtrim((string) ($claims['iss'] ?? ''), '/') !== $issuer) {
+            throw new SsoException('SSO token issuer mismatch.');
+        }
+
+        $clientId = (string) $connection->getAttribute('client_id');
+        $aud = $claims['aud'] ?? null;
+        $audOk = is_array($aud) ? in_array($clientId, $aud, true) : ($aud === $clientId);
+        if (! $audOk) {
+            throw new SsoException('SSO token audience mismatch.');
+        }
+
+        if (($claims['nonce'] ?? null) !== $expectedNonce) {
+            throw new SsoException('SSO token nonce mismatch.');
+        }
+
+        return $claims;
     }
 
     /**

--- a/docs/superpowers/specs/2026-07-08-g2-sso-idtoken-design.md
+++ b/docs/superpowers/specs/2026-07-08-g2-sso-idtoken-design.md
@@ -1,0 +1,58 @@
+# G2 SSO — slice 5: id_token / JWKS validation (design)
+
+**Date:** 2026-07-08
+**Status:** approved, implementing
+**Epic:** G2 SSO. Hardens the OIDC login flow (#501). Closes the deferred "no id_token
+signature validation" ceiling.
+
+## Problem
+
+#501 reads the email from the **userinfo** endpoint, trusting the server-side token exchange
+as the anchor. The OIDC gold standard is to validate the **id_token** JWT the token endpoint
+returns: verify its signature against the provider's JWKS and check `iss`/`aud`/`exp`/`nonce`.
+`firebase/php-jwt` is already installed (no new dependency).
+
+## Design
+
+- **Nonce (replay protection):** `redirect` mints a `nonce` alongside `state`, stores it in the
+  session, and adds it to the authorize URL. `callback` reads it back to verify the id_token.
+- **`OidcClient` additions:**
+  - `authorizeUrl(...)` gains a `$nonce` param (adds `nonce=` to the query).
+  - `exchangeCode(...)` now returns the **full token response array** (so the caller sees both
+    `access_token` and `id_token`).
+  - `jwks(connection)` — fetches `jwks_uri` from discovery (cached), returns the JWKS.
+  - `validateIdToken(connection, idToken, expectedNonce): array` — `JWT::decode` against
+    `JWK::parseKeySet(jwks)` (verifies **signature** + `exp`), then checks `iss` == issuer,
+    `aud` contains `client_id`, `nonce` == the session nonce. Throws `SsoException` on any
+    failure. Returns the verified claims.
+- **`callback` email resolution:**
+  - If the token response carries an `id_token` → **validate it** and take `email`/`name` from
+    the verified claims.
+  - Otherwise fall back to `userinfo` (backward-compatible — existing #501–#503 flows return no
+    id_token, so they are unaffected).
+
+## Security
+
+The id_token signature is cryptographically verified against the IdP's published keys; a
+forged or tampered token, a wrong audience/issuer, an expired token, or a replayed
+nonce is rejected (403). Nonce closes the id_token replay window; `state` still closes the
+authorization-request CSRF window.
+
+## Testing (TDD, `Http::fake` + a generated RSA keypair)
+
+Helper: generate an RSA keypair, expose the public key as a JWKS (`n`/`e` base64url), sign an
+id_token with the private key (`RS256`, `kid`).
+
+1. Valid signed id_token (correct iss/aud/nonce, not expired) → member logged in.
+2. **Tampered / wrong-key** id_token → 403, guest.
+3. Wrong `aud` → 403.
+4. Wrong `nonce` → 403.
+5. Backward compat: a token response **without** id_token → userinfo path still logs in
+   (covered by the unchanged #501 tests).
+
+phpstan 0-new, MySQL 8.4-verified, pint clean. Inline TDD, one PR to `main`.
+
+## Out of scope
+
+`client_secret_basic`, PKCE, SAML, IdP group→role mapping, encrypted (JWE) id_tokens,
+at_hash/c_hash validation.

--- a/tests/Feature/Sso/SsoIdTokenTest.php
+++ b/tests/Feature/Sso/SsoIdTokenTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Sso;
+
+use App\Models\SsoConnection;
+use App\Models\Team;
+use App\Models\User;
+use Database\Seeders\RolesSeeder;
+use Firebase\JWT\JWT;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Testing\TestResponse;
+use Tests\TestCase;
+
+class SsoIdTokenTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $privatePem;
+
+    /** @var array<string, mixed> */
+    private array $jwks;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolesSeeder::class);
+
+        $key = openssl_pkey_new(['private_key_bits' => 2048, 'private_key_type' => OPENSSL_KEYTYPE_RSA]);
+        openssl_pkey_export($key, $pem);
+        $this->privatePem = (string) $pem;
+        $details = openssl_pkey_get_details($key);
+
+        $this->jwks = ['keys' => [[
+            'kty' => 'RSA',
+            'alg' => 'RS256',
+            'use' => 'sig',
+            'kid' => 'test-key',
+            'n' => $this->b64($details['rsa']['n']),
+            'e' => $this->b64($details['rsa']['e']),
+        ]]];
+    }
+
+    private function b64(string $bin): string
+    {
+        return rtrim(strtr(base64_encode($bin), '+/', '-_'), '=');
+    }
+
+    private function idToken(array $overrides = [], ?string $signingKey = null): string
+    {
+        $claims = array_merge([
+            'iss' => 'https://idp.example.com',
+            'aud' => 'client-abc',
+            'exp' => time() + 3600,
+            'iat' => time(),
+            'nonce' => 'nonce-1',
+            'sub' => 'idp-sub-123',
+            'email' => 'member@example.com',
+            'name' => 'SSO Member',
+        ], $overrides);
+
+        return JWT::encode($claims, $signingKey ?? $this->privatePem, 'RS256', 'test-key');
+    }
+
+    private function fakeIdp(string $idToken, ?array $jwks = null): void
+    {
+        Http::fake([
+            '*/.well-known/openid-configuration' => Http::response([
+                'authorization_endpoint' => 'https://idp.example.com/authorize',
+                'token_endpoint' => 'https://idp.example.com/token',
+                'userinfo_endpoint' => 'https://idp.example.com/userinfo',
+                'jwks_uri' => 'https://idp.example.com/jwks',
+            ]),
+            'https://idp.example.com/token' => Http::response(['access_token' => 'access-123', 'id_token' => $idToken]),
+            'https://idp.example.com/jwks' => Http::response($jwks ?? $this->jwks),
+        ]);
+    }
+
+    private function connection(Team $team): SsoConnection
+    {
+        return SsoConnection::factory()->create([
+            'team_id' => $team->id,
+            'issuer_url' => 'https://idp.example.com',
+            'client_id' => 'client-abc',
+            'client_secret' => 'shhh',
+            'enabled' => true,
+        ]);
+    }
+
+    private function hitCallback(Team $team): TestResponse
+    {
+        return $this->withSession(['sso_state' => 'st-1', 'sso_nonce' => 'nonce-1', 'sso_team' => $team->id])
+            ->get(route('sso.callback', $team).'?code=auth-code&state=st-1');
+    }
+
+    public function test_valid_signed_id_token_logs_in_member(): void
+    {
+        $this->fakeIdp($this->idToken());
+        $team = Team::factory()->create();
+        $this->connection($team);
+        $member = User::factory()->create(['email' => 'member@example.com', 'email_verified_at' => now()]);
+        $team->users()->attach($member);
+
+        $this->hitCallback($team)->assertRedirect();
+        $this->assertAuthenticatedAs($member);
+    }
+
+    public function test_id_token_signed_by_a_different_key_is_rejected(): void
+    {
+        $foreign = openssl_pkey_new(['private_key_bits' => 2048, 'private_key_type' => OPENSSL_KEYTYPE_RSA]);
+        openssl_pkey_export($foreign, $foreignPem);
+        $this->fakeIdp($this->idToken([], $foreignPem)); // signed by a key not in the JWKS
+
+        $team = Team::factory()->create();
+        $this->connection($team);
+        $member = User::factory()->create(['email' => 'member@example.com', 'email_verified_at' => now()]);
+        $team->users()->attach($member);
+
+        $this->hitCallback($team)->assertForbidden();
+        $this->assertGuest();
+    }
+
+    public function test_id_token_with_wrong_audience_is_rejected(): void
+    {
+        $this->fakeIdp($this->idToken(['aud' => 'someone-else']));
+        $team = Team::factory()->create();
+        $this->connection($team);
+        User::factory()->create(['email' => 'member@example.com', 'email_verified_at' => now()]);
+
+        $this->hitCallback($team)->assertForbidden();
+        $this->assertGuest();
+    }
+
+    public function test_id_token_with_wrong_nonce_is_rejected(): void
+    {
+        $this->fakeIdp($this->idToken(['nonce' => 'replayed']));
+        $team = Team::factory()->create();
+        $this->connection($team);
+        User::factory()->create(['email' => 'member@example.com', 'email_verified_at' => now()]);
+
+        $this->hitCallback($team)->assertForbidden();
+        $this->assertGuest();
+    }
+}


### PR DESCRIPTION
## What

Hardens the OIDC login flow (#501). The email now comes from a **cryptographically verified id_token** rather than only the userinfo endpoint — closing the deferred "no id_token signature validation" ceiling. `firebase/php-jwt` is already a (transitive) dependency, so **no new package**.

## Changes

- **Nonce** (replay protection): `redirect` mints a `nonce` alongside `state`, stores it in the session, and adds it to the authorize URL.
- `OidcClient`:
  - `authorizeUrl` gains the `nonce` param; `exchangeCode` now returns the **full token response** (so the caller sees `id_token`).
  - `jwks(connection)` — fetches `jwks_uri` from discovery (cached).
  - `validateIdToken(connection, idToken, nonce)` — `JWT::decode` against `JWK::parseKeySet(jwks)` (verifies **RS256 signature** + `exp`), then checks `iss` / `aud` / `nonce`. Throws `SsoException` on failure.
- `SsoLoginController::callback` — validates the id_token when present (email/name from the verified claims), else falls back to `userinfo` (older flows unaffected). An `SsoException` → **403**.

## Security

A forged/tampered id_token, a wrong audience or issuer, an expired token, or a **replayed nonce** is rejected (403). `state` still guards the authorization-request CSRF; `nonce` now guards id_token replay.

## Verification

- New tests (`Http::fake` + a generated RSA keypair signing real RS256 id_tokens against a JWKS): 4 — valid token logs in; **wrong signing key → 403**; **wrong `aud` → 403**; **wrong `nonce` → 403**.
- Full suite **894 pass / 1 skip / 0 fail** (+4) — #501–#503 flows (no id_token → userinfo fallback) unchanged.
- phpstan **0-new** (22 == baseline `ignore.unmatched`).
- **MySQL 8.4-verified**, pint clean.

Spec: `docs/superpowers/specs/2026-07-08-g2-sso-idtoken-design.md`

## Out of scope

`client_secret_basic`, PKCE, SAML, encrypted (JWE) id_tokens, `at_hash`/`c_hash`.