### PR TITLE
Harden Telephony module boundaries

### DIFF
--- a/modules/crm-telephony-api/routes/api.php
+++ b/modules/crm-telephony-api/routes/api.php
@@ -3,7 +3,7 @@
 use Illuminate\Support\Facades\Route;
 use Liberu\CRM\TelephonyApi\Http\Controllers\TelephonyController;
 
-Route::middleware('auth:sanctum')->prefix('api/v1/crm/telephony')->group(function (): void {
+Route::middleware(['auth:sanctum', 'throttle:api'])->prefix('api/v1/crm/telephony')->group(function (): void {
     Route::get('/numbers', [TelephonyController::class, 'numbers']);
     Route::post('/numbers', [TelephonyController::class, 'number']);
     Route::get('/queues', [TelephonyController::class, 'queues']);

--- a/modules/crm-telephony-api/src/Http/Controllers/TelephonyController.php
+++ b/modules/crm-telephony-api/src/Http/Controllers/TelephonyController.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\TelephonyApi\Http\Controllers;
 
-use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
 use Liberu\CRM\Telephony\Actions\ConfigureTelephony;
 use Liberu\CRM\Telephony\Actions\CreateTelephonyQueue;
 use Liberu\CRM\Telephony\Actions\LogTelephonyCall;
@@ -22,48 +23,50 @@ final class TelephonyController extends Controller
         return (int) $request->user()->current_team_id;
     }
 
-    public function numbers(Request $r, TelephonyQuery $q)
+    public function numbers(Request $r, TelephonyQuery $q): JsonResponse
     {
         return response()->json(['data' => $q->numbers($this->team($r))->get()]);
     }
 
-    public function queues(Request $r, TelephonyQuery $q)
+    public function queues(Request $r, TelephonyQuery $q): JsonResponse
     {
         return response()->json(['data' => $q->queues($this->team($r))->get()]);
     }
 
-    public function settings(Request $r, TelephonyQuery $q)
+    public function settings(Request $r, TelephonyQuery $q): JsonResponse
     {
         return response()->json(['data' => $q->settings($this->team($r))]);
     }
 
-    public function configure(Request $r, ConfigureTelephony $a)
+    public function configure(Request $r, ConfigureTelephony $a): JsonResponse
     {
-        return response()->json(['data' => $a->execute($this->team($r), (int) $r->user()->id, $r->all())]);
+        return response()->json(['data' => $a->execute($this->team($r), (int) $r->user()->getAuthIdentifier(), $r->validate(['provider' => ['required', 'string', 'max:50'], 'business_hours' => ['nullable', 'array'], 'ivr' => ['nullable', 'array'], 'skills' => ['nullable', 'array']]))]);
     }
 
-    public function number(Request $r, UpsertTelephonyNumber $a)
+    public function number(Request $r, UpsertTelephonyNumber $a): JsonResponse
     {
-        return response()->json(['data' => $a->execute($this->team($r), (int) $r->user()->id, $r->all())], 201);
+        return response()->json(['data' => $a->execute($this->team($r), (int) $r->user()->getAuthIdentifier(), $r->validate(['number' => ['required', 'string', 'max:32'], 'label' => ['nullable', 'string', 'max:255'], 'provider' => ['required', 'string', 'max:50'], 'status' => ['sometimes', 'in:active,inactive'], 'caller_id_enabled' => ['sometimes', 'boolean'], 'metadata' => ['nullable', 'array']]))], 201);
     }
 
-    public function queue(Request $r, CreateTelephonyQueue $a)
+    public function queue(Request $r, CreateTelephonyQueue $a): JsonResponse
     {
-        return response()->json(['data' => $a->execute($this->team($r), (int) $r->user()->id, $r->all())], 201);
+        return response()->json(['data' => $a->execute($this->team($r), (int) $r->user()->getAuthIdentifier(), $r->validate(['name' => ['required', 'string', 'max:255'], 'strategy' => ['sometimes', 'in:ring_all,round_robin,least_calls'], 'max_wait_seconds' => ['sometimes', 'integer', 'min:1'], 'members' => ['nullable', 'array'], 'members.*' => ['integer', 'distinct']]))], 201);
     }
 
-    public function calls(Request $r, TelephonyQuery $q)
+    public function calls(Request $r, TelephonyQuery $q): JsonResponse
     {
-        return response()->json(['data' => $q->calls($this->team($r))->paginate((int) $r->integer('per_page', 25))]);
+        $perPage = min(100, max(1, $r->integer('per_page', 25)));
+
+        return response()->json(['data' => $q->calls($this->team($r))->paginate($perPage)]);
     }
 
-    public function logCall(Request $r, LogTelephonyCall $a)
+    public function logCall(Request $r, LogTelephonyCall $a): JsonResponse
     {
-        return response()->json(['data' => $a->execute($this->team($r), (int) $r->user()->id, $r->all())], 201);
+        return response()->json(['data' => $a->execute($this->team($r), (int) $r->user()->getAuthIdentifier(), $r->validate(['from_number' => ['required', 'string', 'max:32'], 'to_number' => ['required', 'string', 'max:32'], 'direction' => ['sometimes', 'in:inbound,outbound'], 'status' => ['sometimes', 'string', 'max:50'], 'number_id' => ['nullable', 'integer', 'min:1'], 'contact_id' => ['nullable', 'integer', 'min:1'], 'started_at' => ['nullable', 'date'], 'ended_at' => ['nullable', 'date', 'after_or_equal:started_at'], 'metadata' => ['nullable', 'array'], 'idempotency_key' => ['required', 'string', 'max:255']]))], 201);
     }
 
-    public function updateCall(Request $r, int $call, UpdateCall $a)
+    public function updateCall(Request $r, int $call, UpdateCall $a): JsonResponse
     {
-        return response()->json(['data' => $a->execute($this->team($r), (int) $r->user()->id, $call, $r->all())]);
+        return response()->json(['data' => $a->execute($this->team($r), (int) $r->user()->getAuthIdentifier(), $call, $r->validate(['disposition' => ['nullable', 'string', 'max:100'], 'recording_url' => ['nullable', 'url', 'max:2048'], 'voicemail_url' => ['nullable', 'url', 'max:2048'], 'transfer_to' => ['nullable', 'string', 'max:32']]))]);
     }
 }

--- a/modules/crm-telephony-filament/src/TelephonyFilamentServiceProvider.php
+++ b/modules/crm-telephony-filament/src/TelephonyFilamentServiceProvider.php
@@ -6,4 +6,10 @@ namespace Liberu\CRM\Telephony\Filament;
 
 use Illuminate\Support\ServiceProvider;
 
-final class TelephonyFilamentServiceProvider extends ServiceProvider {}
+final class TelephonyFilamentServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->app->singleton(TelephonyFilamentPlugin::class);
+    }
+}

