### PR TITLE
fix: avoid duplicate personal access token migration

### DIFF
--- a/modules/sessions-devices/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
+++ b/modules/sessions-devices/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
@@ -11,6 +11,10 @@ return new class() extends Migration
      */
     public function up(): void
     {
+        if (Schema::hasTable('personal_access_tokens')) {
+            return;
+        }
+
         Schema::create('personal_access_tokens', function (Blueprint $table) {
             $table->id();
             $table->morphs('tokenable');


### PR DESCRIPTION
## Fix\n- Guard the sessions-devices Sanctum migration when personal_access_tokens already exists.\n- Prevents MySQL 1050 failures when API Access, Sanctum, or an existing installation owns the table.\n\n## Validation\n- Focused Laravel tests: 19 passed (23 assertions)\n- PHPStan: no errors\n- Pint: passed