### PR TITLE
feat(abac): scope contacts by territory (G3 slice 2)

### DIFF
--- a/app/Models/Contact.php
+++ b/app/Models/Contact.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Traits\IsTenantModel;
+use App\Traits\RestrictsToTerritory;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -18,9 +19,11 @@ class Contact extends Model
     use HasFactory;
     use IsTenantModel;
     use Notifiable;
+    use RestrictsToTerritory;
 
     protected $fillable = [
         'team_id',
+        'territory_id',
         'name',
         'last_name',
         'email',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
@@ -193,5 +194,15 @@ class User extends Authenticatable implements FilamentUser, HasDefaultTenant, Ha
             ->whereNull($tables['model_has_roles'].'.'.$teamKey)
             ->whereRaw('LOWER('.$tables['roles'].'.name) = ?', [$roleName])
             ->exists();
+    }
+
+    /**
+     * Territories this user is assigned to (G3 ABAC).
+     *
+     * @return BelongsToMany<Territory, $this>
+     */
+    public function territories(): BelongsToMany
+    {
+        return $this->belongsToMany(Territory::class, 'territory_user');
     }
 }

--- a/app/Support/AccessContext.php
+++ b/app/Support/AccessContext.php
@@ -59,4 +59,28 @@ class AccessContext
 
         return null;
     }
+
+    /**
+     * Territory ids a restricted user is limited to (RestrictsToTerritory models),
+     * or null for see-all. Same restricted-role gate + guard resolution as
+     * restrictToOwnerId. An empty array means a restricted user with no territories.
+     *
+     * @return array<int, int>|null
+     */
+    public static function restrictedTerritoryIds(): ?array
+    {
+        $user = Auth::guard('sanctum')->user() ?? Auth::user();
+
+        if (! $user instanceof User) {
+            return null;
+        }
+
+        foreach (self::RESTRICTED_ROLES as $role) {
+            if ($user->hasRole($role)) {
+                return $user->territories()->pluck('territories.id')->all();
+            }
+        }
+
+        return null;
+    }
 }

--- a/app/Traits/RestrictsToTerritory.php
+++ b/app/Traits/RestrictsToTerritory.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Traits;
+
+use App\Support\AccessContext;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Record-level territory scope (G3 ABAC). Stacks on IsTenantModel's team scope:
+ * when AccessContext restricts the current user to a set of territories, reads
+ * are filtered to rows whose territory_id is in that set. Read-only — territory
+ * is assigned, not creator-derived, so there is no insert auto-stamp.
+ */
+trait RestrictsToTerritory
+{
+    protected static function bootRestrictsToTerritory(): void
+    {
+        static::addGlobalScope('territory', function (Builder $builder): void {
+            $ids = AccessContext::restrictedTerritoryIds();
+
+            if ($ids !== null) {
+                // Empty set (a restricted user with no territories) -> no rows.
+                $builder->whereIn($builder->getModel()->qualifyColumn('territory_id'), $ids);
+            }
+        });
+    }
+}

