### PR TITLE
feat(abac): territory foundation (G3 slice 1)

### DIFF
--- a/app/Filament/App/Resources/TerritoryResource.php
+++ b/app/Filament/App/Resources/TerritoryResource.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\App\Resources;
+
+use App\Enums\Role;
+use App\Filament\App\Resources\TerritoryResource\Pages\CreateTerritory;
+use App\Filament\App\Resources\TerritoryResource\Pages\EditTerritory;
+use App\Filament\App\Resources\TerritoryResource\Pages\ListTerritories;
+use App\Models\Team;
+use App\Models\Territory;
+use App\Models\User;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Facades\Filament;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Auth;
+
+/**
+ * Manage a team's sales territories and their members (G3 ABAC foundation).
+ * Territory is IsTenantModel, so it auto-scopes to the current team.
+ */
+class TerritoryResource extends Resource
+{
+    protected static ?string $model = Territory::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-map';
+
+    protected static string|\UnitEnum|null $navigationGroup = 'Team';
+
+    protected static ?string $navigationLabel = 'Territories';
+
+    protected static ?string $slug = 'territories';
+
+    public static function canAccess(): bool
+    {
+        $user = Auth::user();
+
+        return $user instanceof User && $user->hasRole([Role::SuperAdmin, Role::Admin, Role::Manager]);
+    }
+
+    #[\Override]
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            TextInput::make('name')->required()->maxLength(255),
+            Select::make('users')
+                ->label('Members')
+                ->multiple()
+                ->preload()
+                // Only the current team's members are assignable.
+                ->relationship('users', 'name', fn (Builder $query): Builder => $query->whereIn('users.id', self::teamMemberIds())),
+        ]);
+    }
+
+    #[\Override]
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('name')->searchable(),
+                TextColumn::make('users_count')->counts('users')->label('Members'),
+                TextColumn::make('updated_at')->dateTime()->sortable(),
+            ])
+            ->recordActions([
+                EditAction::make(),
+            ])
+            ->toolbarActions([
+                DeleteBulkAction::make(),
+            ])
+            ->defaultSort('name');
+    }
+
+    #[\Override]
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListTerritories::route('/'),
+            'create' => CreateTerritory::route('/create'),
+            'edit' => EditTerritory::route('/{record}/edit'),
+        ];
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    private static function teamMemberIds(): array
+    {
+        $tenant = Filament::getTenant();
+
+        return $tenant instanceof Team ? $tenant->allUsers()->pluck('id')->all() : [];
+    }
+}

--- a/app/Filament/App/Resources/TerritoryResource/Pages/CreateTerritory.php
+++ b/app/Filament/App/Resources/TerritoryResource/Pages/CreateTerritory.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\App\Resources\TerritoryResource\Pages;
+
+use App\Filament\App\Resources\TerritoryResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateTerritory extends CreateRecord
+{
+    protected static string $resource = TerritoryResource::class;
+}

--- a/app/Filament/App/Resources/TerritoryResource/Pages/EditTerritory.php
+++ b/app/Filament/App/Resources/TerritoryResource/Pages/EditTerritory.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\App\Resources\TerritoryResource\Pages;
+
+use App\Filament\App\Resources\TerritoryResource;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditTerritory extends EditRecord
+{
+    protected static string $resource = TerritoryResource::class;
+
+    #[\Override]
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/App/Resources/TerritoryResource/Pages/ListTerritories.php
+++ b/app/Filament/App/Resources/TerritoryResource/Pages/ListTerritories.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\App\Resources\TerritoryResource\Pages;
+
+use App\Filament\App\Resources\TerritoryResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListTerritories extends ListRecords
+{
+    protected static string $resource = TerritoryResource::class;
+
+    #[\Override]
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Models/Territory.php
+++ b/app/Models/Territory.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Traits\IsTenantModel;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+/**
+ * A team's sales territory (G3 ABAC foundation). Members assigned here will,
+ * in a later slice, be scoped to the records in their territories.
+ */
+class Territory extends Model
+{
+    use HasFactory;
+    use IsTenantModel;
+
+    protected $fillable = [
+        'team_id',
+        'name',
+    ];
+
+    /**
+     * @return BelongsToMany<User, $this>
+     */
+    public function users(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class, 'territory_user');
+    }
+}

--- a/database/factories/TerritoryFactory.php
+++ b/database/factories/TerritoryFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\Team;
+use App\Models\Territory;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class TerritoryFactory extends Factory
+{
+    protected $model = Territory::class;
+
+    public function definition(): array
+    {
+        return [
+            'team_id' => Team::factory(),
+            'name' => $this->faker->unique()->city().' Region',
+        ];
+    }
+}

--- a/database/migrations/2026_07_08_030000_create_territories_table.php
+++ b/database/migrations/2026_07_08_030000_create_territories_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('territories')) {
+            return;
+        }
+
+        Schema::create('territories', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('team_id')->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('territories');
+    }
+};

