### PR TITLE
Harden Usage Wallet mutation boundaries

### DIFF
--- a/modules/crm-usage-wallet-and-rebilling-api/routes/api.php
+++ b/modules/crm-usage-wallet-and-rebilling-api/routes/api.php
@@ -3,7 +3,7 @@
 use Illuminate\Support\Facades\Route;
 use Liberu\CRM\UsageWalletAndRebillingApi\Http\Controllers\UsageWalletController;
 
-Route::middleware('auth:sanctum')->prefix('api/v1/crm/usage-wallet-and-rebilling')->group(function () {
+Route::middleware(['auth:sanctum', 'throttle:api'])->prefix('api/v1/crm/usage-wallet-and-rebilling')->group(function () {
     Route::get('/summary', [UsageWalletController::class, 'summary']);
     Route::get('/imports', [UsageWalletController::class, 'imports']);
     Route::post('/imports', [UsageWalletController::class, 'import']);

--- a/modules/crm-usage-wallet-and-rebilling-api/src/Http/Controllers/UsageWalletController.php
+++ b/modules/crm-usage-wallet-and-rebilling-api/src/Http/Controllers/UsageWalletController.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\UsageWalletAndRebillingApi\Http\Controllers;
 
-use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
 use Liberu\CRM\UsageWalletAndRebilling\Actions\CreateCharge;
 use Liberu\CRM\UsageWalletAndRebilling\Actions\ImportProviderUsage;
 use Liberu\CRM\UsageWalletAndRebilling\Actions\UpsertWallet;
@@ -20,32 +21,32 @@ final class UsageWalletController extends Controller
         return (int) $r->user()->current_team_id;
     }
 
-    public function summary(Request $r, UsageWalletQuery $q)
+    public function summary(Request $r, UsageWalletQuery $q): JsonResponse
     {
         return response()->json(['data' => $q->summary($this->team($r))]);
     }
 
-    public function imports(Request $r, UsageWalletQuery $q)
+    public function imports(Request $r, UsageWalletQuery $q): JsonResponse
     {
         return response()->json($q->imports($this->team($r)));
     }
 
-    public function charges(Request $r, UsageWalletQuery $q)
+    public function charges(Request $r, UsageWalletQuery $q): JsonResponse
     {
         return response()->json($q->charges($this->team($r)));
     }
 
-    public function import(Request $r, ImportProviderUsage $a)
+    public function import(Request $r, ImportProviderUsage $a): JsonResponse
     {
         return response()->json(['data' => $a->execute($this->team($r), (int) $r->user()->id, $r->all())], 201);
     }
 
-    public function charge(Request $r, CreateCharge $a)
+    public function charge(Request $r, CreateCharge $a): JsonResponse
     {
         return response()->json(['data' => $a->execute($this->team($r), (int) $r->user()->id, $r->all())], 201);
     }
 
-    public function wallet(Request $r, UpsertWallet $a)
+    public function wallet(Request $r, UpsertWallet $a): JsonResponse
     {
         return response()->json(['data' => $a->execute($this->team($r), (int) $r->user()->id, $r->all())]);
     }

--- a/modules/crm-usage-wallet-and-rebilling/src/Actions/CreateCharge.php
+++ b/modules/crm-usage-wallet-and-rebilling/src/Actions/CreateCharge.php
@@ -18,7 +18,8 @@ final class CreateCharge
     {
         if (! app(UsagePolicy::class)->canManage($teamId, $actorId)) {
             throw ValidationException::withMessages(['authorization' => 'Not authorized.']);
-        } validator($data, ['usage_import_id' => ['required', 'integer'], 'markup_percent' => ['required', 'numeric', 'min:0', 'max:1000'], 'client_reference' => ['nullable', 'string', 'max:255']])->validate();
+        }
+        $data = validator($data, ['usage_import_id' => ['required', 'integer'], 'markup_percent' => ['required', 'numeric', 'min:0', 'max:1000'], 'client_reference' => ['nullable', 'string', 'max:255']])->validate();
 
         return DB::transaction(function () use ($teamId, $actorId, $data) {
             $import = UsageImport::query()->where('team_id', $teamId)->findOrFail($data['usage_import_id']);

--- a/modules/crm-usage-wallet-and-rebilling/src/Actions/ImportProviderUsage.php
+++ b/modules/crm-usage-wallet-and-rebilling/src/Actions/ImportProviderUsage.php
@@ -16,7 +16,8 @@ final class ImportProviderUsage
     {
         if (! app(UsagePolicy::class)->canManage($teamId, $actorId)) {
             throw ValidationException::withMessages(['authorization' => 'Not authorized.']);
-        } validator($data, ['provider' => ['required', 'string', 'max:100'], 'external_id' => ['required', 'string', 'max:255'], 'amount' => ['required', 'numeric', 'min:0'], 'currency' => ['required', 'regex:/^[A-Z]{3}$/'], 'payload' => ['nullable', 'array']])->validate();
+        }
+        $data = validator($data, ['provider' => ['required', 'string', 'max:100'], 'external_id' => ['required', 'string', 'max:255'], 'amount' => ['required', 'numeric', 'min:0'], 'currency' => ['required', 'regex:/^[A-Z]{3}$/'], 'payload' => ['nullable', 'array']])->validate();
 
         return DB::transaction(function () use ($teamId, $actorId, $data) {
             $import = UsageImport::query()->firstOrCreate(['team_id' => $teamId, 'provider' => $data['provider'], 'external_id' => $data['external_id']], array_merge($data, ['status' => 'imported']));

--- a/modules/crm-usage-wallet-and-rebilling/src/Actions/UpsertWallet.php
+++ b/modules/crm-usage-wallet-and-rebilling/src/Actions/UpsertWallet.php
@@ -16,7 +16,8 @@ final class UpsertWallet
     {
         if (! app(UsagePolicy::class)->canManage($teamId, $actorId)) {
             throw ValidationException::withMessages(['authorization' => 'Not authorized.']);
-        } validator($data, ['currency' => ['required', 'regex:/^[A-Z]{3}$/'], 'threshold' => ['required', 'numeric', 'min:0'], 'reload_amount' => ['required', 'numeric', 'min:0']])->validate();
+        }
+        $data = validator($data, ['currency' => ['required', 'regex:/^[A-Z]{3}$/'], 'threshold' => ['required', 'numeric', 'min:0'], 'reload_amount' => ['required', 'numeric', 'min:0']])->validate();
 
         return DB::transaction(function () use ($teamId, $actorId, $data) {
             $wallet = UsageWallet::query()->lockForUpdate()->firstOrNew(['team_id' => $teamId]);

--- a/tests/Feature/UsageWallet/UsageWalletModuleTest.php
+++ b/tests/Feature/UsageWallet/UsageWalletModuleTest.php
@@ -34,4 +34,17 @@ final class UsageWalletModuleTest extends TestCase
         self::assertSame(0, UsageImport::query()->where('team_id', $other->id)->count());
         self::assertSame(1, UsageCharge::query()->where('team_id', $team->id)->count());
     }
+
+    public function test_wallet_mutations_ignore_unvalidated_control_fields(): void
+    {
+        $owner = User::factory()->create();
+        $team = Team::factory()->create(['user_id' => $owner->id]);
+        $wallet = app(UpsertWallet::class)->execute($team->id, $owner->id, ['currency' => 'USD', 'threshold' => 10, 'reload_amount' => 50, 'team_id' => 999, 'balance' => 900]);
+
+        self::assertSame($team->id, $wallet->team_id);
+        self::assertSame(0.0, (float) $wallet->balance);
+
+        $import = app(ImportProviderUsage::class)->execute($team->id, $owner->id, ['provider' => 'provider', 'external_id' => 'usage-control', 'amount' => 10, 'currency' => 'USD', 'status' => 'failed']);
+        self::assertSame('imported', $import->status);
+    }
 }


### PR DESCRIPTION
## Summary
- persist only validated usage import, wallet, and charge fields
- remove application-controller coupling from the Usage Wallet API package
- add API throttling and regression coverage for control-field injection

## Verification
- php artisan test: 1506 passed, 1 skipped, 3707 assertions
- Pint clean
- PHPStan clean for Usage Wallet domain and API packages
