### PR TITLE
fix: make duplicate table migrations idempotent

### DIFF
--- a/modules/audit/database/migrations/2026_06_29_124053_create_activity_log_table.php
+++ b/modules/audit/database/migrations/2026_06_29_124053_create_activity_log_table.php
@@ -8,6 +8,10 @@ return new class() extends Migration
 {
     public function up(): void
     {
+        if (Schema::hasTable('activity_log')) {
+            return;
+        }
+
         Schema::create('activity_log', function (Blueprint $table) {
             $table->id();
             $table->string('log_name')->nullable()->index();

--- a/modules/identity-socialstream/database/migrations/0001_01_01_000002_create_connected_accounts_table.php
+++ b/modules/identity-socialstream/database/migrations/0001_01_01_000002_create_connected_accounts_table.php
@@ -11,6 +11,10 @@ return new class() extends Migration
      */
     public function up(): void
     {
+        if (Schema::hasTable('connected_accounts')) {
+            return;
+        }
+
         Schema::create('connected_accounts', function (Blueprint $table): void {
             $table->id();
             $table->foreignId('user_id');

--- a/modules/webhooks/database/migrations/2026_08_01_030000_create_webhook_tables.php
+++ b/modules/webhooks/database/migrations/2026_08_01_030000_create_webhook_tables.php
@@ -8,34 +8,35 @@ return new class() extends Migration
 {
     public function up(): void
     {
-        if (Schema::hasTable('webhook_deliveries')) {
-            return;
+        if (! Schema::hasTable('webhook_endpoints')) {
+            Schema::create('webhook_endpoints', function (Blueprint $t): void {
+                $t->id();
+                $t->string('owner_ref')->index();
+                $t->text('url');
+                $t->text('signing_secret');
+                $t->json('events');
+                $t->boolean('active')->default(true);
+                $t->timestamp('rotated_at')->nullable();
+                $t->timestamps();
+            });
         }
 
-        Schema::create('webhook_endpoints', function (Blueprint $t): void {
-            $t->id();
-            $t->string('owner_ref')->index();
-            $t->text('url');
-            $t->text('signing_secret');
-            $t->json('events');
-            $t->boolean('active')->default(true);
-            $t->timestamp('rotated_at')->nullable();
-            $t->timestamps();
-        });
-        Schema::create('webhook_deliveries', function (Blueprint $t): void {
-            $t->uuid('id')->primary();
-            $t->foreignId('endpoint_id')->constrained('webhook_endpoints')->cascadeOnDelete();
-            $t->uuid('event_id')->index();
-            $t->string('event');
-            $t->json('payload');
-            $t->string('status')->default('pending')->index();
-            $t->unsignedInteger('attempts')->default(0);
-            $t->unsignedSmallInteger('response_status')->nullable();
-            $t->text('response_excerpt')->nullable();
-            $t->timestamp('next_attempt_at')->nullable()->index();
-            $t->timestamps();
-            $t->unique(['endpoint_id', 'event_id']);
-        });
+        if (! Schema::hasTable('webhook_deliveries')) {
+            Schema::create('webhook_deliveries', function (Blueprint $t): void {
+                $t->uuid('id')->primary();
+                $t->foreignId('endpoint_id')->constrained('webhook_endpoints')->cascadeOnDelete();
+                $t->uuid('event_id')->index();
+                $t->string('event');
+                $t->json('payload');
+                $t->string('status')->default('pending')->index();
+                $t->unsignedInteger('attempts')->default(0);
+                $t->unsignedSmallInteger('response_status')->nullable();
+                $t->text('response_excerpt')->nullable();
+                $t->timestamp('next_attempt_at')->nullable()->index();
+                $t->timestamps();
+                $t->unique(['endpoint_id', 'event_id']);
+            });
+        }
     }
 
     public function down(): void


### PR DESCRIPTION
## Fix\n- Guard duplicate activity_log and connected_accounts table definitions.\n- Make the personal access token migration path safe when the table already exists.\n- Split webhook endpoint and delivery guards so legacy deliveries do not prevent endpoint creation.\n\n## Validation\n- DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan migrate --seed\n- Pint passed\n- Previous focused suite: 19 tests passed (23 assertions)\n- PHPStan: no errors