### PR TITLE
Complete Work Management queue lifecycle

### DIFF
--- a/modules/crm-work-management-api/src/Http/Controllers/WorkManagementController.php
+++ b/modules/crm-work-management-api/src/Http/Controllers/WorkManagementController.php
@@ -11,6 +11,7 @@ use Liberu\CRM\WorkManagement\Actions\AddChecklistItem;
 use Liberu\CRM\WorkManagement\Actions\AddDependency;
 use Liberu\CRM\WorkManagement\Actions\CompleteWorkItem;
 use Liberu\CRM\WorkManagement\Actions\CreateWorkItem;
+use Liberu\CRM\WorkManagement\Actions\CreateWorkQueue;
 use Liberu\CRM\WorkManagement\Actions\ReviewApproval;
 use Liberu\CRM\WorkManagement\Actions\UpdateWorkItem;
 use Liberu\CRM\WorkManagement\Models\WorkItem;
@@ -98,14 +99,14 @@ final class WorkManagementController extends Controller
         return response()->json(['data' => WorkQueue::query()->where('team_id', $this->teamId($request))->latest()->get()->map(fn (WorkQueue $queue): array => ['id' => (string) $queue->getKey(), 'type' => 'crm-work-queue', 'attributes' => $queue->only(['name', 'description', 'status', 'rules'])])]);
     }
 
-    public function storeQueue(Request $request, IdempotencyStore $idempotency): JsonResponse
+    public function storeQueue(Request $request, CreateWorkQueue $create, IdempotencyStore $idempotency): JsonResponse
     {
         $replay = $this->replayIdempotent($request, $idempotency);
         if ($replay !== null) {
             return $replay;
         }
         $data = $request->validate(['name' => ['required', 'string', 'max:160'], 'description' => ['nullable', 'string', 'max:500'], 'rules' => ['nullable', 'array']]);
-        $queue = WorkQueue::query()->create(array_merge($data, ['team_id' => $this->teamId($request), 'actor_id' => $request->user()->getKey()]));
+        $queue = $create->execute($this->teamId($request), $request->user()->getKey(), $data);
 
         return $this->completeIdempotent($request, $idempotency, response()->json(['data' => ['id' => (string) $queue->getKey(), 'type' => 'crm-work-queue', 'attributes' => $queue->only(['name', 'description', 'status', 'rules'])]], 201));
     }

--- a/modules/crm-work-management-filament/src/Resources/WorkQueueResource.php
+++ b/modules/crm-work-management-filament/src/Resources/WorkQueueResource.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\WorkManagement\Filament\Resources;
 
+use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Resource;
@@ -12,6 +13,7 @@ use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Liberu\CRM\WorkManagement\Filament\Resources\WorkQueueResource\Pages\CreateWorkQueue;
+use Liberu\CRM\WorkManagement\Filament\Resources\WorkQueueResource\Pages\EditWorkQueue;
 use Liberu\CRM\WorkManagement\Filament\Resources\WorkQueueResource\Pages\ListWorkQueues;
 use Liberu\CRM\WorkManagement\Models\WorkQueue;
 
@@ -23,7 +25,7 @@ final class WorkQueueResource extends Resource
 
     public static function form(Schema $schema): Schema
     {
-        return $schema->components([TextInput::make('name')->required()->maxLength(160), Textarea::make('description')->maxLength(500)]);
+        return $schema->components([TextInput::make('name')->required()->maxLength(160), Textarea::make('description')->maxLength(500), Select::make('status')->options(['active' => 'Active', 'paused' => 'Paused', 'archived' => 'Archived'])->required(), Textarea::make('rules')->json()]);
     }
 
     public static function table(Table $table): Table
@@ -41,6 +43,6 @@ final class WorkQueueResource extends Resource
 
     public static function getPages(): array
     {
-        return ['index' => ListWorkQueues::route('/'), 'create' => CreateWorkQueue::route('/create')];
+        return ['index' => ListWorkQueues::route('/'), 'create' => CreateWorkQueue::route('/create'), 'edit' => EditWorkQueue::route('/{record}/edit')];
     }
 }

--- a/modules/crm-work-management-filament/src/Resources/WorkQueueResource/Pages/CreateWorkQueue.php
+++ b/modules/crm-work-management-filament/src/Resources/WorkQueueResource/Pages/CreateWorkQueue.php
@@ -6,8 +6,8 @@ namespace Liberu\CRM\WorkManagement\Filament\Resources\WorkQueueResource\Pages;
 
 use Filament\Resources\Pages\CreateRecord;
 use Illuminate\Database\Eloquent\Model;
+use Liberu\CRM\WorkManagement\Actions\CreateWorkQueue as CreateWorkQueueAction;
 use Liberu\CRM\WorkManagement\Filament\Resources\WorkQueueResource;
-use Liberu\CRM\WorkManagement\Models\WorkQueue;
 
 final class CreateWorkQueue extends CreateRecord
 {
@@ -18,6 +18,6 @@ final class CreateWorkQueue extends CreateRecord
         $teamId = auth()->user()?->current_team_id;
         abort_unless($teamId !== null, 403);
 
-        return WorkQueue::query()->create(array_merge($data, ['team_id' => $teamId, 'actor_id' => auth()->id()]));
+        return app(CreateWorkQueueAction::class)->execute((int) $teamId, auth()->id(), $data);
     }
 }

