### PR TITLE
fix: align Filament logout and portal theme layout

### DIFF
--- a/public/build/manifest.json
+++ b/public/build/manifest.json
@@ -1,6 +1,6 @@
 {
   "resources/css/app.css": {
-    "file": "assets/app-CWc7JaSP.css",
+    "file": "assets/app-Drco4VS_.css",
     "name": "app",
     "names": [
       "app.css"

--- a/resources/views/billing/locked.blade.php
+++ b/resources/views/billing/locked.blade.php
@@ -11,7 +11,7 @@
         </div>
         <div class="mt-8 border-t border-slate-200 pt-6">
             <p class="mb-3 text-sm text-slate-600">Need to leave this account for now?</p>
-            <form method="POST" action="{{ route('logout') }}">
+            <form method="POST" action="{{ filament()->getLogoutUrl() }}">
                 @csrf
                 <button type="submit" class="crm-button w-full justify-center border border-red-200 bg-red-50 text-red-700 hover:bg-red-100 sm:w-auto">Log out</button>
             </form>

--- a/themes/base/resources/views/layouts/app.blade.php
+++ b/themes/base/resources/views/layouts/app.blade.php
@@ -1,3 +1,11 @@
+@php
+    $hasThemePreference = session()->has('theme_preference')
+        || (auth()->check() && is_string(auth()->user()->theme_preference) && auth()->user()->theme_preference !== '');
+
+    if (! $hasThemePreference && app('theme')->getActiveTheme() === config('theme.default')) {
+        app('theme')->selectForSurface('portal');
+    }
+@endphp
 <!doctype html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}" dir="{{ in_array(app()->getLocale(), config('localization.rtl_locales', []), true) ? 'rtl' : 'ltr' }}">
 <head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><meta name="csrf-token" content="{{ csrf_token() }}"><meta name="stripe-key" content="{{ config('services.stripe.key') }}"><title>@yield('title', config('app.name'))</title><link rel="canonical" href="{{ url()->current() }}">@themeVite @livewireStyles @stack('head')</head>


### PR DESCRIPTION
## Summary
- use Filament's panel logout URL on the locked billing screen
- apply the configured portal theme when the base layout is resolved directly
- refresh the production Vite manifest

## Validation
- php artisan test --filter="ThemeSiteResolutionTest|ThemeViteDirectiveTest|HomeControllerTest"
- php artisan theme:validate
- npm run build