### PR TITLE
Harden Unified Conversations boundaries

### DIFF
--- a/modules/crm-unified-conversations-api/routes/api.php
+++ b/modules/crm-unified-conversations-api/routes/api.php
@@ -3,7 +3,7 @@
 use Illuminate\Support\Facades\Route;
 use Liberu\CRM\UnifiedConversationsApi\Http\Controllers\ConversationController;
 
-Route::middleware('auth:sanctum')->prefix('api/v1/crm/unified-conversations')->group(function () {
+Route::middleware(['auth:sanctum', 'throttle:api'])->prefix('api/v1/crm/unified-conversations')->group(function () {
     Route::get('/', [ConversationController::class, 'index']);
     Route::post('/', [ConversationController::class, 'store']);
     Route::post('/{conversation}/messages', [ConversationController::class, 'message']);

--- a/modules/crm-unified-conversations-api/src/Http/Controllers/ConversationController.php
+++ b/modules/crm-unified-conversations-api/src/Http/Controllers/ConversationController.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\UnifiedConversationsApi\Http\Controllers;
 
-use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
 use Liberu\CRM\UnifiedConversations\Actions\OpenConversation;
 use Liberu\CRM\UnifiedConversations\Actions\SendMessage;
 use Liberu\CRM\UnifiedConversations\Queries\ConversationQuery;
@@ -19,18 +20,22 @@ final class ConversationController extends Controller
         return (int) $r->user()->current_team_id;
     }
 
-    public function index(Request $r, ConversationQuery $q)
+    public function index(Request $r, ConversationQuery $q): JsonResponse
     {
         return response()->json($q->list($this->team($r)));
     }
 
-    public function store(Request $r, OpenConversation $a)
+    public function store(Request $r, OpenConversation $a): JsonResponse
     {
-        return response()->json(['data' => $a->execute($this->team($r), (int) $r->user()->id, $r->all())], 201);
+        $data = $r->validate(['channel' => ['required', 'string', 'max:50'], 'external_id' => ['nullable', 'string', 'max:255'], 'subject' => ['nullable', 'string', 'max:255']]);
+
+        return response()->json(['data' => $a->execute($this->team($r), (int) $r->user()->id, $data)], 201);
     }
 
-    public function message(Request $r, int $conversation, SendMessage $a)
+    public function message(Request $r, int $conversation, SendMessage $a): JsonResponse
     {
-        return response()->json(['data' => $a->execute($this->team($r), (int) $r->user()->id, $conversation, $r->all())], 201);
+        $data = $r->validate(['body' => ['required', 'string', 'max:10000'], 'internal' => ['boolean'], 'idempotency_key' => ['nullable', 'string', 'max:255']]);
+
+        return response()->json(['data' => $a->execute($this->team($r), (int) $r->user()->id, $conversation, $data)], 201);
     }
 }

--- a/modules/crm-unified-conversations/src/Actions/AssignConversation.php
+++ b/modules/crm-unified-conversations/src/Actions/AssignConversation.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\UnifiedConversations\Actions;
 
+use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
 use Liberu\CRM\UnifiedConversations\Models\Conversation;
 use Liberu\CRM\UnifiedConversations\Services\ConversationPolicy;
@@ -14,7 +15,11 @@ final class AssignConversation
     {
         if (! app(ConversationPolicy::class)->canManage($teamId, $actorId)) {
             throw ValidationException::withMessages(['authorization' => 'Not authorized.']);
-        }$c = Conversation::query()->where('team_id', $teamId)->findOrFail($conversationId);
+        }
+        if ($assignee !== null && ! DB::table('team_user')->where('team_id', $teamId)->where('user_id', $assignee)->exists() && (int) DB::table('teams')->where('id', $teamId)->value('user_id') !== $assignee) {
+            throw ValidationException::withMessages(['assignee' => 'The assignee is not a member of this team.']);
+        }
+        $c = Conversation::query()->where('team_id', $teamId)->findOrFail($conversationId);
         $c->setAttribute('assigned_to', $assignee);
         $c->save();
 

--- a/modules/crm-unified-conversations/src/Actions/OpenConversation.php
+++ b/modules/crm-unified-conversations/src/Actions/OpenConversation.php
@@ -16,7 +16,8 @@ final class OpenConversation
     {
         if (! app(ConversationPolicy::class)->canManage($teamId, $actorId)) {
             throw ValidationException::withMessages(['authorization' => 'Not authorized.']);
-        }validator($data, ['channel' => ['required', 'string', 'max:50'], 'external_id' => ['nullable', 'string', 'max:255'], 'subject' => ['nullable', 'string', 'max:255']])->validate();
+        }
+        $data = validator($data, ['channel' => ['required', 'string', 'max:50'], 'external_id' => ['nullable', 'string', 'max:255'], 'subject' => ['nullable', 'string', 'max:255']])->validate();
 
         return DB::transaction(function () use ($teamId, $actorId, $data) {
             $c = Conversation::query()->firstOrCreate(['team_id' => $teamId, 'channel' => $data['channel'], 'external_id' => $data['external_id'] ?? null], ['subject' => $data['subject'] ?? null, 'status' => 'open']);

--- a/modules/crm-unified-conversations/src/Actions/SendMessage.php
+++ b/modules/crm-unified-conversations/src/Actions/SendMessage.php
@@ -15,7 +15,8 @@ final class SendMessage
     {
         if (! app(ConversationPolicy::class)->canManage($teamId, $actorId)) {
             throw ValidationException::withMessages(['authorization' => 'Not authorized.']);
-        }validator($data, ['body' => ['required', 'string', 'max:10000'], 'internal' => ['boolean'], 'idempotency_key' => ['nullable', 'string', 'max:255']])->validate();
+        }
+        $data = validator($data, ['body' => ['required', 'string', 'max:10000'], 'internal' => ['boolean'], 'idempotency_key' => ['nullable', 'string', 'max:255']])->validate();
         Conversation::query()->where('team_id', $teamId)->findOrFail($conversationId);
 
         return ConversationMessage::query()->firstOrCreate(['team_id' => $teamId, 'conversation_id' => $conversationId, 'idempotency_key' => $data['idempotency_key'] ?? null], ['sender_id' => $actorId, 'body' => $data['body'], 'internal' => $data['internal'] ?? false, 'delivery_status' => 'sent']);

--- a/modules/crm-unified-conversations/src/Services/ConversationPolicy.php
+++ b/modules/crm-unified-conversations/src/Services/ConversationPolicy.php
@@ -4,14 +4,13 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\UnifiedConversations\Services;
 
-use App\Models\Team;
+use Illuminate\Support\Facades\DB;
 
 final class ConversationPolicy
 {
     public function canManage(int $teamId, int $userId): bool
     {
-        $team = Team::query()->find($teamId);
-
-        return $team !== null && ((int) $team->user_id === $userId || $team->users()->whereKey($userId)->wherePivotIn('role', ['admin', 'manager', 'sales rep'])->exists());
+        return (int) DB::table('teams')->where('id', $teamId)->value('user_id') === $userId
+            || DB::table('team_user')->where('team_id', $teamId)->where('user_id', $userId)->whereIn('role', ['owner', 'admin', 'manager', 'sales rep'])->exists();
     }
 }

--- a/tests/Feature/UsageWallet/UnifiedConversationsModuleTest.php
+++ b/tests/Feature/UsageWallet/UnifiedConversationsModuleTest.php
@@ -7,6 +7,8 @@ namespace Tests\Feature\UsageWallet;
 use App\Models\Team;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Validation\ValidationException;
+use Liberu\CRM\UnifiedConversations\Actions\AssignConversation;
 use Liberu\CRM\UnifiedConversations\Actions\OpenConversation;
 use Liberu\CRM\UnifiedConversations\Actions\SendMessage;
 use Liberu\CRM\UnifiedConversations\Models\Conversation;
@@ -30,5 +32,19 @@ final class UnifiedConversationsModuleTest extends TestCase
         self::assertSame(1, Conversation::query()->where('team_id', $team->id)->count());
         self::assertSame(1, ConversationMessage::query()->where('team_id', $team->id)->count());
         self::assertSame(0, Conversation::query()->where('team_id', $other->id)->count());
+    }
+
+    public function test_conversation_mutations_strip_control_fields_and_reject_foreign_assignees(): void
+    {
+        $owner = User::factory()->create();
+        $team = Team::factory()->create(['user_id' => $owner->id]);
+        $conversation = app(OpenConversation::class)->execute($team->id, $owner->id, ['channel' => 'chat', 'team_id' => 999, 'status' => 'closed']);
+
+        self::assertSame($team->id, $conversation->team_id);
+        self::assertSame('open', $conversation->status);
+
+        $other = User::factory()->create();
+        $this->expectException(ValidationException::class);
+        app(AssignConversation::class)->execute($team->id, $owner->id, $conversation->id, $other->id);
     }
 }


### PR DESCRIPTION
## Summary
- decouple conversation authorization from the application Team model
- validate and persist only approved conversation mutation fields
- enforce team membership for assignees and harden the API controller/routes

## Verification
- php artisan test: 1,507 passed, 1 skipped (3,710 assertions)
- Pint: clean
- PHPStan: clean for Unified Conversations domain/API sources