### PR TITLE
Fix theme Vite asset resolution

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,20 +1,25 @@
 import { defineConfig } from 'vite'
 import laravel, { refreshPaths } from 'laravel-vite-plugin'
-import { viteStaticCopy } from "vite-plugin-static-copy";
+import { viteStaticCopy } from 'vite-plugin-static-copy'
 
 import fs from 'node:fs'
+import { fileURLToPath } from 'node:url'
 import path from 'node:path'
 
-const themeInputs = fs.existsSync('themes')
-    ? fs.readdirSync('themes', { withFileTypes: true })
+const projectRoot = fileURLToPath(new URL('.', import.meta.url))
+const themesDirectory = path.join(projectRoot, 'themes')
+
+const themeInputs = fs.existsSync(themesDirectory)
+    ? fs.readdirSync(themesDirectory, { withFileTypes: true })
         .filter((entry) => entry.isDirectory())
         .flatMap((entry) => {
-            const manifestPath = path.join('themes', entry.name, 'theme.json')
+            const manifestPath = path.join(themesDirectory, entry.name, 'theme.json')
             if (!fs.existsSync(manifestPath)) return []
             const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
             return [...(manifest.assets?.css ?? []), ...(manifest.assets?.js ?? [])]
-                .map((asset) => path.join('themes', entry.name, asset))
+                .map((asset) => path.join(themesDirectory, entry.name, asset))
                 .filter((asset) => fs.existsSync(asset))
+                .map((asset) => path.relative(projectRoot, asset).split(path.sep).join('/'))
         })
     : []
 
@@ -22,9 +27,10 @@ export default defineConfig({
     plugins: [
         laravel({
             input: ['resources/css/app.css', 'resources/js/app.js',
-		    'resources/css/filament/admin/theme.css', ...themeInputs],
+                'resources/css/filament/admin/theme.css', ...themeInputs],
             refresh: [
                 ...refreshPaths,
+                'themes/**',
                 'app/Filament/**',
                 'app/Forms/Components/**',
                 'app/Livewire/**',
@@ -36,8 +42,8 @@ export default defineConfig({
         viteStaticCopy({
             targets: [
                 {
-                    src: "resources/images/*",
-                    dest: "images",
+                    src: 'resources/images/*',
+                    dest: 'images',
                 },
             ],
         }),


### PR DESCRIPTION
## Summary
- resolve theme asset discovery from the Vite config location
- normalize theme input paths to match Laravel Vite manifest keys
- refresh theme files during development

## Verification
- npm run build
- php artisan test --filter='ThemeManager|ThemeServiceProvider|ThemeManifest' --compact