### PR TITLE
feat(rbac): add a team member with a role (F4 phase 2)

### DIFF
--- a/app/Filament/App/Resources/TeamMemberResource/Pages/ListTeamMembers.php
+++ b/app/Filament/App/Resources/TeamMemberResource/Pages/ListTeamMembers.php
@@ -4,10 +4,54 @@ declare(strict_types=1);
 
 namespace App\Filament\App\Resources\TeamMemberResource\Pages;
 
+use App\Enums\Role;
 use App\Filament\App\Resources\TeamMemberResource;
+use App\Models\Team;
+use App\Models\User;
+use App\Services\TeamManagementService;
+use Filament\Actions\Action;
+use Filament\Facades\Filament;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Notifications\Notification;
 use Filament\Resources\Pages\ListRecords;
 
 class ListTeamMembers extends ListRecords
 {
     protected static string $resource = TeamMemberResource::class;
+
+    #[\Override]
+    protected function getHeaderActions(): array
+    {
+        return [
+            Action::make('addMember')
+                ->label('Add member')
+                ->icon('heroicon-o-user-plus')
+                ->schema([
+                    TextInput::make('email')->email()->required(),
+                    Select::make('role')
+                        ->options([
+                            Role::Admin->value => 'Admin',
+                            Role::Manager->value => 'Manager',
+                            Role::SalesRep->value => 'Sales rep',
+                            Role::Free->value => 'Free',
+                        ])
+                        ->required(),
+                ])
+                ->action(function (array $data, TeamManagementService $service): void {
+                    $tenant = Filament::getTenant();
+                    $user = User::where('email', $data['email'])->first();
+
+                    // Existing users only — creating a new account is onboarding / SSO.
+                    if (! $tenant instanceof Team || ! $user instanceof User) {
+                        Notification::make()->title('No user found with that email')->danger()->send();
+
+                        return;
+                    }
+
+                    $service->addTeamMember($user, $tenant, Role::from($data['role']));
+                    Notification::make()->title('Member added')->success()->send();
+                }),
+        ];
+    }
 }

--- a/app/Services/TeamManagementService.php
+++ b/app/Services/TeamManagementService.php
@@ -21,6 +21,19 @@ class TeamManagementService
      * user holds in this team, then assigns the new one — never touching global
      * super_admin/customer. Guards the role so the UI Select can't be bypassed.
      */
