### PR TITLE
feat(abac): field-level masking (G3 slice 3)

### DIFF
--- a/app/Models/Contact.php
+++ b/app/Models/Contact.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Traits\IsTenantModel;
+use App\Traits\MasksFields;
 use App\Traits\RestrictsToTerritory;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -18,8 +19,12 @@ class Contact extends Model
 {
     use HasFactory;
     use IsTenantModel;
+    use MasksFields;
     use Notifiable;
     use RestrictsToTerritory;
+
+    /** Sensitive fields masked in serialized output for masked-role viewers. */
+    protected $maskedFields = ['email', 'phone_number'];
 
     protected $fillable = [
         'team_id',

--- a/app/Support/AccessContext.php
+++ b/app/Support/AccessContext.php
@@ -23,6 +23,9 @@ class AccessContext
     /** Roles restricted to records they own; all other roles see everything in scope. */
     private const RESTRICTED_ROLES = ['sales_rep', 'free'];
 
+    /** Roles whose serialized output has sensitive fields masked (MasksFields models). */
+    private const MASKED_ROLES = ['free'];
+
     protected static ?int $ownerId = null;
 
     protected static bool $overridden = false;
@@ -82,5 +85,26 @@ class AccessContext
         }
 
         return null;
+    }
+
+    /**
+     * Whether the current user's serialized output should mask sensitive fields
+     * (MasksFields models). Same guard resolution as the other methods.
+     */
+    public static function shouldMaskFields(): bool
+    {
+        $user = Auth::guard('sanctum')->user() ?? Auth::user();
+
+        if (! $user instanceof User) {
+            return false;
+        }
+
+        foreach (self::MASKED_ROLES as $role) {
+            if ($user->hasRole($role)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/app/Traits/MasksFields.php
+++ b/app/Traits/MasksFields.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Traits;
+
+use App\Support\AccessContext;
+
+/**
+ * Field-level masking (G3 ABAC). Masks configured sensitive fields in the
+ * model's serialized output (toArray / toJson / API responses) for masked-role
+ * viewers — WITHOUT mutating the stored attributes, so `$model->field` and any
+ * save/business logic still see the real value.
+ *
+ * Declare fields with `protected $maskedFields = ['email', 'phone_number'];`.
+ */
+trait MasksFields
+{
+    private const MASK = '[hidden]';
+
+    /**
+     * @return array<int, string>
+     */
+    public function maskedFields(): array
+    {
+        return property_exists($this, 'maskedFields') ? $this->maskedFields : [];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function attributesToArray(): array
+    {
+        $attributes = parent::attributesToArray();
+
+        if (AccessContext::shouldMaskFields()) {
+            foreach ($this->maskedFields() as $field) {
+                if (array_key_exists($field, $attributes) && $attributes[$field] !== null) {
+                    $attributes[$field] = self::MASK;
+                }
+            }
+        }
+
+        return $attributes;
+    }
+}

--- a/docs/superpowers/specs/2026-07-08-g3-field-masking-design.md
+++ b/docs/superpowers/specs/2026-07-08-g3-field-masking-design.md
@@ -1,0 +1,49 @@
+# G3 ABAC — slice 3: field-level masking (design)
+
+**Date:** 2026-07-08
+**Status:** approved, implementing
+**Epic:** G3 ABAC (final slice). Follows #505 (territories) / #506 (territory scoping).
+
+## Problem
+
+Territory scoping hides whole records; field masking hides *fields* of records a user may
+otherwise see. A low-tier user should be able to see a Contact exists without seeing its
+sensitive contact details (email / phone).
+
+## Design — mask at serialization (not attribute mutation)
+
+Masking is applied in `attributesToArray()` (i.e. `toArray()` / `toJson()` / API responses),
+**not** by mutating the stored attributes. So:
+
+- direct attribute access (`$contact->email`) and any save/business logic see the **real**
+  value — no risk of a mask overwriting data;
+- serialized / API output masks the field for a masked-role viewer.
+
+Components:
+
+- `App\Traits\MasksFields`:
+  - `maskedFields(): array` (from `protected $maskedFields = [...]`).
+  - overrides `attributesToArray()`: when `AccessContext::shouldMaskFields()` is true, each
+    non-null masked field becomes the constant mask `'[hidden]'`.
+- `App\Support\AccessContext::shouldMaskFields(): bool` — true when the current user holds a
+  masked role (`MASKED_ROLES = ['free']` — the most limited tier); false for
+  sales_rep / manager / admin / super_admin / roleless / non-auth. Same guard resolution
+  (sanctum → default) as the other AccessContext methods.
+- Apply to `Contact`: `protected $maskedFields = ['email', 'phone_number']`.
+
+## Testing (TDD, PHPUnit)
+
+1. A `free` user: `$contact->toArray()` masks `email` + `phone_number` (`'[hidden]'`) but keeps
+   `name`.
+2. A `manager`: `toArray()` shows the real `email` / `phone_number`.
+3. **No mutation:** even for a `free` user, `$contact->email` (direct access) is the real value.
+4. `AccessContext::shouldMaskFields` is true for `free`, false for `manager`.
+
+(One `actingAs` per test method — the sanctum guard caches its user within a request, per the
+#506 note.) phpstan 0-new, MySQL 8.4-verified, pint clean. Inline TDD, one PR to `main`.
+
+## Out of scope
+
+Masking in the Filament UI columns (serialization/API only for now), per-field role config
+(fixed `free` gate + `Contact` fields), partial masks (last-4), encryption, masking on other
+models.

--- a/tests/Feature/Tenancy/FieldMaskingTest.php
+++ b/tests/Feature/Tenancy/FieldMaskingTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Tenancy;
+
+use App\Models\Contact;
+use App\Models\Team;
+use App\Models\User;
+use App\Support\AccessContext;
+use Database\Seeders\RolesSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class FieldMaskingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Team $team;
+
+    private Contact $contact;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolesSeeder::class);
+        $this->team = Team::factory()->create();
+        $this->contact = Contact::factory()->create([
+            'team_id' => $this->team->id,
+            'name' => 'Jane',
+            'email' => 'jane@example.com',
+            'phone_number' => '+15551234567',
+        ]);
+    }
+
+    private function actAs(string $role): User
+    {
+        $user = User::factory()->create(['email_verified_at' => now()]);
+        $this->team->users()->attach($user);
+        setPermissionsTeamId($this->team->id);
+        $user->assignRole($role);
+        $this->actingAs($user);
+
+        return $user;
+    }
+
+    public function test_free_user_sees_masked_sensitive_fields_in_serialization(): void
+    {
+        $this->actAs('free');
+
+        $array = $this->contact->fresh()->toArray();
+
+        $this->assertSame('[hidden]', $array['email']);
+        $this->assertSame('[hidden]', $array['phone_number']);
+        $this->assertSame('Jane', $array['name']);
+    }
+
+    public function test_manager_sees_real_values(): void
+    {
+        $this->actAs('manager');
+
+        $array = $this->contact->fresh()->toArray();
+
+        $this->assertSame('jane@example.com', $array['email']);
+        $this->assertSame('+15551234567', $array['phone_number']);
+    }
+
+    public function test_masking_does_not_mutate_the_real_attribute(): void
+    {
+        $this->actAs('free');
+
+        // Direct access (business logic, saves) still sees the real value.
+        $this->assertSame('jane@example.com', $this->contact->fresh()->email);
+    }
+
+    public function test_should_mask_fields_is_true_for_free_only(): void
+    {
+        $this->actAs('free');
+        $this->assertTrue(AccessContext::shouldMaskFields());
+    }
+
+    public function test_should_mask_fields_is_false_for_a_manager(): void
+    {
+        $this->actAs('manager');
+        $this->assertFalse(AccessContext::shouldMaskFields());
+    }
+}


### PR DESCRIPTION
## What

Final slice of **G3 ABAC** (and the last roadmap epic). Territory scoping hides whole records (#506); this hides **fields** of records a user can otherwise see. Sensitive fields are masked in a model's **serialized output** (`toArray` / `toJson` / API) for masked-role viewers.

## Design — mask at serialization, not attribute mutation

Masking happens in `attributesToArray()`, **not** by changing stored attributes. So direct access (`$contact->email`) and any save/business logic see the **real** value — no risk of a mask overwriting data — while serialized/API output masks the field.

## Changes

- `App\Traits\MasksFields` — overrides `attributesToArray()` to replace the declared `$maskedFields` with `'[hidden]'` when `AccessContext::shouldMaskFields()` is true.
- `App\Support\AccessContext::shouldMaskFields(): bool` — true for a masked-role user (`MASKED_ROLES = ['free']`, the most limited tier); false otherwise. Same guard resolution as the other methods.
- `Contact` masks `email` + `phone_number`.

## Verification

- New tests: 5 (a `free` user's `toArray()` masks email/phone but keeps name; a `manager` sees real values; **direct attribute access is unmasked** for a free user — no mutation; `shouldMaskFields` true for free, false for manager).
- Full suite **909 pass / 1 skip / 0 fail** (stable across 3 runs) — the override is inert for non-masked / non-auth contexts.
- phpstan **0-new** (22 == baseline `ignore.unmatched`).
- **MySQL 8.4-verified**, pint clean.

Spec: `docs/superpowers/specs/2026-07-08-g3-field-masking-design.md`

## Out of scope

Filament UI column masking (serialization/API only), per-field role config, partial masks (last-4), masking on other models.