### PR TITLE
feat(rbac): remove a team member (F4 phase 2)

### DIFF
--- a/app/Filament/App/Resources/TeamMemberResource.php
+++ b/app/Filament/App/Resources/TeamMemberResource.php
@@ -102,6 +102,26 @@ class TeamMemberResource extends Resource
                             Notification::make()->title('Role updated')->success()->send();
                         }
                     }),
+                Action::make('removeMember')
+                    ->label('Remove')
+                    ->icon('heroicon-o-user-minus')
+                    ->color('danger')
+                    ->requiresConfirmation()
+                    // Hidden on the acting admin's own row and the owner's row
+                    // (the service rejects removing the owner too).
+                    ->visible(function (User $record): bool {
+                        $tenant = Filament::getTenant();
+                        $ownerId = $tenant instanceof Team ? $tenant->getAttribute('user_id') : null;
+
+                        return $record->getKey() !== Auth::id() && $record->getKey() !== $ownerId;
+                    })
+                    ->action(function (User $record, TeamManagementService $service): void {
+                        $tenant = Filament::getTenant();
+                        if ($tenant instanceof Team) {
+                            $service->removeTeamMember($record, $tenant);
+                            Notification::make()->title('Member removed')->success()->send();
+                        }
+                    }),
             ])
             ->defaultSort('name');
     }

--- a/app/Services/TeamManagementService.php
+++ b/app/Services/TeamManagementService.php
@@ -34,6 +34,33 @@ class TeamManagementService
         $this->changeTeamRole($user, $team, $role);
     }
 
