### PR TITLE
Complete Predictive Models workflow

### DIFF
--- a/modules/crm-predictive-models-api/src/Http/Controllers/PredictiveModelsController.php
+++ b/modules/crm-predictive-models-api/src/Http/Controllers/PredictiveModelsController.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\PredictiveModelsApi\Http\Controllers;
 
-use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
 use Liberu\CRM\PredictiveModels\Actions\DetectDrift;
 use Liberu\CRM\PredictiveModels\Actions\RecordEvaluation;
 use Liberu\CRM\PredictiveModels\Actions\RecordPrediction;

--- a/modules/crm-predictive-models-filament/src/Resources/PredictionResource.php
+++ b/modules/crm-predictive-models-filament/src/Resources/PredictionResource.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 namespace Liberu\CRM\PredictiveModels\Filament\Resources;
 
 use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
+use Liberu\CRM\PredictiveModels\Filament\Resources\PredictionResource\Pages\CreatePrediction;
+use Liberu\CRM\PredictiveModels\Filament\Resources\PredictionResource\Pages\EditPrediction;
 use Liberu\CRM\PredictiveModels\Filament\Resources\PredictionResource\Pages\ListPredictions;
 use Liberu\CRM\PredictiveModels\Models\Prediction;
 
@@ -20,7 +23,7 @@ final class PredictionResource extends Resource
 
     public static function form(Schema $schema): Schema
     {
-        return $schema->components([TextInput::make('model_id')->numeric()->required(), TextInput::make('subject_type')->required(), TextInput::make('subject_id')->numeric()->required(), Select::make('kind')->options(['scoring' => 'Scoring', 'churn' => 'Churn', 'next_action' => 'Next action', 'forecast' => 'Forecast', 'routing' => 'Routing']), TextInput::make('score')->numeric(), TextInput::make('label')]);
+        return $schema->components([TextInput::make('model_id')->numeric()->required(), TextInput::make('subject_type')->required(), TextInput::make('subject_id')->numeric()->required(), Select::make('kind')->options(['scoring' => 'Scoring', 'churn' => 'Churn', 'next_action' => 'Next action', 'next_product' => 'Next product', 'forecast' => 'Forecast', 'routing' => 'Routing'])->required(), TextInput::make('score')->numeric(), TextInput::make('label'), Textarea::make('explanation')->json()->required(), Textarea::make('features')->json()]);
     }
 
     public static function table(Table $table): Table
@@ -38,6 +41,6 @@ final class PredictionResource extends Resource
 
     public static function getPages(): array
     {
-        return ['index' => ListPredictions::route('/')];
+        return ['index' => ListPredictions::route('/'), 'create' => CreatePrediction::route('/create'), 'edit' => EditPrediction::route('/{record}/edit')];
     }
 }

--- a/modules/crm-predictive-models-filament/src/Resources/PredictionResource/Pages/CreatePrediction.php
+++ b/modules/crm-predictive-models-filament/src/Resources/PredictionResource/Pages/CreatePrediction.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\CRM\PredictiveModels\Filament\Resources\PredictionResource\Pages;
+
+use Filament\Resources\Pages\CreateRecord;
+use Illuminate\Database\Eloquent\Model;
+use Liberu\CRM\PredictiveModels\Actions\RecordPrediction;
+use Liberu\CRM\PredictiveModels\Filament\Resources\PredictionResource;
+
+final class CreatePrediction extends CreateRecord
+{
+    protected static string $resource = PredictionResource::class;
+
+    protected function handleRecordCreation(array $data): Model
+    {
+        return app(RecordPrediction::class)->execute((int) auth()->user()?->current_team_id, auth()->id(), $data);
+    }
+}