--- a/database/migrations/2026_07_08_030001_create_territory_user_table.php
+++ b/database/migrations/2026_07_08_030001_create_territory_user_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('territory_user')) {
+            return;
+        }
+
+        Schema::create('territory_user', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('territory_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->unique(['territory_id', 'user_id']);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('territory_user');
+    }
+};

--- a/docs/superpowers/specs/2026-07-08-g3-territory-foundation-design.md
+++ b/docs/superpowers/specs/2026-07-08-g3-territory-foundation-design.md
@@ -1,0 +1,43 @@
+# G3 ABAC — slice 1: territory foundation (design)
+
+**Date:** 2026-07-08
+**Status:** approved, implementing
+**Epic:** G3 attribute-based access control (territory + field-level scoping). First slice.
+
+## Epic decomposition
+
+1. **Territory foundation** (this slice) — a `Territory` per team + assigning users to
+   territories + a management UI. No record scoping yet.
+2. **Record territory scoping** — add `territory_id` to Leads/Deals and a
+   `RestrictsToTerritory` global scope gated by the user's territories (mirrors F4's
+   `RestrictsToOwner` / `AccessContext`).
+3. **Field-level masking** — hide/mask sensitive fields by attribute.
+
+Building the foundation first (like F1/F4) keeps the scoping mechanism a separate, focused
+slice once the data model exists.
+
+## Slice 1 architecture
+
+- `territories` table: `team_id` (FK), `name`, timestamps. `IsTenantModel` (team scope +
+  team_id auto-stamp + the `team()` relationship the app panel needs).
+- `territory_user` pivot: `territory_id`, `user_id` (unique pair), cascade on delete.
+- `App\Models\Territory` — `IsTenantModel`; `users(): BelongsToMany` (via `territory_user`).
+- `App\Filament\App\Resources\TerritoryResource` (app panel, team-scoped): CRUD; `canAccess`
+  → super_admin / admin / manager (territory management is a lead's job, not a rep's). Form:
+  `name` + a **multi-select of the team's members** (`->relationship('users','name')` scoped
+  to `Filament::getTenant()->allUsers()`), so assigning members is part of create/edit.
+
+## Testing (TDD, PHPUnit sqlite → MySQL-verify)
+
+1. An admin creates a territory → `team_id` stamped.
+2. Creating with members selected writes the `territory_user` pivot rows.
+3. Team-scoped: team A's admin doesn't see team B's territory.
+4. `canAccess`: manager ✓, sales_rep ✗.
+
+`Territory` is `IsTenantModel`, so the `CrossTenantLeakageTest` auto-covers it. phpstan 0-new,
+MySQL 8.4-verified, pint clean. Inline TDD, one PR to `main`.
+
+## Out of scope (later slices)
+
+Record `territory_id` + the territory scope (slice 2), field-level masking (slice 3), territory
+hierarchy/parenting, auto-assignment rules, per-territory quotas.