--- a/modules/crm-telephony/src/Actions/ConfigureTelephony.php
+++ b/modules/crm-telephony/src/Actions/ConfigureTelephony.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Telephony\Actions;
 
+use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
 use Liberu\CRM\Telephony\Models\TelephonySettings;
 use Liberu\CRM\Telephony\Services\TelephonyAudit;
@@ -15,13 +16,18 @@ final class ConfigureTelephony
     {
         if (! app(TelephonyPolicy::class)->canManage($teamId, $actorId)) {
             throw ValidationException::withMessages(['authorization' => 'Not authorized.']);
-        } validator($data, ['provider' => ['required', 'string', 'max:50'], 'business_hours' => ['nullable', 'array'], 'ivr' => ['nullable', 'array'], 'skills' => ['nullable', 'array']])->validate();
-        $settings = TelephonySettings::query()->where('team_id', $teamId)->lockForUpdate()->first();
-        $settings ??= new TelephonySettings(['team_id' => $teamId, 'version' => 0]);
-        $settings->fill(['provider' => $data['provider'], 'business_hours' => $data['business_hours'] ?? [], 'ivr' => $data['ivr'] ?? [], 'skills' => $data['skills'] ?? [], 'version' => ((int) $settings->version) + 1]);
-        $settings->save();
-        app(TelephonyAudit::class)->record($teamId, $actorId, 'telephony_configured', ['version' => $settings->version]);
+        }
 