--- a/modules/crm-predictive-models-filament/src/Resources/PredictionResource/Pages/EditPrediction.php
+++ b/modules/crm-predictive-models-filament/src/Resources/PredictionResource/Pages/EditPrediction.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\CRM\PredictiveModels\Filament\Resources\PredictionResource\Pages;
+
+use Filament\Resources\Pages\EditRecord;
+use Illuminate\Database\Eloquent\Model;
+use Liberu\CRM\PredictiveModels\Actions\UpdatePrediction;
+use Liberu\CRM\PredictiveModels\Filament\Resources\PredictionResource;
+use Liberu\CRM\PredictiveModels\Models\Prediction;
+
+final class EditPrediction extends EditRecord
+{
+    protected static string $resource = PredictionResource::class;
+
+    protected function handleRecordUpdate(Model $record, array $data): Model
+    {
+        abort_unless($record instanceof Prediction, 404);
+        $teamId = auth()->user()?->current_team_id;
+        abort_unless($teamId !== null && (int) $record->team_id === (int) $teamId, 403);
+
+        return app(UpdatePrediction::class)->execute((int) $teamId, auth()->id(), $record->id, $data);
+    }
+}

--- a/modules/crm-predictive-models/src/Actions/UpdatePrediction.php
+++ b/modules/crm-predictive-models/src/Actions/UpdatePrediction.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\CRM\PredictiveModels\Actions;
+
+use Illuminate\Support\Facades\Validator;
+use Liberu\CRM\PredictiveModels\Models\Prediction;
+use Liberu\CRM\PredictiveModels\Models\PredictiveModel;
+use Liberu\CRM\PredictiveModels\Services\PredictiveModelPolicy;
+
+final class UpdatePrediction
+{
+    public function __construct(private readonly PredictiveModelPolicy $policy) {}
+
+    public function execute(int $teamId, int $userId, int $predictionId, array $input): Prediction
+    {
+        abort_unless($this->policy->canManage($teamId, $userId), 403);
+        $data = Validator::make($input, [
+            'model_id' => ['required', 'integer'],
+            'subject_type' => ['required', 'string', 'max:255'],
+            'subject_id' => ['required', 'integer'],
+            'kind' => ['required', 'in:scoring,churn,next_action,next_product,forecast,routing'],
+            'score' => ['nullable', 'numeric', 'between:0,1'],
+            'label' => ['nullable', 'string', 'max:255'],
+            'explanation' => ['required', 'array'],
+            'features' => ['nullable', 'array'],
+        ])->validate();
+        PredictiveModel::query()->where('team_id', $teamId)->where('status', 'active')->findOrFail($data['model_id']);
+        $prediction = Prediction::query()->where('team_id', $teamId)->findOrFail($predictionId);
+        $prediction->update($data);
+
+        return $prediction->refresh();
+    }
+}

--- a/modules/crm-predictive-models/src/Models/Prediction.php
+++ b/modules/crm-predictive-models/src/Models/Prediction.php
@@ -6,6 +6,9 @@ namespace Liberu\CRM\PredictiveModels\Models;
 
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @property int $team_id
+ */
 final class Prediction extends Model
 {
     protected $table = 'crm_predictive_predictions';

--- a/tests/Feature/PredictiveModels/PredictiveModelsModuleTest.php
+++ b/tests/Feature/PredictiveModels/PredictiveModelsModuleTest.php
@@ -10,6 +10,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Liberu\CRM\PredictiveModels\Actions\DetectDrift;
 use Liberu\CRM\PredictiveModels\Actions\RecordPrediction;
 use Liberu\CRM\PredictiveModels\Actions\RegisterPredictiveModel;
+use Liberu\CRM\PredictiveModels\Filament\Resources\PredictionResource;
 use Liberu\CRM\PredictiveModels\Models\ModelDrift;
 use Liberu\CRM\PredictiveModels\Models\Prediction;
 use Tests\TestCase;
@@ -17,6 +18,11 @@ use Tests\TestCase;
 final class PredictiveModelsModuleTest extends TestCase
 {
     use RefreshDatabase;
+
+    public function test_prediction_resource_exposes_the_complete_filament_lifecycle(): void
+    {
+        self::assertSame(['index', 'create', 'edit'], array_keys(PredictionResource::getPages()));
+    }
 
     public function test_explained_predictions_and_drift_are_team_scoped(): void
     {


### PR DESCRIPTION
Adds domain-backed prediction editing, Filament create/edit pages, required JSON explanation fields, and decouples the API controller from App classes. Focused tests, Pint, and PHPStan pass.