### PR TITLE
feat(abac): don't search masked contact columns (G3)

### DIFF
--- a/app/Filament/App/Resources/ContactResource.php
+++ b/app/Filament/App/Resources/ContactResource.php
@@ -12,6 +12,7 @@ use App\Filament\App\Resources\ContactResource\RelationManagers\DocumentsRelatio
 use App\Models\Company;
 use App\Models\Contact;
 use App\Services\TwilioService;
+use App\Support\AccessContext;
 use App\Support\PortalCustomer;
 use Filament\Actions\Action;
 use Filament\Actions\BulkAction;
@@ -114,10 +115,12 @@ class ContactResource extends Resource
                     ->sortable(),
                 TextColumn::make('email')
                     ->formatStateUsing(fn (?string $state, Contact $record): mixed => $record->maskFor('email', $state))
-                    ->searchable(),
+                    // Not searchable for masked-role viewers, else search would
+                    // query the real column and confirm a value the UI masks.
+                    ->searchable(! AccessContext::shouldMaskFields()),
                 TextColumn::make('phone_number')
                     ->formatStateUsing(fn (?string $state, Contact $record): mixed => $record->maskFor('phone_number', $state))
-                    ->searchable(),
+                    ->searchable(! AccessContext::shouldMaskFields()),
                 TextColumn::make('status')
                     ->badge()
                     ->color(fn (string $state): string => match ($state) {

--- a/docs/superpowers/specs/2026-07-08-g3-mask-search-design.md
+++ b/docs/superpowers/specs/2026-07-08-g3-mask-search-design.md
@@ -1,0 +1,36 @@
+# G3 ABAC — don't search masked columns (design)
+
+**Date:** 2026-07-08
+**Status:** approved, implementing
+**Epic:** G3 ABAC. Closes the ceiling noted in #508 (UI field masking).
+
+## Problem
+
+#508 masks `email` / `phone_number` in the `ContactResource` table, but the columns stay
+`searchable()`. So a masked-role (`free`) user can type a real email into the table search and
+the query matches the real column — confirming a value the UI otherwise hides. The mask is
+bypassable via search.
+
+## Fix
+
+Make the masked columns non-searchable for masked-role viewers. `AccessContext::shouldMaskFields()`
+is resolved at `table()` build time (request-scoped, current user), so:
+
+```php
+TextColumn::make('email')->searchable(! AccessContext::shouldMaskFields())
+```
+
+A `free` user gets `searchable(false)` on `email` / `phone_number` (no match on those columns);
+everyone else keeps full search. Other columns (name, etc.) stay searchable for all.
+
+## Testing (TDD)
+
+1. A `free` user: the contact is visible unfiltered (territory), but searching its **real
+   email** returns no rows (the masked column is not searchable).
+2. A `manager`: searching the email finds the contact.
+
+phpstan 0-new, MySQL 8.4-verified, pint clean. Inline TDD, one PR to `main`.
+
+## Out of scope
+
+Global-search masking on other resources, edit/view-form masking, encrypting the stored value.

--- a/tests/Feature/Filament/ContactMaskingUiTest.php
+++ b/tests/Feature/Filament/ContactMaskingUiTest.php
@@ -70,4 +70,23 @@ class ContactMaskingUiTest extends TestCase
         Livewire::test(ListContacts::class)
             ->assertSee('jane@example.com');
     }
+
+    public function test_free_user_cannot_find_a_contact_by_searching_its_masked_email(): void
+    {
+        [, $contact] = $this->setUpViewer('free');
+
+        Livewire::test(ListContacts::class)
+            ->assertCanSeeTableRecords([$contact])
+            ->searchTable('jane@example.com')
+            ->assertCanNotSeeTableRecords([$contact]);
+    }
+
+    public function test_manager_can_find_a_contact_by_searching_its_email(): void
+    {
+        [, $contact] = $this->setUpViewer('manager');
+
+        Livewire::test(ListContacts::class)
+            ->searchTable('jane@example.com')
+            ->assertCanSeeTableRecords([$contact]);
+    }
 }


### PR DESCRIPTION
## What

Closes the ceiling noted in #508. The masked `email` / `phone_number` columns stayed `searchable()`, so a masked-role (`free`) user could type a real email into the table search and the query matched the real column — confirming a value the UI masks. **The mask was bypassable via search.**

## Fix

The masked columns are now non-searchable for masked-role viewers:

```php
TextColumn::make('email')->searchable(! AccessContext::shouldMaskFields())
```

`AccessContext::shouldMaskFields()` is resolved at `table()` build time (per request), so a `free` user gets `searchable(false)` on `email` / `phone_number`; everyone else keeps full search. Other columns (name, …) are unchanged.

## Verification

- New tests: 2 (a `free` user sees the contact unfiltered but **cannot find it by searching its real email**; a `manager` can search by email). Plus the 3 existing #508 masking tests still pass.
- Full suite **914 pass / 1 skip / 0 fail** (+2).
- phpstan **0-new** (22 == baseline `ignore.unmatched`).
- **MySQL 8.4-verified**, pint clean.

Spec: `docs/superpowers/specs/2026-07-08-g3-mask-search-design.md`

## Out of scope

Edit/view-form masking (the form still shows the real value on edit), global-search masking on other resources, encrypting the stored value.