-        return $settings;
+        $data = validator($data, ['provider' => ['required', 'string', 'max:50'], 'business_hours' => ['nullable', 'array'], 'ivr' => ['nullable', 'array'], 'skills' => ['nullable', 'array']])->validate();
+
+        return DB::transaction(function () use ($teamId, $actorId, $data): TelephonySettings {
+            $settings = TelephonySettings::query()->where('team_id', $teamId)->lockForUpdate()->first();
+            $settings ??= new TelephonySettings(['team_id' => $teamId, 'version' => 0]);
+            $settings->fill(['provider' => $data['provider'], 'business_hours' => $data['business_hours'] ?? [], 'ivr' => $data['ivr'] ?? [], 'skills' => $data['skills'] ?? [], 'version' => ((int) $settings->version) + 1]);
+            $settings->save();
+            app(TelephonyAudit::class)->record($teamId, $actorId, 'telephony_configured', ['version' => $settings->version]);
+
+            return $settings;
+        });
     }
 }

--- a/modules/crm-telephony/src/Actions/CreateTelephonyQueue.php
+++ b/modules/crm-telephony/src/Actions/CreateTelephonyQueue.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Telephony\Actions;
 
+use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
 use Liberu\CRM\Telephony\Models\TelephonyQueue;
 use Liberu\CRM\Telephony\Services\TelephonyAudit;
@@ -15,8 +16,16 @@ final class CreateTelephonyQueue
     {
         if (! app(TelephonyPolicy::class)->canManage($teamId, $actorId)) {
             throw ValidationException::withMessages(['authorization' => 'Not authorized.']);
-        } validator($data, ['name' => ['required', 'string', 'max:255'], 'strategy' => ['nullable', 'in:ring_all,round_robin,least_calls'], 'max_wait_seconds' => ['nullable', 'integer', 'min:1'], 'members' => ['nullable', 'array']])->validate();
-        $queue = TelephonyQueue::query()->create(['team_id' => $teamId, 'name' => $data['name'], 'strategy' => $data['strategy'] ?? 'ring_all', 'max_wait_seconds' => $data['max_wait_seconds'] ?? 300, 'members' => $data['members'] ?? []]);
+        }
+
+        $data = validator($data, ['name' => ['required', 'string', 'max:255'], 'strategy' => ['nullable', 'in:ring_all,round_robin,least_calls'], 'max_wait_seconds' => ['nullable', 'integer', 'min:1'], 'members' => ['nullable', 'array'], 'members.*' => ['integer', 'distinct']])->validate();
+        foreach ($data['members'] ?? [] as $member) {
+            if (! app(TelephonyPolicy::class)->isTeamMember($teamId, (int) $member, [], true)) {
+                throw ValidationException::withMessages(['members' => 'All queue members must belong to this team.']);
+            }
+        }
+
+        $queue = DB::transaction(fn (): TelephonyQueue => TelephonyQueue::query()->create(['team_id' => $teamId, 'name' => $data['name'], 'strategy' => $data['strategy'] ?? 'ring_all', 'max_wait_seconds' => $data['max_wait_seconds'] ?? 300, 'members' => array_map('intval', $data['members'] ?? [])]));
         app(TelephonyAudit::class)->record($teamId, $actorId, 'queue_created', ['queue_id' => $queue->id]);
 
         return $queue;

--- a/modules/crm-telephony/src/Actions/LogTelephonyCall.php
+++ b/modules/crm-telephony/src/Actions/LogTelephonyCall.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
 use Liberu\CRM\Telephony\Events\CallLogged;
 use Liberu\CRM\Telephony\Models\TelephonyCall;
+use Liberu\CRM\Telephony\Models\TelephonyNumber;
 use Liberu\CRM\Telephony\Services\TelephonyAudit;
 use Liberu\CRM\Telephony\Services\TelephonyPolicy;
 
@@ -17,13 +18,19 @@ final class LogTelephonyCall
     {
         if (! app(TelephonyPolicy::class)->canManage($teamId, $actorId)) {
             throw ValidationException::withMessages(['authorization' => 'Not authorized.']);
-        } validator($data, ['from_number' => ['required', 'string', 'max:32'], 'to_number' => ['required', 'string', 'max:32'], 'direction' => ['nullable', 'in:inbound,outbound'], 'status' => ['nullable', 'string', 'max:50'], 'idempotency_key' => ['required', 'string', 'max:255']])->validate();
+        }
 