--- a/modules/crm-work-management-filament/src/Resources/WorkQueueResource/Pages/EditWorkQueue.php
+++ b/modules/crm-work-management-filament/src/Resources/WorkQueueResource/Pages/EditWorkQueue.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\CRM\WorkManagement\Filament\Resources\WorkQueueResource\Pages;
+
+use Filament\Resources\Pages\EditRecord;
+use Illuminate\Database\Eloquent\Model;
+use Liberu\CRM\WorkManagement\Actions\UpdateWorkQueue;
+use Liberu\CRM\WorkManagement\Filament\Resources\WorkQueueResource;
+use Liberu\CRM\WorkManagement\Models\WorkQueue;
+
+final class EditWorkQueue extends EditRecord
+{
+    protected static string $resource = WorkQueueResource::class;
+
+    protected function handleRecordUpdate(Model $record, array $data): Model
+    {
+        abort_unless($record instanceof WorkQueue, 404);
+        $teamId = auth()->user()?->current_team_id;
+        abort_unless($teamId !== null && (int) $record->team_id === (int) $teamId, 403);
+
+        return app(UpdateWorkQueue::class)->execute($record, auth()->id(), $data);
+    }
+}

--- a/modules/crm-work-management/src/Actions/CreateWorkQueue.php
+++ b/modules/crm-work-management/src/Actions/CreateWorkQueue.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\CRM\WorkManagement\Actions;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+use Liberu\CRM\WorkManagement\Models\WorkQueue;
+use Liberu\CRM\WorkManagement\Services\WorkAudit;
+
+final class CreateWorkQueue
+{
+    /** @param array<string, mixed> $attributes */
+    public function execute(int $teamId, ?int $actorId, array $attributes): WorkQueue
+    {
+        $data = Validator::make($attributes, [
+            'name' => ['required', 'string', 'max:160'],
+            'description' => ['nullable', 'string', 'max:500'],
+            'rules' => ['nullable', 'array'],
+        ])->validate();
+
+        return DB::transaction(function () use ($teamId, $actorId, $data): WorkQueue {
+            $queue = WorkQueue::query()->create([...$data, 'team_id' => $teamId, 'actor_id' => $actorId]);
+            app(WorkAudit::class)->record($queue, $actorId, 'work_queue.created', ['status' => $queue->status]);
+
+            return $queue->refresh();
+        });
+    }
+}

--- a/modules/crm-work-management/src/Actions/UpdateWorkQueue.php
+++ b/modules/crm-work-management/src/Actions/UpdateWorkQueue.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liberu\CRM\WorkManagement\Actions;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+use Liberu\CRM\WorkManagement\Models\WorkQueue;
+use Liberu\CRM\WorkManagement\Services\WorkAudit;
+
+final class UpdateWorkQueue
+{
+    /** @param array<string, mixed> $attributes */
+    public function execute(WorkQueue $queue, ?int $actorId, array $attributes): WorkQueue
+    {
+        $data = Validator::make($attributes, [
+            'name' => ['required', 'string', 'max:160'],
+            'description' => ['nullable', 'string', 'max:500'],
+            'status' => ['required', 'in:active,paused,archived'],
+            'rules' => ['nullable', 'array'],
+        ])->validate();
+
+        return DB::transaction(function () use ($queue, $actorId, $data): WorkQueue {
+            $queue->update($data);
+            app(WorkAudit::class)->record($queue, $actorId, 'work_queue.updated', ['fields' => array_keys($data)]);
+
+            return $queue->refresh();
+        });
+    }
+}

--- a/modules/crm-work-management/src/Models/WorkQueue.php
+++ b/modules/crm-work-management/src/Models/WorkQueue.php
@@ -7,7 +7,10 @@ namespace Liberu\CRM\WorkManagement\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
-/** @property int $team_id */
+/**
+ * @property int $team_id
+ * @property string $status
+ */
 final class WorkQueue extends Model
 {
     protected $table = 'crm_work_queues';

--- a/tests/Feature/WorkManagement/WorkManagementModuleTest.php
+++ b/tests/Feature/WorkManagement/WorkManagementModuleTest.php
@@ -10,14 +10,27 @@ use Liberu\CRM\WorkManagement\Actions\AddChecklistItem;
 use Liberu\CRM\WorkManagement\Actions\AddDependency;
 use Liberu\CRM\WorkManagement\Actions\CompleteWorkItem;
 use Liberu\CRM\WorkManagement\Actions\CreateWorkItem;
+use Liberu\CRM\WorkManagement\Actions\CreateWorkQueue;
 use Liberu\CRM\WorkManagement\Actions\ReviewApproval;
 use Liberu\CRM\WorkManagement\Actions\UpdateWorkItem;
+use Liberu\CRM\WorkManagement\Filament\Resources\WorkQueueResource;
 use Liberu\CRM\WorkManagement\Models\WorkItem;
+use Liberu\CRM\WorkManagement\Models\WorkQueue;
 use Tests\TestCase;
 
 final class WorkManagementModuleTest extends TestCase
 {
     use RefreshDatabase;
+
+    public function test_work_queue_has_domain_owned_lifecycle_and_filament_pages(): void
+    {
+        $queue = app(CreateWorkQueue::class)->execute(7, 11, ['name' => 'Review queue', 'rules' => ['priority' => 'high']]);
+        $queue->update(['status' => 'paused']);
+
+        self::assertSame(['index', 'create', 'edit'], array_keys(WorkQueueResource::getPages()));
+        self::assertSame('paused', WorkQueue::query()->findOrFail($queue->id)->status);
+        self::assertSame(1, $queue->getConnection()->table('crm_work_audits')->where('event', 'work_queue.created')->count());
+    }
 
     public function test_work_item_lifecycle_checklist_approval_and_dependency_are_team_scoped(): void
     {


### PR DESCRIPTION
## Summary
- move work queue creation and updates behind domain actions with validation and audit records
- add Filament queue edit support and delegate API queue creation to the domain action
- cover queue lifecycle and resource page exposure

## Verification
- php artisan test (1501 passed, 1 skipped, 3697 assertions)
- targeted Work Management tests
- Laravel Pint
- targeted PHPStan analysis
- git diff --check