### PR TITLE
Harden White Label settings boundaries

### DIFF
--- a/modules/crm-white-label-api/routes/api.php
+++ b/modules/crm-white-label-api/routes/api.php
@@ -3,7 +3,7 @@
 use Illuminate\Support\Facades\Route;
 use Liberu\CRM\WhiteLabel\Api\Http\Controllers\WhiteLabelController;
 
-Route::middleware('auth:sanctum')->prefix('api/v1/crm/white-label')->group(function (): void {
+Route::middleware(['auth:sanctum', 'throttle:api'])->prefix('api/v1/crm/white-label')->group(function (): void {
     Route::get('/', [WhiteLabelController::class, 'show'])->name('crm.white-label.show');
     Route::patch('/', [WhiteLabelController::class, 'update'])->name('crm.white-label.update');
 });

--- a/modules/crm-white-label-api/src/Http/Controllers/WhiteLabelController.php
+++ b/modules/crm-white-label-api/src/Http/Controllers/WhiteLabelController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Liberu\CRM\WhiteLabel\Actions\UpdateWhiteLabelSettings;
 use Liberu\CRM\WhiteLabel\Queries\WhiteLabelSettingsQuery;
+use Liberu\Foundation\ApiAccess\Support\IdempotencyStore;
 
 final class WhiteLabelController extends Controller
 {
@@ -19,13 +20,18 @@ final class WhiteLabelController extends Controller
         return response()->json(['data' => $this->resource($settings)]);
     }
 
-    public function update(Request $request, UpdateWhiteLabelSettings $update, WhiteLabelSettingsQuery $query): JsonResponse
+    public function update(Request $request, UpdateWhiteLabelSettings $update, WhiteLabelSettingsQuery $query, IdempotencyStore $idempotency): JsonResponse
     {
         $data = $request->validate(['brand_name' => ['sometimes', 'nullable', 'string', 'max:255'], 'custom_domain' => ['sometimes', 'nullable', 'string', 'max:255'], 'theme' => ['sometimes', 'string', 'max:100'], 'email_settings' => ['sometimes', 'nullable', 'array'], 'application_settings' => ['sometimes', 'nullable', 'array'], 'client_experience' => ['sometimes', 'nullable', 'array'], 'provider' => ['sometimes', 'string', 'max:100'], 'show_platform_attribution' => ['sometimes', 'boolean']]);
+        $replay = $this->replayIdempotent($request, $idempotency);
+        if ($replay !== null) {
+            return $replay;
+        }
         $current = $query->forTeam($this->teamId($request));
         $updated = $update->execute($this->teamId($request), (int) $request->user()->getKey(), array_merge($current->only(['theme', 'provider', 'show_platform_attribution']), $data), $this->expectedVersion($request));
+        $response = response()->json(['data' => $this->resource($updated)]);
 
-        return response()->json(['data' => $this->resource($updated)]);
+        return $this->completeIdempotent($request, $idempotency, $response);
     }
 
     private function teamId(Request $request): int
@@ -47,6 +53,32 @@ final class WhiteLabelController extends Controller
         abort_unless(ctype_digit($version), 409, 'If-Match must contain a settings version.');
 
         return (int) $version;
+    }
+
+    private function replayIdempotent(Request $request, IdempotencyStore $idempotency): ?JsonResponse
+    {
+        $key = $request->header('Idempotency-Key');
+        if ($key === null) {
+            return null;
+        }
+        abort_unless(strlen($key) <= 128 && trim($key) !== '', 422, 'Idempotency-Key must be a non-empty value of 128 characters or fewer.');
+        $existing = $idempotency->begin((string) $request->user()->getKey(), $key, (string) $request->getContent());
+        if ($existing === null) {
+            return null;
+        }
+        abort_if($existing->response_body === null, 409, 'The idempotent request is still being processed.');
+
+        return response()->json(json_decode($existing->response_body, true, 512, JSON_THROW_ON_ERROR), (int) $existing->response_status);
+    }
+
+    private function completeIdempotent(Request $request, IdempotencyStore $idempotency, JsonResponse $response): JsonResponse
+    {
+        $key = $request->header('Idempotency-Key');
+        if ($key !== null) {
+            $idempotency->complete((string) $request->user()->getKey(), $key, $response->getStatusCode(), (string) $response->getContent());
+        }
+
+        return $response;
     }
 
     /** @return array<string, mixed> */

--- a/modules/crm-white-label/src/Actions/UpdateWhiteLabelSettings.php
+++ b/modules/crm-white-label/src/Actions/UpdateWhiteLabelSettings.php
@@ -20,7 +20,7 @@ final class UpdateWhiteLabelSettings
             throw ValidationException::withMessages(['authorization' => 'You cannot manage white-label settings for this team.']);
         }
 