+    /**
+     * Remove a user from a team: strips their team roles, detaches membership,
+     * and audits it. The team owner cannot be removed (mirrors the role guard).
+     */
+    public function removeTeamMember(User $user, Team $team): void
+    {
+        if ($user->getKey() === $team->getAttribute('user_id')) {
+            throw new InvalidArgumentException('The team owner cannot be removed.');
+        }
+
+        setPermissionsTeamId($team->getKey());
+
+        foreach (self::TEAM_ROLES as $existing) {
+            if ($user->hasRole($existing->value)) {
+                $user->removeRole($existing->value);
+            }
+        }
+
+        $team->users()->detach($user);
+
+        app(AuditLogService::class)->record(
+            'team.member_removed',
+            "Removed {$user->getAttribute('email')} from the team",
+            $user,
+        );
+    }
+
     public function changeTeamRole(User $user, Team $team, Role $role): void
     {
         if (! in_array($role, self::TEAM_ROLES, true)) {

--- a/docs/superpowers/specs/2026-07-08-f4-remove-member-design.md
+++ b/docs/superpowers/specs/2026-07-08-f4-remove-member-design.md
@@ -1,0 +1,39 @@
+# F4 phase-2 — remove a team member (design)
+
+**Date:** 2026-07-08
+**Status:** approved, implementing
+**Epic:** F4 per-team RBAC, phase 2. Pairs with #511 (add member); reuses #498 (audit) / #499
+(owner guard).
+
+## Problem
+
+`TeamMemberResource` can add (#511) and re-role (#497) members, but there is no way to
+**remove** one from the role UI.
+
+## Fix
+
+A **Remove** row action on `TeamMemberResource`, plus a service method:
+
+- `TeamManagementService::removeTeamMember(User, Team): void`
+  - **owner guard:** throws if the target is the team owner (`$team->user_id`, mirrors #499).
+  - removes the four team roles the user holds (in the team's permission context),
+  - detaches team membership,
+  - records a `team.member_removed` audit (`AuditLogService`, #498).
+- The row action mirrors `changeRole`'s visibility: hidden on the acting admin's **own** row
+  (no self-removal) and on the **owner** row; `requiresConfirmation`. Access is the resource's
+  admin / super_admin gate.
+
+## Testing (TDD)
+
+1. `removeTeamMember` detaches the member and strips their team roles.
+2. `removeTeamMember` **rejects** removing the team owner (throws).
+3. The Remove action is hidden on the admin's own row and the owner's row, visible on a regular
+   member.
+4. Calling the action detaches the member.
+
+phpstan 0-new, MySQL 8.4-verified, pint clean. Inline TDD, one PR to `main`.
+
+## Out of scope
+
+Bulk remove, reassigning the removed member's records, deleting the user account (removal only
+detaches from the team), removing via Jetstream team settings (separate surface).

--- a/tests/Feature/Filament/TeamRemoveMemberTest.php
+++ b/tests/Feature/Filament/TeamRemoveMemberTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament;
+
+use App\Filament\App\Resources\TeamMemberResource\Pages\ListTeamMembers;
+use App\Models\User;
+use App\Services\TeamManagementService;
+use Database\Seeders\RolesSeeder;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use InvalidArgumentException;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class TeamRemoveMemberTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $admin;
+
+    private $team;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RolesSeeder::class);
+        $this->admin = User::factory()->withPersonalTeam()->create(['email_verified_at' => now()]);
+        $this->team = $this->admin->currentTeam;
+        setPermissionsTeamId($this->team->id);
+        $this->admin->assignRole('admin');
+        $this->actingAs($this->admin);
+        Filament::setCurrentPanel(Filament::getPanel('app'));
+        Filament::setTenant($this->team);
+    }
+
+    private function member(string $role = 'sales_rep'): User
+    {
+        $member = User::factory()->create(['email_verified_at' => now()]);
+        $this->team->users()->attach($member);
+        setPermissionsTeamId($this->team->id);
+        $member->assignRole($role);
+
+        return $member;
+    }
+
+    public function test_service_removes_membership_and_roles(): void
+    {
+        $member = $this->member('manager');
+
+        app(TeamManagementService::class)->removeTeamMember($member, $this->team);
+
+        $this->assertFalse($this->team->fresh()->users->contains($member));
+        setPermissionsTeamId($this->team->id);
+        $this->assertFalse($member->fresh()->hasRole('manager'));
+        $this->assertDatabaseHas('audit_logs', [
+            'action' => 'team.member_removed',
+            'auditable_id' => $member->id,
+            'team_id' => $this->team->id,
+        ]);
+    }
+
+    public function test_service_rejects_removing_the_owner(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        app(TeamManagementService::class)->removeTeamMember($this->admin, $this->team);
+    }
+
+    public function test_remove_action_hidden_on_own_and_owner_rows(): void
+    {
+        // The admin owns their personal team, so their own row is also the owner row.
+        $member = $this->member();
+
+        Livewire::test(ListTeamMembers::class)
+            ->assertTableActionHidden('removeMember', $this->admin)
+            ->assertTableActionVisible('removeMember', $member);
+    }
+
+    public function test_action_removes_the_member(): void
+    {
+        $member = $this->member();
+
+        Livewire::test(ListTeamMembers::class)
+            ->callTableAction('removeMember', $member);
+
+        $this->assertFalse($this->team->fresh()->users->contains($member));
+    }
+}


### PR DESCRIPTION
## What

Pairs with #511 (add member) to close the add/remove loop on the `TeamMemberResource` role UI. A **Remove** row action.

## Changes

- `TeamManagementService::removeTeamMember(User, Team)`:
  - **owner guard** — throws if the target is the team owner (`$team->user_id`, mirrors #499);
  - strips the four team roles the user holds (in the team's permission context);
  - detaches team membership;
  - records a `team.member_removed` audit (`AuditLogService`, #498).
- **Remove** row action mirrors `changeRole`'s visibility — hidden on the acting admin's **own** row and the **owner** row; `requiresConfirmation`. Access inherited from the resource (admin / super_admin).

## Verification

- New tests: 4 (`removeTeamMember` detaches + strips roles + audits; rejects removing the owner; the action is hidden on own + owner rows, visible on a member; calling it removes the member).
- Full suite **924 pass / 1 skip / 0 fail** (+4) — #497–#499, #511 intact.
- phpstan **0-new** (22 == baseline `ignore.unmatched`).
- **MySQL 8.4-verified**, pint clean.

Spec: `docs/superpowers/specs/2026-07-08-f4-remove-member-design.md`

## Out of scope

Bulk remove, reassigning the removed member's records, deleting the user account (removal only detaches from the team).