+    /**
+     * Add an existing user to a team with a team role. Attaches membership if
+     * needed, then delegates to changeTeamRole (role guard + owner guard + audit).
+     */
+    public function addTeamMember(User $user, Team $team, Role $role): void
+    {
+        if (! $user->belongsToTeam($team)) {
+            $team->users()->attach($user);
+        }
+
+        $this->changeTeamRole($user, $team, $role);
+    }
+
     public function changeTeamRole(User $user, Team $team, Role $role): void
     {
         if (! in_array($role, self::TEAM_ROLES, true)) {

--- a/docs/superpowers/specs/2026-07-08-f4-add-member-design.md
+++ b/docs/superpowers/specs/2026-07-08-f4-add-member-design.md
@@ -1,0 +1,43 @@
+# F4 phase-2 — add a team member with a role (design)
+
+**Date:** 2026-07-08
+**Status:** approved, implementing
+**Epic:** F4 per-team RBAC, phase 2. Follows #497 (role UI) / #498 (audit) / #499 (owner guard).
+
+## Problem
+
+`TeamMemberResource` (#497) lets a team admin **re-role existing** members, but there is no way
+to **add** a member to the team from that surface — you can only change roles of people already
+there.
+
+## Fix
+
+An **Add member** header action on `ListTeamMembers`:
+
+- Form: `email` (required) + `role` Select (the four team roles — `admin` / `manager` /
+  `sales_rep` / `free`; `super_admin` and `customer` are never offered).
+- On submit: resolve the `User` by email. If none → a danger notification (no user creation
+  here — that is onboarding/SSO territory). Otherwise
+  `TeamManagementService::addTeamMember($user, $tenant, $role)`.
+
+`TeamManagementService::addTeamMember(User, Team, Role)`:
+- attaches the user to the team if not already a member, then calls the existing
+  `changeTeamRole(...)` — so the role is validated (∈ team roles), the **owner guard** (#499)
+  and the **audit** (`team.role_changed`, #498) both apply for free, and the assignment is
+  team-scoped.
+
+Access is inherited from the resource (`canAccess` = admin / super_admin, #497).
+
+## Testing (TDD)
+
+1. An admin adds an existing user by email with role `manager` → the user is a team member and
+   holds `manager` in the team.
+2. Adding an **unknown** email adds no one (danger path).
+3. The added member then appears in the team-scoped resource list.
+
+phpstan 0-new, MySQL 8.4-verified, pint clean. Inline TDD, one PR to `main`.
+
+## Out of scope
+
+Creating a brand-new user (onboarding/SSO does that), Jetstream email invitations, bulk add,
+removing a member (a separate action), choosing a role at Jetstream-invitation acceptance.

--- a/tests/Feature/Filament/TeamAddMemberTest.php
+++ b/tests/Feature/Filament/TeamAddMemberTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament;
+
+use App\Enums\Role;
+use App\Filament\App\Resources\TeamMemberResource\Pages\ListTeamMembers;
+use App\Models\User;
+use App\Services\TeamManagementService;
+use Database\Seeders\RolesSeeder;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class TeamAddMemberTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $admin;
+
+    private $team;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolesSeeder::class);
+        $this->admin = User::factory()->withPersonalTeam()->create(['email_verified_at' => now()]);
+        $this->team = $this->admin->currentTeam;
+        setPermissionsTeamId($this->team->id);
+        $this->admin->assignRole('admin');
+        $this->actingAs($this->admin);
+        Filament::setCurrentPanel(Filament::getPanel('app'));
+        Filament::setTenant($this->team);
+    }
+
+    public function test_admin_adds_an_existing_user_with_a_role(): void
+    {
+        $target = User::factory()->create(['email' => 'newbie@example.com', 'email_verified_at' => now()]);
+
+        Livewire::test(ListTeamMembers::class)
+            ->callAction('addMember', data: ['email' => 'newbie@example.com', 'role' => Role::Manager->value]);
+
+        $this->assertTrue($this->team->fresh()->users->contains($target));
+
+        setPermissionsTeamId($this->team->id);
+        $this->assertTrue($target->fresh()->hasRole(Role::Manager->value));
+    }
+
+    public function test_adding_an_unknown_email_adds_no_one(): void
+    {
+        $before = $this->team->users()->count();
+
+        Livewire::test(ListTeamMembers::class)
+            ->callAction('addMember', data: ['email' => 'nobody@example.com', 'role' => Role::Free->value]);
+
+        $this->assertSame($before, $this->team->fresh()->users()->count());
+    }
+
+    public function test_service_adds_member_and_role(): void
+    {
+        $target = User::factory()->create();
+
+        app(TeamManagementService::class)->addTeamMember($target, $this->team, Role::SalesRep);
+
+        $this->assertTrue($this->team->fresh()->users->contains($target));
+        setPermissionsTeamId($this->team->id);
+        $this->assertTrue($target->fresh()->hasRole(Role::SalesRep->value));
+    }
+}


### PR DESCRIPTION
## What

`TeamMemberResource` (#497) let a team admin **re-role existing** members but had no way to **add** one from that surface. Adds an **Add member** header action.

## Changes

- `TeamManagementService::addTeamMember(User, Team, Role)` — attaches team membership if needed, then delegates to the existing `changeTeamRole(...)`, so the **role guard** (∈ team roles), the **owner guard** (#499), and the **audit** (`team.role_changed`, #498) all apply for free.
- `ListTeamMembers` **Add member** action: `email` + `role` Select (the four team roles; `super_admin` / `customer` are never offered). **Existing users only** — a danger notice for an unknown email (creating accounts is onboarding / SSO territory).

Access is inherited from the resource (`canAccess` admin / super_admin).

## Verification

- New tests: 3 (admin adds an existing user by email with `manager` → member + role; an unknown email adds no one; the service attaches + roles).
- Full suite **920 pass / 1 skip / 0 fail** (+3).
- phpstan **0-new** (22 == baseline `ignore.unmatched`).
- **MySQL 8.4-verified**, pint clean.

Spec: `docs/superpowers/specs/2026-07-08-f4-add-member-design.md`

## Out of scope

Creating a brand-new user (onboarding/SSO), Jetstream email invitations, bulk add, removing a member, choosing a role at invitation-acceptance.