-        validator($attributes, [
+        $data = validator($attributes, [
             'brand_name' => ['nullable', 'string', 'max:255'],
             'custom_domain' => ['nullable', 'string', 'max:255', 'regex:/^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}$/i'],
             'theme' => ['required', 'string', 'max:100'],
@@ -31,14 +31,14 @@ final class UpdateWhiteLabelSettings
             'show_platform_attribution' => ['required', 'boolean'],
         ])->validate();
 
-        return DB::transaction(function () use ($teamId, $actorId, $attributes, $expectedVersion): WhiteLabelSettings {
+        return DB::transaction(function () use ($teamId, $actorId, $data, $expectedVersion): WhiteLabelSettings {
             $settings = WhiteLabelSettings::query()->lockForUpdate()->firstOrNew(['team_id' => $teamId]);
             if ($expectedVersion !== null && $settings->exists && $settings->version !== $expectedVersion) {
                 throw ValidationException::withMessages(['version' => 'The white-label settings changed since they were loaded.']);
             }
 
             $before = $settings->getOriginal();
-            $settings->fill($attributes);
+            $settings->fill($data);
             $settings->version = $settings->exists ? $settings->version + 1 : 1;
             $settings->save();
             DB::afterCommit(fn (): bool => event(new WhiteLabelSettingsUpdated($settings->fresh(), $actorId)) === null);

--- a/modules/crm-white-label/src/Models/WhiteLabelSettings.php
+++ b/modules/crm-white-label/src/Models/WhiteLabelSettings.php
@@ -12,6 +12,9 @@ use Illuminate\Database\Eloquent\Model;
  * @property string|null $custom_domain
  * @property string $theme
  * @property string $provider
+ * @property array<string, mixed>|null $email_settings
+ * @property array<string, mixed>|null $application_settings
+ * @property array<string, mixed>|null $client_experience
  * @property bool $show_platform_attribution
  * @property int $version
  */

--- a/tests/Feature/WhiteLabel/WhiteLabelModuleTest.php
+++ b/tests/Feature/WhiteLabel/WhiteLabelModuleTest.php
@@ -9,12 +9,18 @@ use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Validation\ValidationException;
 use Liberu\CRM\WhiteLabel\Actions\UpdateWhiteLabelSettings;
+use Liberu\CRM\WhiteLabel\Filament\Resources\WhiteLabelSettingsResource;
 use Liberu\CRM\WhiteLabel\Models\WhiteLabelSettings;
 use Tests\TestCase;
 
 final class WhiteLabelModuleTest extends TestCase
 {
     use RefreshDatabase;
+
+    public function test_white_label_resource_exposes_read_and_edit_surfaces(): void
+    {
+        self::assertSame(['index', 'edit'], array_keys(WhiteLabelSettingsResource::getPages()));
+    }
 
     public function test_owner_can_update_settings_and_audit_is_redacted_and_versioned(): void
     {
@@ -53,5 +59,22 @@ final class WhiteLabelModuleTest extends TestCase
 
         self::assertSame($first->id, WhiteLabelSettings::query()->where('team_id', 101)->firstOrFail()->id);
         self::assertNull(WhiteLabelSettings::query()->where('team_id', 303)->first());
+    }
+
+    public function test_settings_update_cannot_override_tenant_or_version_fields(): void
+    {
+        $owner = User::factory()->create();
+        $team = Team::factory()->create(['user_id' => $owner->id]);
+
+        $settings = app(UpdateWhiteLabelSettings::class)->execute($team->id, $owner->id, [
+            'theme' => 'dark',
+            'provider' => 'platform',
+            'show_platform_attribution' => true,
+            'team_id' => 999,
+            'version' => 99,
+        ]);
+
+        self::assertSame($team->id, $settings->team_id);
+        self::assertSame(1, $settings->version);
     }
 }


### PR DESCRIPTION
## Summary
- add throttling and idempotent PATCH handling to the White Label API
- validate settings updates before persistence to protect tenant and version fields
- cover the Filament surface and settings boundary regression

## Verification
- php artisan test: 1503 passed, 1 skipped, 3704 assertions
- Pint clean
- PHPStan clean for White Label packages
