### PR TITLE
Complete Playbooks and Enablement workflow

### DIFF
--- a/modules/crm-playbooks-and-enablement-api/src/Http/Controllers/PlaybooksAndEnablementController.php
+++ b/modules/crm-playbooks-and-enablement-api/src/Http/Controllers/PlaybooksAndEnablementController.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\PlaybooksAndEnablementApi\Http\Controllers;
 
-use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
 use Liberu\CRM\PlaybooksAndEnablement\Actions\AssignPlaybook;
 use Liberu\CRM\PlaybooksAndEnablement\Actions\CompletePlaybook;
 use Liberu\CRM\PlaybooksAndEnablement\Actions\CreatePlaybook;

--- a/modules/crm-playbooks-and-enablement-filament/src/Resources/PlaybookResource.php
+++ b/modules/crm-playbooks-and-enablement-filament/src/Resources/PlaybookResource.php
@@ -12,6 +12,8 @@ use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
+use Liberu\CRM\PlaybooksAndEnablement\Filament\Resources\PlaybookResource\Pages\CreatePlaybook;
+use Liberu\CRM\PlaybooksAndEnablement\Filament\Resources\PlaybookResource\Pages\EditPlaybook;
 use Liberu\CRM\PlaybooksAndEnablement\Filament\Resources\PlaybookResource\Pages\ListPlaybooks;
 use Liberu\CRM\PlaybooksAndEnablement\Models\Playbook;
 
@@ -21,7 +23,7 @@ final class PlaybookResource extends Resource
 
     public static function form(Schema $schema): Schema
     {
-        return $schema->components([TextInput::make('name')->required(), Select::make('kind')->options(['script' => 'Guided script', 'qualification' => 'Qualification card', 'battlecard' => 'Battlecard', 'onboarding' => 'Onboarding', 'coaching' => 'Coaching'])->required(), Textarea::make('description'), Textarea::make('steps')->required()]);
+        return $schema->components([TextInput::make('name')->required(), Select::make('kind')->options(['script' => 'Guided script', 'qualification' => 'Qualification card', 'battlecard' => 'Battlecard', 'onboarding' => 'Onboarding', 'coaching' => 'Coaching'])->required(), Textarea::make('description'), Textarea::make('steps')->json()->required()]);
     }
 
     public static function table(Table $table): Table
@@ -39,6 +41,6 @@ final class PlaybookResource extends Resource
 
     public static function getPages(): array
     {
-        return ['index' => ListPlaybooks::route('/')];
+        return ['index' => ListPlaybooks::route('/'), 'create' => CreatePlaybook::route('/create'), 'edit' => EditPlaybook::route('/{record}/edit')];
     }
 }

--- a/modules/crm-playbooks-and-enablement-filament/src/Resources/PlaybookResource/Pages/CreatePlaybook.php
+++ b/modules/crm-playbooks-and-enablement-filament/src/Resources/PlaybookResource/Pages/CreatePlaybook.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\CRM\PlaybooksAndEnablement\Filament\Resources\PlaybookResource\Pages;
+
+use Filament\Resources\Pages\CreateRecord;
+use Illuminate\Database\Eloquent\Model;
+use Liberu\CRM\PlaybooksAndEnablement\Actions\CreatePlaybook as CreatePlaybookAction;
+use Liberu\CRM\PlaybooksAndEnablement\Filament\Resources\PlaybookResource;
+
+final class CreatePlaybook extends CreateRecord
+{
+    protected static string $resource = PlaybookResource::class;
+
+    protected function handleRecordCreation(array $data): Model
+    {
+        return app(CreatePlaybookAction::class)->execute((int) auth()->user()?->current_team_id, auth()->id(), $data);
+    }
+}