--- a/database/migrations/2026_07_08_040000_add_territory_id_to_contacts_table.php
+++ b/database/migrations/2026_07_08_040000_add_territory_id_to_contacts_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('contacts', function (Blueprint $table): void {
+            if (! Schema::hasColumn('contacts', 'territory_id')) {
+                $table->foreignId('territory_id')->nullable()->after('team_id')->constrained()->nullOnDelete();
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('contacts', function (Blueprint $table): void {
+            $table->dropConstrainedForeignId('territory_id');
+        });
+    }
+};

--- a/docs/superpowers/specs/2026-07-08-g3-territory-scoping-design.md
+++ b/docs/superpowers/specs/2026-07-08-g3-territory-scoping-design.md
@@ -1,0 +1,48 @@
+# G3 ABAC — slice 2: record territory scoping (design)
+
+**Date:** 2026-07-08
+**Status:** approved, implementing
+**Epic:** G3 ABAC. Builds on #505 (territory foundation). Territories now *do* something.
+
+## Scope
+
+Filter **Contact** records by the current user's territories. Contact is chosen because it has
+**no** F4 owner-scope (`RestrictsToOwner` was skipped for Contact — no owner column), so the
+new territory scope stacks cleanly on the team scope without an owner-AND-territory conflict.
+
+Mirrors the F4 pattern: a removable global scope gated by `AccessContext`, restricting the same
+roles (`sales_rep` / `free`); managers / admins / super_admins / roleless / non-auth contexts
+see everything in scope.
+
+## Architecture
+
+- Migration: `contacts.territory_id` (nullable FK → `territories`, `nullOnDelete`).
+- `User::territories(): BelongsToMany` (inverse of `Territory::users`, via `territory_user`).
+- `App\Support\AccessContext::restrictedTerritoryIds(): ?array` — for a restricted-role user,
+  the ids of their assigned territories; otherwise `null` (see-all). Same guard resolution
+  (sanctum → default) as `restrictToOwnerId`.
+- `App\Traits\RestrictsToTerritory` — a global `territory` scope: when
+  `restrictedTerritoryIds()` is non-null, `whereIn(territory_id, ids)`. **No auto-stamp**
+  (territory is assigned, not creator-derived). Read-only scoping.
+- Apply the trait to `Contact` (+ `territory_id` fillable).
+
+**Behavior:** a restricted user sees only contacts whose `territory_id` is in their
+territories. Unassigned (`null`) contacts are **not** visible to restricted users (strict
+territory ABAC); managers/admins see all.
+
+## Testing (TDD, PHPUnit sqlite → MySQL-verify)
+
+1. A `sales_rep` assigned to territory T sees a contact in T and **not** one in another
+   territory.
+2. A `manager` sees contacts across all territories.
+3. A roleless user is unrestricted (sees all).
+4. `AccessContext::restrictedTerritoryIds` returns the ids for a `sales_rep`, `null` for a
+   `manager`.
+
+phpstan 0-new, MySQL 8.4-verified, pint clean. Inline TDD, one PR to `main`.
+
+## Out of scope
+
+Territory scoping on other models (Lead/Deal already owner-scoped — a combined policy is its
+own decision), auto-assigning a contact's territory, field masking (slice 3), letting
+restricted users also see unassigned contacts (a product toggle if wanted later).

--- a/tests/Feature/Tenancy/TerritoryScopingTest.php
+++ b/tests/Feature/Tenancy/TerritoryScopingTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Tenancy;
+
+use App\Models\Contact;
+use App\Models\Team;
+use App\Models\Territory;
+use App\Models\User;
+use App\Support\AccessContext;
+use Database\Seeders\RolesSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Collection;
+use Tests\TestCase;
+
+class TerritoryScopingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Team $team;
+
+    private Territory $t1;
+
+    private Territory $t2;
+
+    private Contact $inT1;
+
+    private Contact $inT2;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolesSeeder::class);
+        $this->team = Team::factory()->create();
+        $this->t1 = Territory::factory()->create(['team_id' => $this->team->id]);
+        $this->t2 = Territory::factory()->create(['team_id' => $this->team->id]);
+        $this->inT1 = Contact::factory()->create(['team_id' => $this->team->id, 'territory_id' => $this->t1->id]);
+        $this->inT2 = Contact::factory()->create(['team_id' => $this->team->id, 'territory_id' => $this->t2->id]);
+    }
+
+    /** Contacts visible ignoring the team scope (isolate the territory scope). */
+    private function visibleContactIds(): Collection
+    {
+        return Contact::withoutGlobalScope('tenant')->pluck('id');
+    }
+
+    private function member(string $role): User
+    {
+        $user = User::factory()->create(['email_verified_at' => now()]);
+        $this->team->users()->attach($user);
+        setPermissionsTeamId($this->team->id);
+        $user->assignRole($role);
+
+        return $user;
+    }
+
+    public function test_sales_rep_sees_only_their_territory(): void
+    {
+        $rep = $this->member('sales_rep');
+        $rep->territories()->attach($this->t1);
+        $this->actingAs($rep);
+
+        $ids = $this->visibleContactIds();
+        $this->assertTrue($ids->contains($this->inT1->id));
+        $this->assertFalse($ids->contains($this->inT2->id));
+    }
+
+    public function test_manager_sees_all_territories(): void
+    {
+        $this->actingAs($this->member('manager'));
+
+        $ids = $this->visibleContactIds();
+        $this->assertTrue($ids->contains($this->inT1->id));
+        $this->assertTrue($ids->contains($this->inT2->id));
+    }
+
+    public function test_roleless_user_is_unrestricted(): void
+    {
+        $user = User::factory()->create(['email_verified_at' => now()]);
+        $this->team->users()->attach($user);
+        $this->actingAs($user);
+
+        $ids = $this->visibleContactIds();
+        $this->assertTrue($ids->contains($this->inT1->id));
+        $this->assertTrue($ids->contains($this->inT2->id));
+    }
+
+    public function test_restricted_territory_ids_for_a_sales_rep(): void
+    {
+        $rep = $this->member('sales_rep');
+        $rep->territories()->attach($this->t1);
+        $this->actingAs($rep);
+
+        $this->assertEqualsCanonicalizing([$this->t1->id], AccessContext::restrictedTerritoryIds());
+    }
+
+    public function test_restricted_territory_ids_is_null_for_a_manager(): void
+    {
+        $this->actingAs($this->member('manager'));
+
+        $this->assertNull(AccessContext::restrictedTerritoryIds());
+    }
+}


