### PR TITLE
Load Tailwind alongside active theme CSS

### DIFF
--- a/modules/theme-support/src/Services/ThemeManager.php
+++ b/modules/theme-support/src/Services/ThemeManager.php
@@ -197,7 +197,12 @@ final class ThemeManager
 
     public function activeEntries(): array
     {
-        return array_values(array_unique(array_filter([$this->activeCssEntry(), $this->getThemeJs(), 'resources/js/app.js'])));
+        return array_values(array_unique(array_filter([
+            'resources/css/app.css',
+            $this->activeCssEntry(),
+            $this->getThemeJs(),
+            'resources/js/app.js',
+        ])));
     }
 
     public function assetUrl(string $path, ?string $theme = null): string

--- a/tests/Unit/ThemeManagerActiveCssEntryTest.php
+++ b/tests/Unit/ThemeManagerActiveCssEntryTest.php
@@ -12,6 +12,12 @@ it('selects the built theme bundle when available and otherwise uses the applica
     expect($manager->activeCssEntry())->toBe($expected);
 });
 
+it('keeps the main Tailwind bundle when a theme bundle is active', function () {
+    $manager = app(ThemeManager::class);
+
+    expect($manager->activeEntries())->toContain('resources/css/app.css');
+});
+
 it('returns the theme bundle path when it is present in the Vite manifest', function () {
     $manifestPath = public_path('build/manifest.json');
     $backup = File::exists($manifestPath) ? File::get($manifestPath) : null;


### PR DESCRIPTION
## Summary
- keep resources/css/app.css in themeVite entries
- retain the active theme stylesheet and theme JavaScript
- add regression coverage for the main Tailwind entry

## Verification
- php artisan test --filter='ThemeManagerActiveCssEntryTest|ThemeServiceProvider' --compact
- npm run build