### PR TITLE
feat(abac): mask sensitive fields in the edit form (G3)

### DIFF
--- a/app/Filament/App/Resources/ContactResource.php
+++ b/app/Filament/App/Resources/ContactResource.php
@@ -18,6 +18,7 @@ use Filament\Actions\Action;
 use Filament\Actions\BulkAction;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
+use Filament\Forms\Components\Placeholder;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
@@ -45,14 +46,27 @@ class ContactResource extends Resource
                     ->maxLength(255),
                 TextInput::make('last_name')
                     ->maxLength(255),
+                // On edit, a masked-role viewer gets the read-only placeholder below
+                // instead of the real input. The hidden real field is neither
+                // validated nor dehydrated, so a save preserves the stored value.
                 TextInput::make('email')
                     ->email()
                     ->required()
-                    ->maxLength(255),
+                    ->maxLength(255)
+                    ->visible(fn (string $operation): bool => $operation === 'create' || ! AccessContext::shouldMaskFields()),
+                Placeholder::make('email_masked')
+                    ->label('Email')
+                    ->content('[hidden]')
+                    ->visible(fn (string $operation): bool => $operation !== 'create' && AccessContext::shouldMaskFields()),
                 TextInput::make('phone_number')
                     ->tel()
                     ->required()
-                    ->maxLength(255),
+                    ->maxLength(255)
+                    ->visible(fn (string $operation): bool => $operation === 'create' || ! AccessContext::shouldMaskFields()),
+                Placeholder::make('phone_masked')
+                    ->label('Phone number')
+                    ->content('[hidden]')
+                    ->visible(fn (string $operation): bool => $operation !== 'create' && AccessContext::shouldMaskFields()),
                 Select::make('status')
                     ->options([
                         'active' => 'Active',

--- a/docs/superpowers/specs/2026-07-08-g3-form-masking-design.md
+++ b/docs/superpowers/specs/2026-07-08-g3-form-masking-design.md
@@ -1,0 +1,38 @@
+# G3 ABAC — mask sensitive fields in the edit form (design)
+
+**Date:** 2026-07-08
+**Status:** approved, implementing
+**Epic:** G3 ABAC. Closes the last masking gap after #507 (serialization) / #508 (table) /
+#509 (search).
+
+## Problem
+
+A masked-role (`free`) user opening a contact's **Edit** page still sees the real `email` /
+`phone_number` in the form inputs. That's a read leak of the exact data the table + API hide.
+
+## Fix (mask without corrupting on save)
+
+Masking a form field naively would let the mask overwrite the real value on save. So on the
+`email` / `phone_number` inputs, **only on edit (not create), only for a masked viewer**:
+
+- `->disabled(...)` — the field is read-only.
+- `->formatStateUsing(... '[hidden]' ...)` — it displays the mask, not the real value.
+- `->dehydrated(...)` false — it is **not submitted**, so a save (e.g. changing the name)
+  **preserves** the stored email/phone. This is the critical no-corruption property.
+
+Gated on `$operation !== 'create' && AccessContext::shouldMaskFields()` so create is normal
+(a user must be able to enter the value) and non-masked users edit normally.
+
+## Testing (TDD)
+
+1. A `free` user on the Edit page sees `'[hidden]'` in the email field (form state masked).
+2. **No corruption:** a `free` user changes the name and saves → the stored `email` is still the
+   real value (the disabled, non-dehydrated field was not written).
+3. A `manager` on the Edit page sees the real email.
+
+phpstan 0-new, MySQL 8.4-verified, pint clean. Inline TDD, one PR to `main`.
+
+## Out of scope
+
+Masking in create (no existing value to hide), masking other resources' forms, encrypting the
+stored value, per-field role config.

--- a/tests/Feature/Filament/ContactMaskingUiTest.php
+++ b/tests/Feature/Filament/ContactMaskingUiTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Filament;
 
+use App\Filament\App\Resources\ContactResource\Pages\EditContact;
 use App\Filament\App\Resources\ContactResource\Pages\ListContacts;
 use App\Models\Contact;
 use App\Models\Territory;
@@ -36,6 +37,7 @@ class ContactMaskingUiTest extends TestCase
             'territory_id' => $territory->id,
             'name' => 'Jane',
             'email' => 'jane@example.com',
+            'company_id' => null,
         ]);
 
         $this->actingAs($user);
@@ -88,5 +90,33 @@ class ContactMaskingUiTest extends TestCase
         Livewire::test(ListContacts::class)
             ->searchTable('jane@example.com')
             ->assertCanSeeTableRecords([$contact]);
+    }
+
+    public function test_free_user_sees_masked_email_in_the_edit_form(): void
+    {
+        [, $contact] = $this->setUpViewer('free');
+
+        Livewire::test(EditContact::class, ['record' => $contact->getKey()])
+            ->assertSee('[hidden]')
+            ->assertDontSee('jane@example.com');
+    }
+
+    public function test_real_email_field_is_hidden_from_a_free_user_on_edit(): void
+    {
+        // A hidden Filament field is neither validated nor dehydrated, so a save
+        // cannot overwrite the stored email/phone with the mask — no corruption.
+        [, $contact] = $this->setUpViewer('free');
+
+        Livewire::test(EditContact::class, ['record' => $contact->getKey()])
+            ->assertFormFieldIsHidden('email')
+            ->assertFormFieldIsHidden('phone_number');
+    }
+
+    public function test_manager_sees_the_real_email_in_the_edit_form(): void
+    {
+        [, $contact] = $this->setUpViewer('manager');
+
+        Livewire::test(EditContact::class, ['record' => $contact->getKey()])
+            ->assertFormSet(['email' => 'jane@example.com']);
     }
 }


### PR DESCRIPTION
## What

Closes the **last masking gap** after #507 (serialization), #508 (table), #509 (search): a masked-role (`free`) user opening a contact's **Edit** page still saw the real `email` / `phone_number` in the form inputs.

## Fix (mask without corrupting on save)

On **edit** (not create), for masked viewers:
- the real `email` / `phone_number` `TextInput`s are `->visible(false)` — a hidden Filament field is **neither validated nor dehydrated**, so a save (e.g. renaming) **preserves** the stored value;
- a read-only `Placeholder` shows `'[hidden]'` in their place.

Create is unmasked (the user must be able to enter the value); non-masked users edit normally.

## Verification

- New tests: 3 (a `free` user sees `[hidden]` in the edit form and not the real email; the real `email`/`phone_number` fields are **hidden** for a free user on edit → cannot be overwritten; a `manager` sees the real email).
- Full suite **917 pass / 1 skip / 0 fail** (+3).
- phpstan **0-new** (22 == baseline `ignore.unmatched`).
- **MySQL 8.4-verified**, pint clean.

Note: the no-corruption property is proven structurally (the field is hidden → excluded from validation + dehydration) rather than via a full form save, because the pre-existing `Contact::associateWithCompany()` boot hook makes an end-to-end save noisy in tests — unrelated to masking.

Spec: `docs/superpowers/specs/2026-07-08-g3-form-masking-design.md`

## Milestone

Field masking is now **end-to-end**: serialization → table → search → edit form.

## Out of scope

Masking other resources' forms, encrypting the stored value, per-field role config.