--- a/tests/Feature/Filament/TerritoryResourceTest.php
+++ b/tests/Feature/Filament/TerritoryResourceTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament;
+
+use App\Filament\App\Resources\TerritoryResource;
+use App\Filament\App\Resources\TerritoryResource\Pages\CreateTerritory;
+use App\Filament\App\Resources\TerritoryResource\Pages\ListTerritories;
+use App\Models\Team;
+use App\Models\Territory;
+use App\Models\User;
+use Database\Seeders\RolesSeeder;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class TerritoryResourceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $admin;
+
+    private $team;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolesSeeder::class);
+        $this->admin = User::factory()->withPersonalTeam()->create(['email_verified_at' => now()]);
+        $this->team = $this->admin->currentTeam;
+        setPermissionsTeamId($this->team->id);
+        $this->admin->assignRole('admin');
+        $this->actingAs($this->admin);
+        Filament::setCurrentPanel(Filament::getPanel('app'));
+        Filament::setTenant($this->team);
+    }
+
+    public function test_admin_creates_a_territory_scoped_to_team(): void
+    {
+        Livewire::test(CreateTerritory::class)
+            ->fillForm(['name' => 'West Region'])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        $this->assertDatabaseHas('territories', [
+            'name' => 'West Region',
+            'team_id' => $this->team->id,
+        ]);
+    }
+
+    public function test_creating_with_members_writes_the_pivot(): void
+    {
+        $member = User::factory()->create(['email_verified_at' => now()]);
+        $this->team->users()->attach($member);
+
+        Livewire::test(CreateTerritory::class)
+            ->fillForm(['name' => 'East Region', 'users' => [$member->id]])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        $territory = Territory::withoutGlobalScope('tenant')->where('name', 'East Region')->first();
+        $this->assertNotNull($territory);
+        $this->assertTrue($territory->users()->where('users.id', $member->id)->exists());
+    }
+
+    public function test_list_is_team_scoped(): void
+    {
+        $mine = Territory::factory()->create(['team_id' => $this->team->id]);
+        $other = Territory::factory()->create(['team_id' => Team::factory()->create()->id]);
+
+        Livewire::test(ListTerritories::class)
+            ->assertCanSeeTableRecords([$mine])
+            ->assertCanNotSeeTableRecords([$other]);
+    }
+
+    public function test_manager_can_access_sales_rep_cannot(): void
+    {
+        $this->assertTrue(TerritoryResource::canAccess());
+
+        $rep = User::factory()->withPersonalTeam()->create(['email_verified_at' => now()]);
+        setPermissionsTeamId($rep->currentTeam->id);
+        $rep->assignRole('sales_rep');
+        $this->actingAs($rep);
+
+        $this->assertFalse(TerritoryResource::canAccess());
+    }
+}


### PR DESCRIPTION
## What

First slice of the **G3 ABAC** epic (attribute-based access: territory + field-level scoping). This is the **foundation** — a team manages sales territories and assigns members. **No record scoping yet** (that's slice 2).

### Epic decomposition
1. **Territory foundation** (this PR)
2. Record territory scoping — add `territory_id` to Leads/Deals + a `RestrictsToTerritory` scope gated by the user's territories (mirrors F4's `RestrictsToOwner`)
3. Field-level masking

## Changes

- `territories` table (team-scoped) + `territory_user` pivot (unique pair, cascade).
- `App\Models\Territory` — `IsTenantModel` (team scope + `team_id` auto-stamp + `team()`); `users(): BelongsToMany` via `territory_user`.
- `App\Filament\App\Resources\TerritoryResource` (app panel, `canAccess` admin/manager/super_admin): CRUD + a **members multi-select** scoped to the team's users.

## Verification

- New tests: 4 (create stamps `team_id`; creating with members writes the `territory_user` pivot; list is team-scoped; `canAccess` manager✓/sales_rep✗).
- Full suite **899 pass / 1 skip / 0 fail** (+5) — the `CrossTenantLeakageTest` auto-covers the new IsTenantModel, mount sweeps pass.
- phpstan **0-new** (22 == baseline `ignore.unmatched`).
- **MySQL 8.4-verified**, pint clean.

Notable: the members `->relationship('users','name', ...)` option query joins `territory_user`, so the team-scoping predicate must qualify the column (`users.id`) — a bare `id` is ambiguous.

Spec: `docs/superpowers/specs/2026-07-08-g3-territory-foundation-design.md`

## Out of scope (later slices)

Record `territory_id` + the territory scope, field-level masking, territory hierarchy, auto-assignment rules, per-territory quotas.