--- a/modules/crm-playbooks-and-enablement-filament/src/Resources/PlaybookResource/Pages/EditPlaybook.php
+++ b/modules/crm-playbooks-and-enablement-filament/src/Resources/PlaybookResource/Pages/EditPlaybook.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\CRM\PlaybooksAndEnablement\Filament\Resources\PlaybookResource\Pages;
+
+use Filament\Resources\Pages\EditRecord;
+use Illuminate\Database\Eloquent\Model;
+use Liberu\CRM\PlaybooksAndEnablement\Actions\UpdatePlaybook;
+use Liberu\CRM\PlaybooksAndEnablement\Filament\Resources\PlaybookResource;
+use Liberu\CRM\PlaybooksAndEnablement\Models\Playbook;
+
+final class EditPlaybook extends EditRecord
+{
+    protected static string $resource = PlaybookResource::class;
+
+    protected function handleRecordUpdate(Model $record, array $data): Model
+    {
+        abort_unless($record instanceof Playbook, 404);
+        $teamId = auth()->user()?->current_team_id;
+        abort_unless($teamId !== null && (int) $record->team_id === (int) $teamId, 403);
+
+        return app(UpdatePlaybook::class)->execute((int) $teamId, auth()->id(), $record->id, $data);
+    }
+}

--- a/modules/crm-playbooks-and-enablement/src/Actions/UpdatePlaybook.php
+++ b/modules/crm-playbooks-and-enablement/src/Actions/UpdatePlaybook.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\CRM\PlaybooksAndEnablement\Actions;
+
+use Illuminate\Support\Facades\Validator;
+use Liberu\CRM\PlaybooksAndEnablement\Models\Playbook;
+use Liberu\CRM\PlaybooksAndEnablement\Services\PlaybookPolicy;
+
+final class UpdatePlaybook
+{
+    public function __construct(private readonly PlaybookPolicy $policy) {}
+
+    public function execute(int $teamId, int $userId, int $playbookId, array $input): Playbook
+    {
+        abort_unless($this->policy->canManage($teamId, $userId), 403);
+        $data = Validator::make($input, [
+            'name' => ['required', 'string', 'max:255'],
+            'kind' => ['required', 'in:script,qualification,battlecard,onboarding,coaching'],
+            'description' => ['nullable', 'string'],
+            'steps' => ['required', 'array'],
+        ])->validate();
+        $playbook = Playbook::query()->where('team_id', $teamId)->findOrFail($playbookId);
+        $playbook->update($data);
+
+        return $playbook->refresh();
+    }
+}

--- a/modules/crm-playbooks-and-enablement/src/Models/Playbook.php
+++ b/modules/crm-playbooks-and-enablement/src/Models/Playbook.php
@@ -6,6 +6,9 @@ namespace Liberu\CRM\PlaybooksAndEnablement\Models;
 
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @property int $team_id
+ */
 final class Playbook extends Model
 {
     protected $table = 'crm_playbooks';

--- a/tests/Feature/PlaybooksAndEnablement/PlaybooksAndEnablementModuleTest.php
+++ b/tests/Feature/PlaybooksAndEnablement/PlaybooksAndEnablementModuleTest.php
@@ -10,6 +10,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Liberu\CRM\PlaybooksAndEnablement\Actions\AssignPlaybook;
 use Liberu\CRM\PlaybooksAndEnablement\Actions\CompletePlaybook;
 use Liberu\CRM\PlaybooksAndEnablement\Actions\CreatePlaybook;
+use Liberu\CRM\PlaybooksAndEnablement\Filament\Resources\PlaybookResource;
 use Liberu\CRM\PlaybooksAndEnablement\Models\PlaybookAssignment;
 use Liberu\CRM\PlaybooksAndEnablement\Models\PlaybookUsage;
 use Tests\TestCase;
@@ -17,6 +18,11 @@ use Tests\TestCase;
 final class PlaybooksAndEnablementModuleTest extends TestCase
 {
     use RefreshDatabase;
+
+    public function test_playbook_resource_exposes_the_complete_filament_lifecycle(): void
+    {
+        self::assertSame(['index', 'create', 'edit'], array_keys(PlaybookResource::getPages()));
+    }
 
     public function test_assigned_playbook_evidence_completion_is_team_scoped(): void
     {


### PR DESCRIPTION
Adds domain-backed playbook editing, Filament create/edit pages, JSON step handling, and decouples the API controller from App classes. Focused tests, Pint, and PHPStan pass.