### PR DESCRIPTION
## What

Second slice of **G3 ABAC** — the payoff. Territories now **filter records**: a territory-restricted user sees only contacts in their assigned territories.

Applied to **Contact** (which has no F4 owner-scope, so the territory scope stacks cleanly on the team scope with no owner-AND-territory conflict). Mirrors F4's `RestrictsToOwner` / `AccessContext`: the same roles are restricted (`sales_rep` / `free`); managers / admins / super_admins / roleless / non-auth see everything in scope.

## Changes

- `contacts.territory_id` (nullable FK → `territories`, `nullOnDelete`).
- `User::territories()` (inverse of `Territory::users`, via `territory_user`).
- `App\Support\AccessContext::restrictedTerritoryIds(): ?array` — a restricted user's territory ids, else `null` (see-all). Same guard resolution as `restrictToOwnerId`.
- `App\Traits\RestrictsToTerritory` — a global `territory` scope (`whereIn(territory_id, ids)` when restricted; read-only, no auto-stamp), applied to `Contact`.

**Behavior:** a restricted user sees only contacts whose `territory_id` is in their territories; unassigned (`null`) contacts are hidden from them (strict territory ABAC).

## Verification

- New tests: 5 (sales_rep sees only their territory's contact, not another's; manager sees all; roleless is unrestricted; `restrictedTerritoryIds` resolves for a rep and is null for a manager).
- Full suite **904 pass / 1 skip / 0 fail** (+5) — the trait is inert for non-restricted / non-auth contexts, so existing Contact tests are unaffected.
- phpstan **0-new** (22 == baseline `ignore.unmatched`).
- **MySQL 8.4-verified**, pint clean.

Note: `restrictedTerritoryIds` resolves the sanctum guard first (matching F4). Splitting a test that called `actingAs` twice was needed because the sanctum guard caches its user within a single request/test — a test artifact, not a production issue.

Spec: `docs/superpowers/specs/2026-07-08-g3-territory-scoping-design.md`

## Out of scope

Territory scoping on Lead/Deal (already owner-scoped — a combined policy is its own decision), auto-assigning a contact's territory, field masking (slice 3).