### PR TITLE
Fix loading all declared Filament module plugins

### DIFF
--- a/modules/module-manager/src/Manifest.php
+++ b/modules/module-manager/src/Manifest.php
@@ -133,6 +133,10 @@ final readonly class Manifest
     {
         $plugins = $this->data['presentation']['filament'][$panel] ?? [];
 
+        if (is_array($plugins) && isset($plugins['plugins'])) {
+            $plugins = $plugins['plugins'];
+        }
+
         return is_array($plugins) ? array_values(array_filter($plugins, 'is_string')) : [];
     }
 

--- a/modules/module-manager/tests/Unit/ModuleRegistryCoverageTest.php
+++ b/modules/module-manager/tests/Unit/ModuleRegistryCoverageTest.php
@@ -51,6 +51,15 @@ it('exposes and normalizes all manifest metadata', function () {
         ->and($manifest->toArray()['path'])->toBe($manifest->path);
 });
 
+it('reads nested Filament plugin metadata', function () {
+    $manifest = makeCoverageManifest([
+        'category' => 'presentation',
+        'presentation' => ['filament' => ['app' => ['plugins' => [TestCase::class]]]],
+    ]);
+
+    expect($manifest->filamentPlugins('app'))->toBe([TestCase::class]);
+});
+
 it('rejects malformed manifests', function (array $mutation, string $message) {
     $data = [
         'name' => 'example', 'display_name' => 'Example', 'description' => 'Test',


### PR DESCRIPTION
## Fixes\n- Support both direct and nested Filament plugin manifest metadata.\n- Ensure declared plugins are discovered and validated consistently.\n\n## Verification\n- php artisan module:validate\n- Module registry and Filament plugin tests\n- Pint