### PR TITLE
Harden Web Intent mutation boundaries

### DIFF
--- a/modules/crm-web-intent/src/Actions/ConvertIntent.php
+++ b/modules/crm-web-intent/src/Actions/ConvertIntent.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Liberu\CRM\WebIntent\Actions;
 
 use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
 use Liberu\CRM\WebIntent\Models\WebIntentConversion;
+use Liberu\CRM\WebIntent\Models\WebIntentVisit;
 use Liberu\CRM\WebIntent\Services\WebIntentAudit;
 use Liberu\CRM\WebIntent\Services\WebIntentPolicy;
 
@@ -16,6 +18,9 @@ final class ConvertIntent
     {
         abort_unless($policy->canManage($teamId, $actorId), 403, 'You cannot convert web intent for this team.');
         validator(compact('visitorKey', 'targetType', 'targetId'), ['visitorKey' => ['required', 'string', 'max:128'], 'targetType' => ['required', 'string', 'max:100'], 'targetId' => ['required', 'integer', 'min:1']])->validate();
+        if ($visitId !== null && ! WebIntentVisit::query()->where('team_id', $teamId)->whereKey($visitId)->exists()) {
+            throw ValidationException::withMessages(['visitId' => 'The visit does not belong to this team.']);
+        }
 
         return DB::transaction(function () use ($teamId, $actorId, $visitorKey, $targetType, $targetId, $visitId, $metadata): WebIntentConversion {
             $conversion = WebIntentConversion::query()->firstOrCreate(['team_id' => $teamId, 'visitor_key' => $visitorKey, 'target_type' => $targetType, 'target_id' => $targetId], ['visit_id' => $visitId, 'actor_id' => $actorId, 'metadata' => $metadata, 'status' => 'completed']);

--- a/modules/crm-web-intent/src/Actions/CreateAlert.php
+++ b/modules/crm-web-intent/src/Actions/CreateAlert.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Liberu\CRM\WebIntent\Actions;
 
 use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
 use Liberu\CRM\WebIntent\Models\WebIntentAlert;
+use Liberu\CRM\WebIntent\Models\WebIntentVisit;
 use Liberu\CRM\WebIntent\Services\WebIntentAudit;
 use Liberu\CRM\WebIntent\Services\WebIntentPolicy;
 
@@ -14,7 +16,10 @@ final class CreateAlert
     public function execute(int $teamId, int $actorId, string $visitorKey, string $title, string $severity, ?int $visitId, ?string $details, WebIntentPolicy $policy): WebIntentAlert
     {
         abort_unless($policy->canManage($teamId, $actorId), 403, 'You cannot manage web-intent alerts for this team.');
-        validator(compact('title', 'severity'), ['title' => ['required', 'string', 'max:255'], 'severity' => ['required', 'in:low,normal,high,critical']])->validate();
+        validator(compact('visitorKey', 'title', 'severity', 'details'), ['visitorKey' => ['required', 'string', 'max:128'], 'title' => ['required', 'string', 'max:255'], 'severity' => ['required', 'in:low,normal,high,critical'], 'details' => ['nullable', 'string', 'max:65535']])->validate();
+        if ($visitId !== null && ! WebIntentVisit::query()->where('team_id', $teamId)->whereKey($visitId)->exists()) {
+            throw ValidationException::withMessages(['visitId' => 'The visit does not belong to this team.']);
+        }
 
         return DB::transaction(function () use ($teamId, $actorId, $visitorKey, $title, $severity, $visitId, $details): WebIntentAlert {
             $alert = WebIntentAlert::query()->create(['team_id' => $teamId, 'visitor_key' => $visitorKey, 'title' => $title, 'severity' => $severity, 'visit_id' => $visitId, 'details' => $details, 'triggered_at' => now(), 'status' => 'open']);

--- a/modules/crm-web-intent/src/Actions/RecordEngagement.php
+++ b/modules/crm-web-intent/src/Actions/RecordEngagement.php
@@ -20,22 +20,22 @@ final class RecordEngagement
         if (($attributes['team_id'] ?? $visit->team_id) !== $visit->team_id) {
             throw ValidationException::withMessages(['visit' => 'The visit does not belong to this team.']);
         }
-        validator($attributes, ['event_type' => ['required', 'string', 'max:64'], 'page_url' => ['nullable', 'url', 'max:2048'], 'content_type' => ['nullable', 'string', 'max:100'], 'content_id' => ['nullable', 'string', 'max:190'], 'duration_seconds' => ['nullable', 'integer', 'min:0', 'max:86400'], 'dedupe_key' => ['nullable', 'string', 'max:190'], 'metadata' => ['nullable', 'array']])->validate();
-        if (isset($attributes['dedupe_key'])) {
-            $existing = WebIntentEngagement::query()->where('team_id', $visit->team_id)->where('dedupe_key', $attributes['dedupe_key'])->first();
+        $data = validator($attributes, ['event_type' => ['required', 'string', 'max:64'], 'page_url' => ['nullable', 'url', 'max:2048'], 'content_type' => ['nullable', 'string', 'max:100'], 'content_id' => ['nullable', 'string', 'max:190'], 'duration_seconds' => ['nullable', 'integer', 'min:0', 'max:86400'], 'dedupe_key' => ['nullable', 'string', 'max:190'], 'metadata' => ['nullable', 'array']])->validate();
+        if (isset($data['dedupe_key'])) {
+            $existing = WebIntentEngagement::query()->where('team_id', $visit->team_id)->where('dedupe_key', $data['dedupe_key'])->first();
             if ($existing instanceof WebIntentEngagement) {
                 return $existing;
             }
         }
 
-        return DB::transaction(function () use ($visit, $attributes, $scorer): WebIntentEngagement {
-            $points = $scorer->points((string) $attributes['event_type'], isset($attributes['duration_seconds']) ? (int) $attributes['duration_seconds'] : null);
-            $engagement = WebIntentEngagement::query()->create(array_merge($attributes, ['team_id' => $visit->team_id, 'visit_id' => $visit->getKey(), 'visitor_key' => $visit->visitor_key, 'points' => $points, 'occurred_at' => $attributes['occurred_at'] ?? now()]));
+        return DB::transaction(function () use ($visit, $data, $scorer): WebIntentEngagement {
+            $points = $scorer->points((string) $data['event_type'], isset($data['duration_seconds']) ? (int) $data['duration_seconds'] : null);
+            $engagement = WebIntentEngagement::query()->create(array_merge($data, ['team_id' => $visit->team_id, 'visit_id' => $visit->getKey(), 'visitor_key' => $visit->visitor_key, 'points' => $points, 'occurred_at' => now()]));
             $lockedVisit = WebIntentVisit::query()->whereKey($visit->getKey())->lockForUpdate()->firstOrFail();
             $lockedVisit->score = min(100, $lockedVisit->score + $points);
             $lockedVisit->intent_level = $scorer->level($lockedVisit->score);
             $lockedVisit->save();
-            WebIntentSignal::query()->create(['team_id' => $lockedVisit->team_id, 'visit_id' => $lockedVisit->getKey(), 'visitor_key' => $lockedVisit->visitor_key, 'signal' => (string) $attributes['event_type'], 'points' => $points, 'metadata' => $attributes['metadata'] ?? null, 'occurred_at' => $attributes['occurred_at'] ?? now()]);
+            WebIntentSignal::query()->create(['team_id' => $lockedVisit->team_id, 'visit_id' => $lockedVisit->getKey(), 'visitor_key' => $lockedVisit->visitor_key, 'signal' => (string) $data['event_type'], 'points' => $points, 'metadata' => $data['metadata'] ?? null, 'occurred_at' => now()]);
 
             DB::afterCommit(fn (): bool => event(new EngagementRecorded($engagement->fresh())) === null);
 

--- a/modules/crm-web-intent/src/Actions/RecordVisit.php
+++ b/modules/crm-web-intent/src/Actions/RecordVisit.php
@@ -15,13 +15,14 @@ final class RecordVisit
     /** @param array<string, mixed> $attributes */
     public function execute(int $teamId, string $visitorKey, array $attributes = []): WebIntentVisit
     {
-        validator(['visitor_key' => $visitorKey, ...$attributes], ['visitor_key' => ['required', 'string', 'max:128'], 'session_key' => ['nullable', 'string', 'max:128'], 'landing_url' => ['nullable', 'url', 'max:2048'], 'referrer' => ['nullable', 'url', 'max:2048'], 'consent_status' => ['nullable', 'in:unknown,granted,denied,withdrawn'], 'metadata' => ['nullable', 'array']])->validate();
-        if (($attributes['consent_status'] ?? 'unknown') === 'denied') {
+        $data = validator(['visitor_key' => $visitorKey, ...$attributes], ['visitor_key' => ['required', 'string', 'max:128'], 'session_key' => ['nullable', 'string', 'max:128'], 'landing_url' => ['nullable', 'url', 'max:2048'], 'referrer' => ['nullable', 'url', 'max:2048'], 'consent_status' => ['nullable', 'in:unknown,granted,denied,withdrawn'], 'metadata' => ['nullable', 'array']])->validate();
+        unset($data['visitor_key']);
+        if (($data['consent_status'] ?? 'unknown') === 'denied') {
             throw ValidationException::withMessages(['consent_status' => 'A denied visitor cannot be tracked.']);
         }
 
-        return DB::transaction(function () use ($teamId, $visitorKey, $attributes): WebIntentVisit {
-            $visit = WebIntentVisit::query()->create(array_merge($attributes, ['team_id' => $teamId, 'visitor_key' => $visitorKey, 'started_at' => $attributes['started_at'] ?? now(), 'intent_level' => 'unknown', 'status' => 'active']));
+        return DB::transaction(function () use ($teamId, $visitorKey, $data): WebIntentVisit {
+            $visit = WebIntentVisit::query()->create(array_merge($data, ['team_id' => $teamId, 'visitor_key' => $visitorKey, 'started_at' => now(), 'intent_level' => 'unknown', 'status' => 'active']));
             DB::afterCommit(fn (): bool => event(new VisitRecorded($visit->fresh())) === null);
             app(WebIntentAudit::class)->record($teamId, null, 'visit_recorded', ['visitor_key' => $visitorKey]);
 

--- a/tests/Feature/WebIntent/WebIntentModuleTest.php
+++ b/tests/Feature/WebIntent/WebIntentModuleTest.php
@@ -70,4 +70,29 @@ final class WebIntentModuleTest extends TestCase
         self::assertSame($first->id, $second->id);
         self::assertSame('resolved', $alert->fresh()->status);
     }
+
+    public function test_mutations_reject_foreign_visits_and_ignore_control_fields(): void
+    {
+        $visit = app(RecordVisit::class)->execute(7, 'visitor-a', ['consent_status' => 'granted', 'team_id' => 99, 'status' => 'ended']);
+        $foreignVisit = app(RecordVisit::class)->execute(8, 'visitor-b', ['consent_status' => 'granted']);
+        $owner = User::factory()->create();
+        $team = Team::factory()->create(['user_id' => $owner->id]);
+        $policy = app(WebIntentPolicy::class);
+
+        self::assertSame(7, $visit->team_id);
+        self::assertSame('active', $visit->status);
+
+        $this->expectException(ValidationException::class);
+        app(CreateAlert::class)->execute($team->id, $owner->id, 'visitor-b', 'Foreign visit', 'high', $foreignVisit->id, null, $policy);
+    }
+
+    public function test_conversion_rejects_a_foreign_visit(): void
+    {
+        $owner = User::factory()->create();
+        $team = Team::factory()->create(['user_id' => $owner->id]);
+        $foreignVisit = app(RecordVisit::class)->execute(8, 'visitor-b', ['consent_status' => 'granted']);
+
+        $this->expectException(ValidationException::class);
+        app(ConvertIntent::class)->execute($team->id, $owner->id, 'visitor-b', 'lead', 42, $foreignVisit->id, [], app(WebIntentPolicy::class));
+    }
 }


### PR DESCRIPTION
## Summary
- use validated data for Web Intent visit and engagement persistence
- reject alerts and conversions that reference another team's visit
- add regression coverage for control-field injection and cross-team references

## Verification
- php artisan test: 1505 passed, 1 skipped, 3708 assertions
- Pint clean
- PHPStan clean for the Web Intent domain package