-        return DB::transaction(function () use ($teamId, $actorId, $data) {
+        $data = validator($data, ['from_number' => ['required', 'string', 'max:32'], 'to_number' => ['required', 'string', 'max:32'], 'direction' => ['nullable', 'in:inbound,outbound'], 'status' => ['nullable', 'string', 'max:50'], 'number_id' => ['nullable', 'integer', 'min:1'], 'contact_id' => ['nullable', 'integer', 'min:1'], 'started_at' => ['nullable', 'date'], 'ended_at' => ['nullable', 'date', 'after_or_equal:started_at'], 'metadata' => ['nullable', 'array'], 'idempotency_key' => ['required', 'string', 'max:255']])->validate();
+
+        return DB::transaction(function () use ($teamId, $actorId, $data): TelephonyCall {
+            if (isset($data['number_id']) && ! TelephonyNumber::query()->where('team_id', $teamId)->whereKey($data['number_id'])->exists()) {
+                throw ValidationException::withMessages(['number_id' => 'The number does not belong to this team.']);
+            }
             $existing = TelephonyCall::query()->where('team_id', $teamId)->where('idempotency_key', $data['idempotency_key'])->lockForUpdate()->first();
             if ($existing) {
                 return $existing;
-            } $call = TelephonyCall::query()->create(array_merge($data, ['team_id' => $teamId, 'direction' => $data['direction'] ?? 'inbound', 'status' => $data['status'] ?? 'completed']));
+            }
+            $call = TelephonyCall::query()->create(array_merge($data, ['team_id' => $teamId, 'direction' => $data['direction'] ?? 'inbound', 'status' => $data['status'] ?? 'completed']));
             app(TelephonyAudit::class)->record($teamId, $actorId, 'call_logged', ['call_id' => $call->id]);
             CallLogged::dispatch($call);
 

--- a/modules/crm-telephony/src/Actions/UpdateCall.php
+++ b/modules/crm-telephony/src/Actions/UpdateCall.php
@@ -15,8 +15,9 @@ final class UpdateCall
     {
         if (! app(TelephonyPolicy::class)->canManage($teamId, $actorId)) {
             throw ValidationException::withMessages(['authorization' => 'Not authorized.']);
-        } $call = TelephonyCall::query()->where('team_id', $teamId)->findOrFail($callId);
-        validator($data, ['disposition' => ['nullable', 'string', 'max:100'], 'recording_url' => ['nullable', 'url', 'max:2048'], 'voicemail_url' => ['nullable', 'url', 'max:2048'], 'transfer_to' => ['nullable', 'string', 'max:32']])->validate();
+        }
+        $call = TelephonyCall::query()->where('team_id', $teamId)->findOrFail($callId);
+        $data = validator($data, ['disposition' => ['nullable', 'string', 'max:100'], 'recording_url' => ['nullable', 'url', 'max:2048'], 'voicemail_url' => ['nullable', 'url', 'max:2048'], 'transfer_to' => ['nullable', 'string', 'max:32']])->validate();
         $call->fill($data)->save();
         app(TelephonyAudit::class)->record($teamId, $actorId, 'call_updated', ['call_id' => $call->id, 'fields' => array_keys($data)]);
 

--- a/modules/crm-telephony/src/Actions/UpsertTelephonyNumber.php
+++ b/modules/crm-telephony/src/Actions/UpsertTelephonyNumber.php
@@ -15,7 +15,8 @@ final class UpsertTelephonyNumber
     {
         if (! app(TelephonyPolicy::class)->canManage($teamId, $actorId)) {
             throw ValidationException::withMessages(['authorization' => 'Not authorized.']);
-        } validator($data, ['number' => ['required', 'string', 'max:32'], 'label' => ['nullable', 'string', 'max:255'], 'provider' => ['required', 'string', 'max:50'], 'status' => ['nullable', 'in:active,inactive']])->validate();
+        }
+        $data = validator($data, ['number' => ['required', 'string', 'max:32'], 'label' => ['nullable', 'string', 'max:255'], 'provider' => ['required', 'string', 'max:50'], 'status' => ['nullable', 'in:active,inactive'], 'caller_id_enabled' => ['sometimes', 'boolean'], 'metadata' => ['nullable', 'array']])->validate();
         $number = TelephonyNumber::query()->updateOrCreate(['id' => $id, 'team_id' => $teamId], ['number' => $data['number'], 'label' => $data['label'] ?? null, 'provider' => $data['provider'], 'status' => $data['status'] ?? 'active', 'caller_id_enabled' => (bool) ($data['caller_id_enabled'] ?? true), 'metadata' => $data['metadata'] ?? null]);
         app(TelephonyAudit::class)->record($teamId, $actorId, 'number_updated', ['number_id' => $number->id]);
 

--- a/modules/crm-telephony/src/Services/TelephonyPolicy.php
+++ b/modules/crm-telephony/src/Services/TelephonyPolicy.php
@@ -4,14 +4,28 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Telephony\Services;
 
-use App\Models\Team;
+use Illuminate\Support\Facades\DB;
 
 final class TelephonyPolicy
 {
     public function canManage(int $teamId, int $userId): bool
     {
-        $team = Team::query()->find($teamId);
+        return $this->isTeamMember($teamId, $userId, ['admin', 'manager'], true);
+    }
 
-        return $team !== null && ((int) $team->user_id === $userId || (bool) $team->users()->whereKey($userId)->wherePivotIn('role', ['admin', 'manager'])->exists());
+    public function isTeamMember(int $teamId, int $userId, array $roles = [], bool $includeOwner = false): bool
+    {
+        if ($includeOwner && (int) DB::table('teams')->where('id', $teamId)->value('user_id') === $userId) {
+            return true;
+        }
+
+        $query = DB::table('team_user')->where('team_id', $teamId)->where('user_id', $userId);
+        if ($roles !== []) {
+            $query->whereIn('role', $roles);
+        }
+
+        return $query->where(function ($query): void {
+            $query->whereNull('status')->orWhere('status', 'active');
+        })->exists();
     }
 }

--- a/tests/Feature/Telephony/TelephonyModuleTest.php
+++ b/tests/Feature/Telephony/TelephonyModuleTest.php
@@ -56,4 +56,46 @@ final class TelephonyModuleTest extends TestCase
         $this->expectException(ValidationException::class);
         app(CreateTelephonyQueue::class)->execute($team->id, $member->id, ['name' => 'Restricted']);
     }
+
+    public function test_queue_members_and_call_numbers_are_team_scoped(): void
+    {
+        $owner = User::factory()->create();
+        $otherOwner = User::factory()->create();
+        $team = Team::factory()->create(['user_id' => $owner->id]);
+        $otherTeam = Team::factory()->create(['user_id' => $otherOwner->id]);
+        $foreignNumber = app(UpsertTelephonyNumber::class)->execute($otherTeam->id, $otherOwner->id, ['number' => '+15550999', 'provider' => 'twilio']);
+
+        $this->expectException(ValidationException::class);
+        app(CreateTelephonyQueue::class)->execute($team->id, $owner->id, ['name' => 'Foreign members', 'members' => [$otherOwner->id]]);
+
+        self::assertNotNull($foreignNumber->id);
+    }
+
+    public function test_call_numbers_cannot_cross_team_boundaries(): void
+    {
+        $owner = User::factory()->create();
+        $otherOwner = User::factory()->create();
+        $team = Team::factory()->create(['user_id' => $owner->id]);
+        $otherTeam = Team::factory()->create(['user_id' => $otherOwner->id]);
+        $foreignNumber = app(UpsertTelephonyNumber::class)->execute($otherTeam->id, $otherOwner->id, ['number' => '+15550998', 'provider' => 'twilio']);
+
+        $this->expectException(ValidationException::class);
+        app(LogTelephonyCall::class)->execute($team->id, $owner->id, ['from_number' => '+15550101', 'to_number' => '+15550102', 'number_id' => $foreignNumber->id, 'idempotency_key' => 'foreign-number']);
+    }
+
+    public function test_call_logging_ignores_unvalidated_control_fields(): void
+    {
+        $owner = User::factory()->create();
+        $team = Team::factory()->create(['user_id' => $owner->id]);
+        $call = app(LogTelephonyCall::class)->execute($team->id, $owner->id, [
+            'from_number' => '+15550101',
+            'to_number' => '+15550102',
+            'idempotency_key' => 'controlled-call',
+            'team_id' => 999999,
+            'actor_id' => 999999,
+        ]);
+
+        self::assertSame($team->id, $call->getAttribute('team_id'));
+        self::assertNull($call->getAttribute('actor_id'));
+    }
 }


### PR DESCRIPTION
## Summary
- remove application Team coupling from telephony authorization
- validate queue members, call numbers, settings, and call update payloads
- make settings updates transactional and bound API pagination
- throttle telephony API routes and preserve module/plugin boundaries

## Verification
- php artisan test: 1,514 passed, 1 skipped (3,718 assertions)
- Pint: passed
- PHPStan: clean for Telephony domain/API/Filament/Livewire sources