### PR TITLE
feat(abac): mask sensitive fields in the Filament UI (G3)

### DIFF
--- a/app/Filament/App/Resources/ContactResource.php
+++ b/app/Filament/App/Resources/ContactResource.php
@@ -113,8 +113,10 @@ class ContactResource extends Resource
                     ->searchable()
                     ->sortable(),
                 TextColumn::make('email')
+                    ->formatStateUsing(fn (?string $state, Contact $record): mixed => $record->maskFor('email', $state))
                     ->searchable(),
                 TextColumn::make('phone_number')
+                    ->formatStateUsing(fn (?string $state, Contact $record): mixed => $record->maskFor('phone_number', $state))
                     ->searchable(),
                 TextColumn::make('status')
                     ->badge()

--- a/app/Traits/MasksFields.php
+++ b/app/Traits/MasksFields.php
@@ -27,17 +27,31 @@ trait MasksFields
     }
 
     /**
+     * The value to display for a field: the mask when the field is masked and the
+     * viewer is a masked role, otherwise the real value. Reused by attribute
+     * serialization and by display surfaces (e.g. Filament columns).
+     */
+    public function maskFor(string $field, mixed $value): mixed
+    {
+        if ($value !== null
+            && in_array($field, $this->maskedFields(), true)
+            && AccessContext::shouldMaskFields()) {
+            return self::MASK;
+        }
+
+        return $value;
+    }
+
+    /**
      * @return array<string, mixed>
      */
     public function attributesToArray(): array
     {
         $attributes = parent::attributesToArray();
 
-        if (AccessContext::shouldMaskFields()) {
-            foreach ($this->maskedFields() as $field) {
-                if (array_key_exists($field, $attributes) && $attributes[$field] !== null) {
-                    $attributes[$field] = self::MASK;
-                }
+        foreach ($this->maskedFields() as $field) {
+            if (array_key_exists($field, $attributes)) {
+                $attributes[$field] = $this->maskFor($field, $attributes[$field]);
             }
         }
 

--- a/docs/superpowers/specs/2026-07-08-g3-ui-masking-design.md
+++ b/docs/superpowers/specs/2026-07-08-g3-ui-masking-design.md
@@ -1,0 +1,39 @@
+# G3 ABAC — field masking in the Filament UI (design)
+
+**Date:** 2026-07-08
+**Status:** approved, implementing
+**Epic:** G3 ABAC follow-up. Extends #507 (serialization masking) to the staff UI.
+
+## Problem
+
+#507 masks sensitive fields in serialized output (API / toArray), but the app-panel
+`ContactResource` table reads attributes directly, so a masked-role (`free`) user still sees
+the real `email` / `phone_number` in the Filament UI. Close that gap and make the mask logic
+reusable.
+
+## Design
+
+- Add a reusable `MasksFields::maskFor(string $field, mixed $value): mixed` — returns the
+  `'[hidden]'` mask when the value is non-null, the field is masked, and
+  `AccessContext::shouldMaskFields()` is true; otherwise the value. Refactor
+  `attributesToArray()` to use it (behavior unchanged).
+- `ContactResource` `email` / `phone_number` columns get
+  `->formatStateUsing(fn ($state, Contact $record) => $record->maskFor('<field>', $state))`,
+  so the table shows `'[hidden]'` for a masked-role viewer and the real value for everyone else.
+
+## Testing (TDD)
+
+1. `maskFor` masks a masked field for a `free` user, leaves a non-masked field, and returns the
+   real value for a `manager`.
+2. Filament table: a `free` user (with the contact in their territory so it is visible) sees
+   `'[hidden]'`, not the real email, in `ListContacts`.
+3. Filament table: a `manager` sees the real email.
+
+phpstan 0-new, MySQL 8.4-verified, pint clean. Inline TDD, one PR to `main`.
+
+## Out of scope / ceiling
+
+- Search still queries the real column, so a masked column that stays `searchable()` lets a
+  user confirm a value by searching for it (display-level mask; the record is already
+  territory-scoped). Restricting search per role is a later refinement.
+- Edit/View form masking, masking on other resources, per-field role config.

--- a/tests/Feature/Filament/ContactMaskingUiTest.php
+++ b/tests/Feature/Filament/ContactMaskingUiTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament;
+
+use App\Filament\App\Resources\ContactResource\Pages\ListContacts;
+use App\Models\Contact;
+use App\Models\Territory;
+use App\Models\User;
+use Database\Seeders\RolesSeeder;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class ContactMaskingUiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @return array{0: User, 1: Contact}
+     */
+    private function setUpViewer(string $role): array
+    {
+        $this->seed(RolesSeeder::class);
+        $user = User::factory()->withPersonalTeam()->create(['email_verified_at' => now()]);
+        $team = $user->currentTeam;
+        $territory = Territory::factory()->create(['team_id' => $team->id]);
+        setPermissionsTeamId($team->id);
+        $user->assignRole($role);
+        $user->territories()->attach($territory);
+
+        $contact = Contact::factory()->create([
+            'team_id' => $team->id,
+            'territory_id' => $territory->id,
+            'name' => 'Jane',
+            'email' => 'jane@example.com',
+        ]);
+
+        $this->actingAs($user);
+        Filament::setCurrentPanel(Filament::getPanel('app'));
+        Filament::setTenant($team);
+
+        return [$user, $contact];
+    }
+
+    public function test_mask_for_helper_masks_only_masked_fields_for_masked_roles(): void
+    {
+        [, $contact] = $this->setUpViewer('free');
+        $fresh = $contact->fresh();
+
+        $this->assertSame('[hidden]', $fresh->maskFor('email', $fresh->email));
+        $this->assertSame('Jane', $fresh->maskFor('name', 'Jane'));
+    }
+
+    public function test_free_user_sees_masked_email_in_the_table(): void
+    {
+        $this->setUpViewer('free');
+
+        Livewire::test(ListContacts::class)
+            ->assertSee('[hidden]')
+            ->assertDontSee('jane@example.com');
+    }
+
+    public function test_manager_sees_the_real_email_in_the_table(): void
+    {
+        $this->setUpViewer('manager');
+
+        Livewire::test(ListContacts::class)
+            ->assertSee('jane@example.com');
+    }
+}


### PR DESCRIPTION
## What

Extends #507's **serialization** field masking to the **staff UI**. The app-panel `ContactResource` table now shows `[hidden]` for `email` / `phone_number` to masked-role (`free`) viewers, and the mask logic is now reusable.

## Changes

- `MasksFields::maskFor(field, value)` — a reusable helper returning the mask when the field is masked and `AccessContext::shouldMaskFields()` is true, else the value. `attributesToArray()` refactored to use it (behavior unchanged, #507 tests still pass).
- `ContactResource` `email` / `phone_number` columns: `->formatStateUsing(fn ($state, Contact $record) => $record->maskFor('<field>', $state))`.

## Verification

- New tests: 3 (`maskFor` masks a masked field for `free`, leaves a non-masked field, real for `manager`; a `free` user sees `[hidden]` in the `ListContacts` table, not the real email; a `manager` sees the real email).
- Full suite **912 pass / 1 skip / 0 fail** (+3).
- phpstan **0-new** (22 == baseline `ignore.unmatched`).
- **MySQL 8.4-verified**, pint clean.

Spec: `docs/superpowers/specs/2026-07-08-g3-ui-masking-design.md`

## Ceiling

Masked columns stay `searchable()`, so search still queries the real column — a user could confirm a value by searching for it (display-level mask; the record is already territory-scoped). Restricting search per role, edit/view-form masking, and other resources are follow-ups.