### PR TITLE
Fix CRM team relationships and organize navigation

### DIFF
--- a/app/Filament/CrmNavigation.php
+++ b/app/Filament/CrmNavigation.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament;
+
+use Filament\Panel;
+use Filament\Resources\Resource;
+
+final class CrmNavigation
+{
+    public function configure(Panel $panel): void
+    {
+        $panel->navigationGroups([
+            'CRM',
+            'Sales',
+            'Marketing',
+            'Communication',
+            'Support',
+            'Operations',
+            'Data & intelligence',
+            'Team',
+            'Settings & integrations',
+            'Account',
+        ])->collapsibleNavigationGroups();
+
+        foreach ($panel->getResources() as $resource) {
+            if (! is_a($resource, Resource::class, true)) {
+                continue;
+            }
+
+            $resource::navigationGroup($this->groupFor($resource));
+        }
+    }
+
+    private function groupFor(string $resource): string
+    {
+        $resource = strtolower($resource);
+
+        return match (true) {
+            str_contains($resource, 'sales'),
+            str_contains($resource, 'account'),
+            str_contains($resource, 'affiliate'),
+            str_contains($resource, 'attribution'),
+            str_contains($resource, 'deal'),
+            str_contains($resource, 'forecast'),
+            str_contains($resource, 'leadqualification'),
+            str_contains($resource, 'pipeline'),
+            str_contains($resource, 'prospect'),
+            str_contains($resource, 'quote'),
+            str_contains($resource, 'revenue') => 'Sales',
+
+            str_contains($resource, 'marketing'),
+            str_contains($resource, 'advertis'),
+            str_contains($resource, 'campaign'),
+            str_contains($resource, 'enrichment'),
+            str_contains($resource, 'funnel'),
+            str_contains($resource, 'journey'),
+            str_contains($resource, 'webintent') => 'Marketing',
+
+            str_contains($resource, 'activit'),
+            str_contains($resource, 'chat'),
+            str_contains($resource, 'conversation'),
+            str_contains($resource, 'dialer'),
+            str_contains($resource, 'email'),
+            str_contains($resource, 'messag'),
+            str_contains($resource, 'telephon') => 'Communication',
+
+            str_contains($resource, 'customer'),
+            str_contains($resource, 'case'),
+            str_contains($resource, 'contactcenter'),
+            str_contains($resource, 'knowledge'),
+            str_contains($resource, 'onboarding'),
+            str_contains($resource, 'service'),
+            str_contains($resource, 'support'),
+            str_contains($resource, 'ticket') => 'Support',
+
+            str_contains($resource, 'analytic'),
+            str_contains($resource, 'copilot'),
+            str_contains($resource, 'data'),
+            str_contains($resource, 'intelligen'),
+            str_contains($resource, 'predict'),
+            str_contains($resource, 'search') => 'Data & intelligence',
+
+            str_contains($resource, 'automation'),
+            str_contains($resource, 'document'),
+            str_contains($resource, 'process'),
+            str_contains($resource, 'project'),
+            str_contains($resource, 'work'),
+            str_contains($resource, 'planning'),
+            str_contains($resource, 'resource') => 'Operations',
+
+            default => 'CRM',
+        };
+    }
+}

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -6,6 +6,7 @@ namespace App\Providers\Filament;
 
 use App\Filament\App\Pages;
 use App\Filament\App\Pages\EditProfile;
+use App\Filament\CrmNavigation;
 use App\Filament\ModulePlugins;
 use App\Http\Middleware\EnsureSsoWhenRequired;
 use App\Http\Middleware\TeamsPermission;
@@ -24,7 +25,6 @@ use Filament\Pages\Dashboard;
 use Filament\Panel;
 use Filament\PanelProvider;
 use Filament\Widgets;
-use Illuminate\Contracts\Routing\UrlGenerator;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
 use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
@@ -53,21 +53,11 @@ class AppPanelProvider extends PanelProvider
             // ->emailVerification()
             ->viteTheme('resources/css/filament/admin/theme.css')
             ->colors(app(ThemeColors::class)->forSite())
-            ->navigationGroups([
-                'CRM',
-                'Sales',
-                'Marketing',
-                'Communication',
-                'Support',
-                'Team',
-                'Settings & integrations',
-                'Account',
-            ])
             ->userMenuItems([
                 MenuItem::make()
                     ->label('Profile')
                     ->icon('heroicon-o-user-circle')
-                    ->url(fn (): UrlGenerator|string => $this->shouldRegisterMenuItem()
+                    ->url(fn () => $this->shouldRegisterMenuItem()
                         ? url(EditProfile::getUrl())
                         : url($panel->getPath())),
             ])
@@ -118,7 +108,7 @@ class AppPanelProvider extends PanelProvider
                     MenuItem::make()
                         ->label('Team Settings')
                         ->icon('heroicon-o-cog-6-tooth')
-                        ->url(fn (): UrlGenerator|string => $this->shouldRegisterMenuItem()
+                        ->url(fn () => $this->shouldRegisterMenuItem()
                             ? url(Pages\EditTeam::getUrl())
                             : url($panel->getPath())),
                 ]);
@@ -131,6 +121,8 @@ class AppPanelProvider extends PanelProvider
         foreach (glob(base_path('modules/*/src/Legacy/Filament/App/Pages')) ?: [] as $path) {
             $panel->discoverPages(in: $path, for: 'App\\Filament\\App\\Pages');
         }
+
+        app(CrmNavigation::class)->configure($panel);
 
         return $panel;
     }

--- a/modules/crm-account-based-marketing/src/Models/AccountBasedMarketingRecord.php
+++ b/modules/crm-account-based-marketing/src/Models/AccountBasedMarketingRecord.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\AccountBasedMarketing\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
@@ -21,6 +22,8 @@ use Illuminate\Support\Carbon;
  */
 final class AccountBasedMarketingRecord extends Model
 {
+    use IsTenantModel;
+
     public const KINDS = [
         'target_account',
         'tier',

--- a/modules/crm-account-planning/src/Models/AccountPlanningRecord.php
+++ b/modules/crm-account-planning/src/Models/AccountPlanningRecord.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\AccountPlanning\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
@@ -21,6 +22,8 @@ use Illuminate\Support\Carbon;
  */
 final class AccountPlanningRecord extends Model
 {
+    use IsTenantModel;
+
     public const KINDS = ['account_hierarchy', 'stakeholder', 'influence_map', 'whitespace', 'account_plan', 'objective', 'risk', 'mutual_action_plan', 'coordination'];
 
     public const STATUSES = ['draft', 'active', 'paused', 'completed', 'archived'];

--- a/modules/crm-activities/src/Models/Activity.php
+++ b/modules/crm-activities/src/Models/Activity.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Activities\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Carbon;
@@ -22,6 +23,8 @@ use Illuminate\Support\Carbon;
  */
 final class Activity extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_activities';
 
     protected $fillable = ['team_id', 'actor_id', 'assigned_to', 'kind', 'status', 'title', 'description', 'subject_type', 'subject_id', 'starts_at', 'due_at', 'ends_at', 'recurrence', 'recurrence_until', 'reminder_at', 'queue', 'outcome', 'outcome_notes', 'metadata', 'completed_at'];

--- a/modules/crm-activities/src/Models/ActivityEvent.php
+++ b/modules/crm-activities/src/Models/ActivityEvent.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Activities\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 final class ActivityEvent extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_activity_events';
 
     protected $fillable = ['team_id', 'activity_id', 'actor_id', 'event', 'details'];

--- a/modules/crm-activities/src/Models/ActivityGoal.php
+++ b/modules/crm-activities/src/Models/ActivityGoal.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Activities\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 final class ActivityGoal extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_activity_goals';
 
     protected $fillable = ['team_id', 'owner_id', 'name', 'kind', 'target', 'progress', 'starts_at', 'ends_at', 'status', 'criteria'];

--- a/modules/crm-advertising/src/Models/AdvertisingRecord.php
+++ b/modules/crm-advertising/src/Models/AdvertisingRecord.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Advertising\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
@@ -21,6 +22,8 @@ use Illuminate\Support\Carbon;
  */
 final class AdvertisingRecord extends Model
 {
+    use IsTenantModel;
+
     public const KINDS = ['ad_account_connection', 'campaign', 'lead_ad', 'crm_audience', 'offline_conversion', 'performance_sync', 'attribution'];
 
     public const STATUSES = ['draft', 'active', 'paused', 'completed', 'archived'];

--- a/modules/crm-advocacy/src/Models/AdvocacyRecord.php
+++ b/modules/crm-advocacy/src/Models/AdvocacyRecord.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Advocacy\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
@@ -21,6 +22,8 @@ use Illuminate\Support\Carbon;
  */
 final class AdvocacyRecord extends Model
 {
+    use IsTenantModel;
+
     public const KINDS = ['reference', 'testimonial', 'review', 'case_study_consent', 'speaker', 'advisory_board', 'nomination', 'request', 'recognition'];
 
     public const STATUSES = ['draft', 'requested', 'approved', 'active', 'completed', 'archived'];

--- a/modules/crm-affiliate-management/src/Models/Affiliate.php
+++ b/modules/crm-affiliate-management/src/Models/Affiliate.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\AffiliateManagement\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
@@ -14,6 +15,8 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  */
 final class Affiliate extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_affiliates';
 
     protected $guarded = [];

--- a/modules/crm-affiliate-management/src/Models/AffiliateLink.php
+++ b/modules/crm-affiliate-management/src/Models/AffiliateLink.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\AffiliateManagement\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -13,6 +14,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class AffiliateLink extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_affiliate_links';
 
     protected $guarded = [];

--- a/modules/crm-affiliate-management/src/Models/AffiliatePayout.php
+++ b/modules/crm-affiliate-management/src/Models/AffiliatePayout.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\AffiliateManagement\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -13,6 +14,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class AffiliatePayout extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_affiliate_payouts';
 
     protected $guarded = [];

--- a/modules/crm-agency-workspace/src/Models/AgencyAccount.php
+++ b/modules/crm-agency-workspace/src/Models/AgencyAccount.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\AgencyWorkspace\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /** @property int $team_id @property int|null $parent_id @property string $account_type @property string $status @property array<string,mixed>|null $branding @property array<string,mixed>|null $usage_snapshot */
 final class AgencyAccount extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_agency_accounts';
 
     protected $guarded = [];

--- a/modules/crm-ai-reception-and-conversation/src/Models/ReceptionAgent.php
+++ b/modules/crm-ai-reception-and-conversation/src/Models/ReceptionAgent.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\AIReceptionAndConversation\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -14,6 +15,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class ReceptionAgent extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_ai_reception_agents';
 
     protected $guarded = [];

--- a/modules/crm-ai-reception-and-conversation/src/Models/ReceptionConversation.php
+++ b/modules/crm-ai-reception-and-conversation/src/Models/ReceptionConversation.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\AIReceptionAndConversation\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
@@ -18,6 +19,8 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  */
 final class ReceptionConversation extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_ai_reception_conversations';
 
     protected $guarded = [];

--- a/modules/crm-analytics/src/Models/AnalyticsAsset.php
+++ b/modules/crm-analytics/src/Models/AnalyticsAsset.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Analytics\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -17,6 +18,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class AnalyticsAsset extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_analytics_assets';
 
     protected $guarded = [];

--- a/modules/crm-analytics/src/Models/AnalyticsExecution.php
+++ b/modules/crm-analytics/src/Models/AnalyticsExecution.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Analytics\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $asset_id @property int $actor_id @property string $status */
 final class AnalyticsExecution extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_analytics_executions';
 
     protected $guarded = [];

--- a/modules/crm-attribution/src/Models/Touchpoint.php
+++ b/modules/crm-attribution/src/Models/Touchpoint.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Attribution\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property string $visitor_key @property string $source @property float $cost */
 final class Touchpoint extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_attribution_touchpoints';
 
     protected $guarded = [];

--- a/modules/crm-automation-pack/src/Models/AutomationApproval.php
+++ b/modules/crm-automation-pack/src/Models/AutomationApproval.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\AutomationPack\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -13,6 +14,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class AutomationApproval extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_automation_approvals';
 
     protected $guarded = [];

--- a/modules/crm-automation-pack/src/Models/AutomationEnrollment.php
+++ b/modules/crm-automation-pack/src/Models/AutomationEnrollment.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\AutomationPack\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -13,6 +14,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class AutomationEnrollment extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_automation_enrollments';
 
     protected $guarded = [];

--- a/modules/crm-automation-pack/src/Models/AutomationRecipe.php
+++ b/modules/crm-automation-pack/src/Models/AutomationRecipe.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\AutomationPack\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -16,6 +17,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class AutomationRecipe extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_automation_recipes';
 
     protected $guarded = [];

--- a/modules/crm-automation-pack/src/Models/AutomationRun.php
+++ b/modules/crm-automation-pack/src/Models/AutomationRun.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\AutomationPack\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -13,6 +14,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class AutomationRun extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_automation_runs';
 
     protected $guarded = [];

--- a/modules/crm-business-process-management/src/Models/Process.php
+++ b/modules/crm-business-process-management/src/Models/Process.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\BusinessProcessManagement\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
@@ -17,6 +18,8 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  */
 final class Process extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_bpm_processes';
 
     protected $guarded = [];

--- a/modules/crm-business-process-management/src/Models/ProcessRun.php
+++ b/modules/crm-business-process-management/src/Models/ProcessRun.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\BusinessProcessManagement\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -17,6 +18,8 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  */
 final class ProcessRun extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_bpm_runs';
 
     protected $guarded = [];

--- a/modules/crm-campaigns/src/Models/Campaign.php
+++ b/modules/crm-campaigns/src/Models/Campaign.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Campaigns\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -18,6 +19,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class Campaign extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_campaigns';
 
     protected $guarded = [];

--- a/modules/crm-campaigns/src/Models/CampaignEvent.php
+++ b/modules/crm-campaigns/src/Models/CampaignEvent.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Campaigns\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $campaign_id @property string $type @property float $value */
 final class CampaignEvent extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_campaign_events';
 
     protected $guarded = [];

--- a/modules/crm-case-management/src/Models/CaseAudit.php
+++ b/modules/crm-case-management/src/Models/CaseAudit.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\CaseManagement\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $case_id @property string $event */
 final class CaseAudit extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_case_audits';
 
     protected $guarded = [];

--- a/modules/crm-case-management/src/Models/CaseRecord.php
+++ b/modules/crm-case-management/src/Models/CaseRecord.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\CaseManagement\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -17,6 +18,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class CaseRecord extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_cases';
 
     protected $guarded = [];

--- a/modules/crm-channel-gateway/src/Models/GatewayChannel.php
+++ b/modules/crm-channel-gateway/src/Models/GatewayChannel.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\ChannelGateway\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -15,6 +16,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class GatewayChannel extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_gateway_channels';
 
     protected $guarded = [];

--- a/modules/crm-channel-gateway/src/Models/GatewayDelivery.php
+++ b/modules/crm-channel-gateway/src/Models/GatewayDelivery.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\ChannelGateway\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $channel_id @property string $status @property int $attempts */
 final class GatewayDelivery extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_gateway_deliveries';
 
     protected $guarded = [];

--- a/modules/crm-channel-sales/src/Models/ChannelEvent.php
+++ b/modules/crm-channel-sales/src/Models/ChannelEvent.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\ChannelSales\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $opportunity_id @property string $type @property float|null $commission */
 final class ChannelEvent extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_channel_events';
 
     protected $guarded = [];

--- a/modules/crm-channel-sales/src/Models/ChannelOpportunity.php
+++ b/modules/crm-channel-sales/src/Models/ChannelOpportunity.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\ChannelSales\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -18,6 +19,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class ChannelOpportunity extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_channel_opportunities';
 
     protected $guarded = [];

--- a/modules/crm-chat-and-bots/src/Models/ChatBot.php
+++ b/modules/crm-chat-and-bots/src/Models/ChatBot.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\ChatAndBots\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -15,6 +16,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class ChatBot extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_chat_bots';
 
     protected $guarded = [];

--- a/modules/crm-chat-and-bots/src/Models/ChatSession.php
+++ b/modules/crm-chat-and-bots/src/Models/ChatSession.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\ChatAndBots\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -15,6 +16,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class ChatSession extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_chat_sessions';
 
     protected $guarded = [];

--- a/modules/crm-client-onboarding/src/Models/ClientOnboarding.php
+++ b/modules/crm-client-onboarding/src/Models/ClientOnboarding.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\ClientOnboarding\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -16,6 +17,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class ClientOnboarding extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_client_onboardings';
 
     protected $guarded = [];

--- a/modules/crm-client-onboarding/src/Models/ClientOnboardingStep.php
+++ b/modules/crm-client-onboarding/src/Models/ClientOnboardingStep.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\ClientOnboarding\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $onboarding_id @property string $kind @property string $status */
 final class ClientOnboardingStep extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_client_onboarding_steps';
 
     protected $guarded = [];

--- a/modules/crm-collaboration/src/Models/CollaborationRecord.php
+++ b/modules/crm-collaboration/src/Models/CollaborationRecord.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Collaboration\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property string $record_key @property string $kind @property string $status @property array<int,mixed>|null $mentions */
 final class CollaborationRecord extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_collaboration_records';
 
     protected $guarded = [];

--- a/modules/crm-collaboration/src/Models/CollaborationWork.php
+++ b/modules/crm-collaboration/src/Models/CollaborationWork.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Collaboration\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -15,6 +16,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class CollaborationWork extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_collaboration_work';
 
     protected $guarded = [];

--- a/modules/crm-communities/src/Models/CommunityContent.php
+++ b/modules/crm-communities/src/Models/CommunityContent.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Communities\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $space_id @property string $author_key @property string $kind @property string $status */
 final class CommunityContent extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_community_content';
 
     protected $guarded = [];

--- a/modules/crm-communities/src/Models/CommunityMembership.php
+++ b/modules/crm-communities/src/Models/CommunityMembership.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Communities\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $space_id @property string $subject_key @property string $status @property int $points */
 final class CommunityMembership extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_community_memberships';
 
     protected $guarded = [];

--- a/modules/crm-communities/src/Models/CommunitySpace.php
+++ b/modules/crm-communities/src/Models/CommunitySpace.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Communities\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -14,6 +15,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class CommunitySpace extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_community_spaces';
 
     protected $guarded = [];

--- a/modules/crm-consent-and-preferences/src/Models/ConsentRecord.php
+++ b/modules/crm-consent-and-preferences/src/Models/ConsentRecord.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\ConsentAndPreferences\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
 
@@ -20,6 +21,8 @@ use Illuminate\Support\Carbon;
  */
 final class ConsentRecord extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_consent_records';
 
     protected $fillable = ['team_id', 'subject_type', 'subject_id', 'channel', 'topic', 'lawful_basis', 'status', 'source', 'proof', 'consented_at', 'expires_at', 'withdrawn_at', 'actor_id'];

--- a/modules/crm-consent-and-preferences/src/Models/PolicyEvaluation.php
+++ b/modules/crm-consent-and-preferences/src/Models/PolicyEvaluation.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\ConsentAndPreferences\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 final class PolicyEvaluation extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_policy_evaluations';
 
     protected $fillable = ['team_id', 'subject_type', 'subject_id', 'channel', 'topic', 'allowed', 'reasons', 'evaluated_at'];

--- a/modules/crm-consent-and-preferences/src/Models/PreferenceRecord.php
+++ b/modules/crm-consent-and-preferences/src/Models/PreferenceRecord.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\ConsentAndPreferences\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property string $state */
 final class PreferenceRecord extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_preference_records';
 
     protected $fillable = ['team_id', 'subject_type', 'subject_id', 'channel', 'topic', 'state', 'quiet_hours', 'timezone', 'actor_id'];

--- a/modules/crm-consent-and-preferences/src/Models/SuppressionRecord.php
+++ b/modules/crm-consent-and-preferences/src/Models/SuppressionRecord.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\ConsentAndPreferences\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
 
@@ -13,6 +14,8 @@ use Illuminate\Support\Carbon;
  */
 final class SuppressionRecord extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_suppression_records';
 
     protected $fillable = ['team_id', 'subject_type', 'subject_id', 'channel', 'topic', 'reason', 'source', 'expires_at', 'withdrawn_at', 'actor_id'];

--- a/modules/crm-contact-center/src/Models/ContactCenterAgent.php
+++ b/modules/crm-contact-center/src/Models/ContactCenterAgent.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\ContactCenter\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $user_id @property string $presence @property int $capacity @property array<int,mixed>|null $skills */
 final class ContactCenterAgent extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_contact_center_agents';
 
     protected $guarded = [];

--- a/modules/crm-contact-center/src/Models/ContactCenterEvent.php
+++ b/modules/crm-contact-center/src/Models/ContactCenterEvent.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\ContactCenter\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $agent_id @property string $type @property string $status @property int|null $sla_seconds @property int|null $wait_seconds */
 final class ContactCenterEvent extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_contact_center_events';
 
     protected $guarded = [];

--- a/modules/crm-contracts/src/Models/Contract.php
+++ b/modules/crm-contracts/src/Models/Contract.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Contracts\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -16,6 +17,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class Contract extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_contracts';
 
     protected $guarded = [];

--- a/modules/crm-contracts/src/Models/ContractEvent.php
+++ b/modules/crm-contracts/src/Models/ContractEvent.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Contracts\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $contract_id @property int $actor_id @property string $type @property string $status */
 final class ContractEvent extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_contract_events';
 
     protected $guarded = [];

--- a/modules/crm-conversation-analytics/src/Models/ConversationAnalysis.php
+++ b/modules/crm-conversation-analytics/src/Models/ConversationAnalysis.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\ConversationAnalytics\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $analyst_id @property string $conversation_key @property array<string,mixed>|null $scorecard */
 final class ConversationAnalysis extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_conversation_analytics';
 
     protected $guarded = [];

--- a/modules/crm-conversation-intelligence/src/Models/Conversation.php
+++ b/modules/crm-conversation-intelligence/src/Models/Conversation.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\ConversationIntelligence\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $owner_id @property string $status @property string|null $transcript @property array<string,mixed>|null $summary @property array<string,mixed>|null $insights */
 final class Conversation extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_ci_conversations';
 
     protected $guarded = [];

--- a/modules/crm-conversation-intelligence/src/Models/ConversationEvidence.php
+++ b/modules/crm-conversation-intelligence/src/Models/ConversationEvidence.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\ConversationIntelligence\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $conversation_id @property string $kind @property string $label @property string $content */
 final class ConversationEvidence extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_ci_evidence';
 
     protected $guarded = [];

--- a/modules/crm-conversion-optimization/src/Models/ConversionExperiment.php
+++ b/modules/crm-conversion-optimization/src/Models/ConversionExperiment.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\ConversionOptimization\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -16,6 +17,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class ConversionExperiment extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_conversion_experiments';
 
     protected $guarded = [];

--- a/modules/crm-conversion-optimization/src/Models/ConversionObservation.php
+++ b/modules/crm-conversion-optimization/src/Models/ConversionObservation.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\ConversionOptimization\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $experiment_id @property string $subject_key @property string $variant @property string $event */
 final class ConversionObservation extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_conversion_observations';
 
     protected $guarded = [];

--- a/modules/crm-copilot/src/Models/CopilotAction.php
+++ b/modules/crm-copilot/src/Models/CopilotAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Copilot\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -14,6 +15,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class CopilotAction extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_copilot_actions';
 
     protected $guarded = [];

--- a/modules/crm-copilot/src/Models/CopilotRequest.php
+++ b/modules/crm-copilot/src/Models/CopilotRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Copilot\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -14,6 +15,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class CopilotRequest extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_copilot_requests';
 
     protected $guarded = [];

--- a/modules/crm-core/src/Models/Attachment.php
+++ b/modules/crm-core/src/Models/Attachment.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Core\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 final class Attachment extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_core_attachments';
 
     protected $fillable = ['team_id', 'uploaded_by', 'disk', 'path', 'name', 'mime_type', 'size', 'metadata'];

--- a/modules/crm-core/src/Models/Favorite.php
+++ b/modules/crm-core/src/Models/Favorite.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Core\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 final class Favorite extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_core_favorites';
 
     protected $fillable = ['team_id', 'user_id'];

--- a/modules/crm-core/src/Models/Note.php
+++ b/modules/crm-core/src/Models/Note.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Core\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 final class Note extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_core_notes';
 
     protected $fillable = ['team_id', 'author_id', 'body'];

--- a/modules/crm-core/src/Models/Record.php
+++ b/modules/crm-core/src/Models/Record.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Core\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
@@ -22,6 +23,8 @@ use Illuminate\Support\Carbon;
  */
 class Record extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_core_records';
 
     protected $fillable = ['record_type', 'team_id', 'owner_id', 'name', 'status', 'data', 'archived_at'];

--- a/modules/crm-core/src/Models/Relationship.php
+++ b/modules/crm-core/src/Models/Relationship.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Core\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 final class Relationship extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_core_relationships';
 
     protected $fillable = ['team_id', 'relationship_type', 'metadata'];

--- a/modules/crm-core/src/Models/Tag.php
+++ b/modules/crm-core/src/Models/Tag.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Core\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 
 /** @property int $team_id */
 final class Tag extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_core_tags';
 
     protected $fillable = ['team_id', 'name', 'slug'];

--- a/modules/crm-core/src/Models/TimelineEntry.php
+++ b/modules/crm-core/src/Models/TimelineEntry.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Core\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 final class TimelineEntry extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_core_timeline';
 
     protected $fillable = ['team_id', 'actor_id', 'event_type', 'summary', 'payload'];

--- a/modules/crm-cpq/src/Models/CpqApproval.php
+++ b/modules/crm-cpq/src/Models/CpqApproval.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\CPQ\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -14,6 +15,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class CpqApproval extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_cpq_approvals';
 
     protected $guarded = [];

--- a/modules/crm-cpq/src/Models/CpqQuote.php
+++ b/modules/crm-cpq/src/Models/CpqQuote.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\CPQ\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -21,6 +22,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class CpqQuote extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_cpq_quotes';
 
     protected $guarded = [];

--- a/modules/crm-customer-data-model/src/Models/ObjectDefinition.php
+++ b/modules/crm-customer-data-model/src/Models/ObjectDefinition.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\CustomerDataModel\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
@@ -18,6 +19,8 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  */
 final class ObjectDefinition extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_customer_data_objects';
 
     protected $fillable = ['team_id', 'key', 'label', 'description', 'is_standard', 'status', 'current_version'];

--- a/modules/crm-customer-data-model/src/Models/RelationshipDefinition.php
+++ b/modules/crm-customer-data-model/src/Models/RelationshipDefinition.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\CustomerDataModel\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 final class RelationshipDefinition extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_customer_data_relationships';
 
     protected $fillable = ['team_id', 'from_object_id', 'to_object_id', 'key', 'label', 'cardinality', 'config'];

--- a/modules/crm-customer-data-platform/src/Models/CdpAudience.php
+++ b/modules/crm-customer-data-platform/src/Models/CdpAudience.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\CustomerDataPlatform\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -13,6 +14,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class CdpAudience extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_cdp_audiences';
 
     protected $guarded = [];

--- a/modules/crm-customer-data-platform/src/Models/CdpEvent.php
+++ b/modules/crm-customer-data-platform/src/Models/CdpEvent.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\CustomerDataPlatform\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $profile_id @property bool $consented */
 final class CdpEvent extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_cdp_events';
 
     protected $guarded = [];

--- a/modules/crm-customer-data-platform/src/Models/CdpIdentity.php
+++ b/modules/crm-customer-data-platform/src/Models/CdpIdentity.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\CustomerDataPlatform\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $profile_id */
 final class CdpIdentity extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_cdp_identities';
 
     protected $guarded = [];

--- a/modules/crm-customer-data-platform/src/Models/CdpProfile.php
+++ b/modules/crm-customer-data-platform/src/Models/CdpProfile.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\CustomerDataPlatform\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property string $profile_key @property array|null $consent */
 final class CdpProfile extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_cdp_profiles';
 
     protected $guarded = [];

--- a/modules/crm-customer-self-service/src/Models/SelfServiceCase.php
+++ b/modules/crm-customer-self-service/src/Models/SelfServiceCase.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\CustomerSelfService\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $profile_id @property string $status */
 final class SelfServiceCase extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_self_service_cases';
 
     protected $guarded = [];

--- a/modules/crm-customer-self-service/src/Models/SelfServiceProfile.php
+++ b/modules/crm-customer-self-service/src/Models/SelfServiceProfile.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\CustomerSelfService\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -13,6 +14,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class SelfServiceProfile extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_self_service_profiles';
 
     protected $guarded = [];

--- a/modules/crm-customer-self-service/src/Models/SelfServiceReference.php
+++ b/modules/crm-customer-self-service/src/Models/SelfServiceReference.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\CustomerSelfService\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $profile_id @property string $kind */
 final class SelfServiceReference extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_self_service_references';
 
     protected $guarded = [];

--- a/modules/crm-customer-self-service/src/Models/SelfServiceResource.php
+++ b/modules/crm-customer-self-service/src/Models/SelfServiceResource.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\CustomerSelfService\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property string $kind @property bool $published */
 final class SelfServiceResource extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_self_service_resources';
 
     protected $guarded = [];

--- a/modules/crm-customer-success/src/Models/SuccessCustomer.php
+++ b/modules/crm-customer-success/src/Models/SuccessCustomer.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\CustomerSuccess\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property string $customer_key @property string $lifecycle @property int $health_score */
 final class SuccessCustomer extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_success_customers';
 
     protected $guarded = [];

--- a/modules/crm-customer-success/src/Models/SuccessRenewal.php
+++ b/modules/crm-customer-success/src/Models/SuccessRenewal.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\CustomerSuccess\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $customer_id @property string $status */
 final class SuccessRenewal extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_success_renewals';
 
     protected $guarded = [];

--- a/modules/crm-customer-success/src/Models/SuccessRisk.php
+++ b/modules/crm-customer-success/src/Models/SuccessRisk.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\CustomerSuccess\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $customer_id @property string $status */
 final class SuccessRisk extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_success_risks';
 
     protected $guarded = [];

--- a/modules/crm-customer-success/src/Models/SuccessSignal.php
+++ b/modules/crm-customer-success/src/Models/SuccessSignal.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\CustomerSuccess\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $customer_id */
 final class SuccessSignal extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_success_signals';
 
     protected $guarded = [];

--- a/modules/crm-data-operations/src/Models/DataOperation.php
+++ b/modules/crm-data-operations/src/Models/DataOperation.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\DataOperations\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
@@ -14,6 +15,8 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  */
 final class DataOperation extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_data_operations';
 
     protected $fillable = ['team_id', 'actor_id', 'kind', 'status', 'source', 'target', 'options', 'total_rows', 'processed_rows', 'failed_rows', 'failure_reason', 'started_at', 'completed_at'];

--- a/modules/crm-data-operations/src/Models/DuplicateMatch.php
+++ b/modules/crm-data-operations/src/Models/DuplicateMatch.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\DataOperations\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 final class DuplicateMatch extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_data_operation_duplicates';
 
     protected $fillable = ['team_id', 'operation_id', 'left_record_id', 'right_record_id', 'confidence', 'status'];

--- a/modules/crm-data-operations/src/Models/OperationException.php
+++ b/modules/crm-data-operations/src/Models/OperationException.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\DataOperations\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property string $status */
 final class OperationException extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_data_operation_exceptions';
 
     protected $fillable = ['team_id', 'operation_id', 'row_number', 'payload', 'reason', 'status', 'resolved_by', 'resolved_at'];

--- a/modules/crm-data-operations/src/Models/OperationRule.php
+++ b/modules/crm-data-operations/src/Models/OperationRule.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\DataOperations\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 final class OperationRule extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_data_operation_rules';
 
     protected $fillable = ['team_id', 'name', 'kind', 'definition', 'active'];

--- a/modules/crm-data-operations/src/Models/OperationSchedule.php
+++ b/modules/crm-data-operations/src/Models/OperationSchedule.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\DataOperations\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 final class OperationSchedule extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_data_operation_schedules';
 
     protected $fillable = ['team_id', 'operation_id', 'cron', 'timezone', 'active', 'next_run_at'];

--- a/modules/crm-deal-registration/src/Models/DealRegistration.php
+++ b/modules/crm-deal-registration/src/Models/DealRegistration.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\DealRegistration\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -15,6 +16,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class DealRegistration extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_deal_registrations';
 
     protected $guarded = [];

--- a/modules/crm-deal-registration/src/Models/DealRegistrationEvent.php
+++ b/modules/crm-deal-registration/src/Models/DealRegistrationEvent.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\DealRegistration\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $deal_id @property string $event */
 final class DealRegistrationEvent extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_deal_registration_events';
 
     protected $guarded = [];

--- a/modules/crm-dialer-and-outreach/src/Models/DialerCall.php
+++ b/modules/crm-dialer-and-outreach/src/Models/DialerCall.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\DialerAndOutreach\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -14,6 +15,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class DialerCall extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_dialer_calls';
 
     protected $guarded = [];

--- a/modules/crm-dialer-and-outreach/src/Models/DialerEvent.php
+++ b/modules/crm-dialer-and-outreach/src/Models/DialerEvent.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\DialerAndOutreach\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $call_id @property string $event */
 final class DialerEvent extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_dialer_events';
 
     protected $guarded = [];

--- a/modules/crm-dialer-and-outreach/src/Models/DialerList.php
+++ b/modules/crm-dialer-and-outreach/src/Models/DialerList.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\DialerAndOutreach\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property string $mode @property string $status */
 final class DialerList extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_dialer_lists';
 
     protected $guarded = [];

--- a/modules/crm-documents/src/Models/CrmDocument.php
+++ b/modules/crm-documents/src/Models/CrmDocument.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Documents\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property string $status @property string $storage_key */
 final class CrmDocument extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_documents';
 
     protected $guarded = [];

--- a/modules/crm-documents/src/Models/DocumentEvent.php
+++ b/modules/crm-documents/src/Models/DocumentEvent.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Documents\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $document_id @property string $event */
 final class DocumentEvent extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_document_events';
 
     protected $guarded = [];

--- a/modules/crm-documents/src/Models/DocumentLink.php
+++ b/modules/crm-documents/src/Models/DocumentLink.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Documents\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $document_id @property string $status */
 final class DocumentLink extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_document_links';
 
     protected $guarded = [];

--- a/modules/crm-documents/src/Models/DocumentVersion.php
+++ b/modules/crm-documents/src/Models/DocumentVersion.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Documents\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $document_id @property int $version */
 final class DocumentVersion extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_document_versions';
 
     protected $guarded = [];

--- a/modules/crm-email-marketing/src/Models/EmailCampaign.php
+++ b/modules/crm-email-marketing/src/Models/EmailCampaign.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\EmailMarketing\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property string $status @property string $content_type */
 final class EmailCampaign extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_email_marketing_campaigns';
 
     protected $guarded = [];

--- a/modules/crm-email-marketing/src/Models/EmailDelivery.php
+++ b/modules/crm-email-marketing/src/Models/EmailDelivery.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\EmailMarketing\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $campaign_id @property string $status */
 final class EmailDelivery extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_email_marketing_deliveries';
 
     protected $guarded = [];

--- a/modules/crm-email-marketing/src/Models/EmailMarketingEvent.php
+++ b/modules/crm-email-marketing/src/Models/EmailMarketingEvent.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\EmailMarketing\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $campaign_id @property string $event */
 final class EmailMarketingEvent extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_email_marketing_events';
 
     protected $guarded = [];

--- a/modules/crm-email-productivity/src/Models/EmailEvent.php
+++ b/modules/crm-email-productivity/src/Models/EmailEvent.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\EmailProductivity\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $message_id @property string $event */
 final class EmailEvent extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_email_events';
 
     protected $guarded = [];

--- a/modules/crm-email-productivity/src/Models/EmailMailbox.php
+++ b/modules/crm-email-productivity/src/Models/EmailMailbox.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\EmailProductivity\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property string $provider @property string $status */
 final class EmailMailbox extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_email_mailboxes';
 
     protected $guarded = [];

--- a/modules/crm-email-productivity/src/Models/EmailMessage.php
+++ b/modules/crm-email-productivity/src/Models/EmailMessage.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\EmailProductivity\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -13,6 +14,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class EmailMessage extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_email_messages';
 
     protected $guarded = [];

--- a/modules/crm-email-productivity/src/Models/EmailTemplate.php
+++ b/modules/crm-email-productivity/src/Models/EmailTemplate.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\EmailProductivity\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property bool $shared */
 final class EmailTemplate extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_email_templates';
 
     protected $guarded = [];

--- a/modules/crm-enrichment/src/Models/EnrichmentChange.php
+++ b/modules/crm-enrichment/src/Models/EnrichmentChange.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Enrichment\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $profile_id @property string $status */
 final class EnrichmentChange extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_enrichment_changes';
 
     protected $guarded = [];

--- a/modules/crm-enrichment/src/Models/EnrichmentField.php
+++ b/modules/crm-enrichment/src/Models/EnrichmentField.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Enrichment\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $profile_id @property string $field */
 final class EnrichmentField extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_enrichment_fields';
 
     protected $guarded = [];

--- a/modules/crm-enrichment/src/Models/EnrichmentProfile.php
+++ b/modules/crm-enrichment/src/Models/EnrichmentProfile.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Enrichment\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -15,6 +16,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class EnrichmentProfile extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_enrichment_profiles';
 
     protected $guarded = [];

--- a/modules/crm-events-and-webinars/src/Models/CrmEvent.php
+++ b/modules/crm-events-and-webinars/src/Models/CrmEvent.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\EventsAndWebinars\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -13,6 +14,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class CrmEvent extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_events';
 
     protected $guarded = [];

--- a/modules/crm-events-and-webinars/src/Models/EventFollowUp.php
+++ b/modules/crm-events-and-webinars/src/Models/EventFollowUp.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\EventsAndWebinars\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $event_id */
 final class EventFollowUp extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_event_follow_ups';
 
     protected $guarded = [];

--- a/modules/crm-events-and-webinars/src/Models/EventRegistration.php
+++ b/modules/crm-events-and-webinars/src/Models/EventRegistration.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\EventsAndWebinars\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -14,6 +15,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class EventRegistration extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_event_registrations';
 
     protected $guarded = [];

--- a/modules/crm-events-and-webinars/src/Models/EventSession.php
+++ b/modules/crm-events-and-webinars/src/Models/EventSession.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\EventsAndWebinars\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $event_id */
 final class EventSession extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_event_sessions';
 
     protected $guarded = [];

--- a/modules/crm-feedback-and-voice-of-customer/src/Models/FeedbackAlert.php
+++ b/modules/crm-feedback-and-voice-of-customer/src/Models/FeedbackAlert.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\FeedbackAndVoiceOfCustomer\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $response_id @property string $status */
 final class FeedbackAlert extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_feedback_alerts';
 
     protected $guarded = [];

--- a/modules/crm-feedback-and-voice-of-customer/src/Models/FeedbackCase.php
+++ b/modules/crm-feedback-and-voice-of-customer/src/Models/FeedbackCase.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\FeedbackAndVoiceOfCustomer\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $response_id @property string $status */
 final class FeedbackCase extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_feedback_cases';
 
     protected $guarded = [];

--- a/modules/crm-feedback-and-voice-of-customer/src/Models/FeedbackDelivery.php
+++ b/modules/crm-feedback-and-voice-of-customer/src/Models/FeedbackDelivery.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\FeedbackAndVoiceOfCustomer\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -13,6 +14,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class FeedbackDelivery extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_feedback_deliveries';
 
     protected $guarded = [];

--- a/modules/crm-feedback-and-voice-of-customer/src/Models/FeedbackResponse.php
+++ b/modules/crm-feedback-and-voice-of-customer/src/Models/FeedbackResponse.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\FeedbackAndVoiceOfCustomer\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $survey_id @property int|null $score @property string|null $sentiment */
 final class FeedbackResponse extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_feedback_responses';
 
     protected $guarded = [];

--- a/modules/crm-feedback-and-voice-of-customer/src/Models/FeedbackSurvey.php
+++ b/modules/crm-feedback-and-voice-of-customer/src/Models/FeedbackSurvey.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\FeedbackAndVoiceOfCustomer\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -13,6 +14,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class FeedbackSurvey extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_feedback_surveys';
 
     protected $guarded = [];

--- a/modules/crm-field-service-coordination/src/Models/MaintenanceHandoff.php
+++ b/modules/crm-field-service-coordination/src/Models/MaintenanceHandoff.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\FieldServiceCoordination\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $appointment_id @property string $status */
 final class MaintenanceHandoff extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_field_service_handoffs';
 
     protected $guarded = [];

--- a/modules/crm-field-service-coordination/src/Models/ServiceAppointment.php
+++ b/modules/crm-field-service-coordination/src/Models/ServiceAppointment.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\FieldServiceCoordination\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $work_type_id @property int|null $technician_id @property string $status */
 final class ServiceAppointment extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_field_service_appointments';
 
     protected $guarded = [];

--- a/modules/crm-field-service-coordination/src/Models/ServiceAsset.php
+++ b/modules/crm-field-service-coordination/src/Models/ServiceAsset.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\FieldServiceCoordination\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id */
 final class ServiceAsset extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_field_service_assets';
 
     protected $guarded = [];

--- a/modules/crm-field-service-coordination/src/Models/ServiceHistory.php
+++ b/modules/crm-field-service-coordination/src/Models/ServiceHistory.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\FieldServiceCoordination\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $appointment_id */
 final class ServiceHistory extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_field_service_history';
 
     protected $guarded = [];

--- a/modules/crm-field-service-coordination/src/Models/WorkType.php
+++ b/modules/crm-field-service-coordination/src/Models/WorkType.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\FieldServiceCoordination\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property string $code @property bool $active */
 final class WorkType extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_field_service_work_types';
 
     protected $guarded = [];

--- a/modules/crm-forecasting/src/Models/Forecast.php
+++ b/modules/crm-forecasting/src/Models/Forecast.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Forecasting\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $category_id @property string $period @property float $pipeline @property float $best_case @property float $commit */
 final class Forecast extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_forecasts';
 
     protected $guarded = [];

--- a/modules/crm-forecasting/src/Models/ForecastAdjustment.php
+++ b/modules/crm-forecasting/src/Models/ForecastAdjustment.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Forecasting\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $forecast_id @property float $amount */
 final class ForecastAdjustment extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_forecast_adjustments';
 
     protected $guarded = [];

--- a/modules/crm-forecasting/src/Models/ForecastCategory.php
+++ b/modules/crm-forecasting/src/Models/ForecastCategory.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Forecasting\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property string $code */
 final class ForecastCategory extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_forecast_categories';
 
     protected $guarded = [];

--- a/modules/crm-forecasting/src/Models/ForecastSubmission.php
+++ b/modules/crm-forecasting/src/Models/ForecastSubmission.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Forecasting\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $forecast_id */
 final class ForecastSubmission extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_forecast_submissions';
 
     protected $guarded = [];

--- a/modules/crm-forms-and-surveys/src/Models/FormSubmission.php
+++ b/modules/crm-forms-and-surveys/src/Models/FormSubmission.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\FormsAndSurveys\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -11,6 +12,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class FormSubmission extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_forms_submissions';
 
     protected $guarded = [];

--- a/modules/crm-forms-and-surveys/src/Models/SurveyForm.php
+++ b/modules/crm-forms-and-surveys/src/Models/SurveyForm.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\FormsAndSurveys\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
@@ -14,6 +15,8 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  */
 final class SurveyForm extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_forms_surveys';
 
     protected $guarded = [];

--- a/modules/crm-goals-and-performance/src/Models/PerformanceGoal.php
+++ b/modules/crm-goals-and-performance/src/Models/PerformanceGoal.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\GoalsAndPerformance\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /** @property int $team_id @property int $owner_id @property float $target @property float $actual */
 final class PerformanceGoal extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_performance_goals';
 
     protected $guarded = [];

--- a/modules/crm-journey-orchestration/src/Models/Journey.php
+++ b/modules/crm-journey-orchestration/src/Models/Journey.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\JourneyOrchestration\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
@@ -14,6 +15,8 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  */
 final class Journey extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_journeys';
 
     protected $guarded = [];

--- a/modules/crm-journey-orchestration/src/Models/JourneyRun.php
+++ b/modules/crm-journey-orchestration/src/Models/JourneyRun.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\JourneyOrchestration\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -14,6 +15,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class JourneyRun extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_journey_runs';
 
     protected $guarded = [];

--- a/modules/crm-knowledge/src/Models/KnowledgeArticle.php
+++ b/modules/crm-knowledge/src/Models/KnowledgeArticle.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Knowledge\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /** @property int $team_id @property string $status @property string $visibility */
 final class KnowledgeArticle extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_knowledge_articles';
 
     protected $guarded = [];

--- a/modules/crm-landing-pages-and-funnels/src/Models/Funnel.php
+++ b/modules/crm-landing-pages-and-funnels/src/Models/Funnel.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\LandingPagesAndFunnels\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /** @property int $team_id @property string $status */
 final class Funnel extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_funnels';
 
     protected $guarded = [];

--- a/modules/crm-lead-capture/src/Models/CaptureForm.php
+++ b/modules/crm-lead-capture/src/Models/CaptureForm.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\LeadCapture\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -14,6 +15,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class CaptureForm extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_lead_capture_forms';
 
     protected $fillable = ['team_id', 'actor_id', 'kind', 'name', 'slug', 'status', 'schema', 'settings', 'submissions_count'];

--- a/modules/crm-lead-capture/src/Models/CaptureQrCode.php
+++ b/modules/crm-lead-capture/src/Models/CaptureQrCode.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\LeadCapture\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 final class CaptureQrCode extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_lead_capture_qr_codes';
 
     protected $fillable = ['team_id', 'actor_id', 'name', 'code', 'destination', 'status', 'metadata', 'scan_count'];

--- a/modules/crm-lead-capture/src/Models/CaptureReferral.php
+++ b/modules/crm-lead-capture/src/Models/CaptureReferral.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\LeadCapture\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 final class CaptureReferral extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_lead_capture_referrals';
 
     protected $fillable = ['team_id', 'actor_id', 'code', 'referrer_type', 'referrer_id', 'referred_type', 'referred_id', 'status', 'metadata'];

--- a/modules/crm-lead-capture/src/Models/CapturedLead.php
+++ b/modules/crm-lead-capture/src/Models/CapturedLead.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\LeadCapture\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /** @property int $team_id @property string $channel @property string $status */
 final class CapturedLead extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_lead_capture_leads';
 
     protected $guarded = [];

--- a/modules/crm-lead-capture/src/Models/LeadCapture.php
+++ b/modules/crm-lead-capture/src/Models/LeadCapture.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\LeadCapture\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id */
 final class LeadCapture extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_lead_captures';
 
     protected $fillable = ['team_id', 'actor_id', 'kind', 'status', 'name', 'email', 'phone', 'source', 'source_medium', 'source_campaign', 'external_id', 'dedupe_key', 'source_metadata', 'payload', 'provenance', 'captured_at', 'processed_at', 'failure_reason'];

--- a/modules/crm-lead-qualification/src/Models/LeadQualification.php
+++ b/modules/crm-lead-qualification/src/Models/LeadQualification.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\LeadQualification\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -17,6 +18,8 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  */
 final class LeadQualification extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_lead_qualifications';
 
     protected $fillable = ['team_id', 'actor_id', 'subject_type', 'subject_id', 'framework_id', 'lifecycle_stage', 'fit_score', 'engagement_score', 'total_score', 'qualification_status', 'disqualification_reason', 'nurture_until', 'converted_at', 'version', 'metadata'];

--- a/modules/crm-lead-qualification/src/Models/NurtureEnrollment.php
+++ b/modules/crm-lead-qualification/src/Models/NurtureEnrollment.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\LeadQualification\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 final class NurtureEnrollment extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_lead_qualification_nurtures';
 
     protected $fillable = ['team_id', 'qualification_id', 'actor_id', 'status', 'sequence', 'starts_at', 'ends_at', 'metadata'];

--- a/modules/crm-lead-qualification/src/Models/QualificationFramework.php
+++ b/modules/crm-lead-qualification/src/Models/QualificationFramework.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\LeadQualification\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -15,6 +16,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class QualificationFramework extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_lead_qualification_frameworks';
 
     protected $fillable = ['team_id', 'actor_id', 'name', 'status', 'mql_threshold', 'pql_threshold', 'sql_threshold', 'service_qualified_threshold', 'rules', 'settings'];

--- a/modules/crm-lead-qualification/src/Models/QualifiedLead.php
+++ b/modules/crm-lead-qualification/src/Models/QualifiedLead.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\LeadQualification\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /** @property int $team_id @property string $stage @property string $qualification @property int $fit_score @property int $engagement_score @property bool $nurture */
 final class QualifiedLead extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_lead_qualification_leads';
 
     protected $guarded = [];

--- a/modules/crm-lead-qualification/src/Models/StageHistory.php
+++ b/modules/crm-lead-qualification/src/Models/StageHistory.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\LeadQualification\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 final class StageHistory extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_lead_qualification_stage_history';
 
     protected $fillable = ['team_id', 'qualification_id', 'actor_id', 'from_stage', 'to_stage', 'reason'];

--- a/modules/crm-learning-and-courses/src/Models/LearningCourse.php
+++ b/modules/crm-learning-and-courses/src/Models/LearningCourse.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\LearningAndCourses\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property string $status */
 final class LearningCourse extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_learning_courses';
 
     protected $guarded = [];

--- a/modules/crm-learning-and-courses/src/Models/LearningEnrollment.php
+++ b/modules/crm-learning-and-courses/src/Models/LearningEnrollment.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\LearningAndCourses\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -14,6 +15,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class LearningEnrollment extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_learning_enrollments';
 
     protected $guarded = [];

--- a/modules/crm-loyalty/src/Models/LoyaltyMember.php
+++ b/modules/crm-loyalty/src/Models/LoyaltyMember.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Loyalty\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -14,6 +15,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class LoyaltyMember extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_loyalty_members';
 
     protected $guarded = [];

--- a/modules/crm-loyalty/src/Models/LoyaltyProgram.php
+++ b/modules/crm-loyalty/src/Models/LoyaltyProgram.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Loyalty\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property string $status */
 final class LoyaltyProgram extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_loyalty_programs';
 
     protected $guarded = [];

--- a/modules/crm-marketing-agent/src/Models/AgentRequest.php
+++ b/modules/crm-marketing-agent/src/Models/AgentRequest.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\MarketingAgent\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /** @property int $team_id @property string $kind @property string $status */
 final class AgentRequest extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_marketing_agent_requests';
 
     protected $guarded = [];

--- a/modules/crm-marketing-development-funds/src/Models/MdfFund.php
+++ b/modules/crm-marketing-development-funds/src/Models/MdfFund.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\MarketingDevelopmentFunds\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -14,6 +15,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class MdfFund extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_mdf_funds';
 
     protected $guarded = [];

--- a/modules/crm-marketing-development-funds/src/Models/MdfRequest.php
+++ b/modules/crm-marketing-development-funds/src/Models/MdfRequest.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\MarketingDevelopmentFunds\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property string $status @property float $amount @property float $reimbursed @property float $attributed_revenue */
 final class MdfRequest extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_mdf_requests';
 
     protected $guarded = [];

--- a/modules/crm-marketing-resources/src/Models/MarketingResource.php
+++ b/modules/crm-marketing-resources/src/Models/MarketingResource.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\MarketingResources\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /** @property int $team_id @property string $kind @property string $status */
 final class MarketingResource extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_marketing_resources';
 
     protected $guarded = [];

--- a/modules/crm-memberships/src/Models/MembershipGrant.php
+++ b/modules/crm-memberships/src/Models/MembershipGrant.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Memberships\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $member_id @property string $status */
 final class MembershipGrant extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_membership_grants';
 
     protected $guarded = [];

--- a/modules/crm-memberships/src/Models/MembershipPlan.php
+++ b/modules/crm-memberships/src/Models/MembershipPlan.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Memberships\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property string $status @property float $price */
 final class MembershipPlan extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_membership_plans';
 
     protected $guarded = [];

--- a/modules/crm-mobile-messaging/src/Models/MessagingCampaign.php
+++ b/modules/crm-mobile-messaging/src/Models/MessagingCampaign.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\MobileMessaging\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /** @property int $team_id @property string $channel @property string $status */
 final class MessagingCampaign extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_mobile_messaging_campaigns';
 
     protected $guarded = [];

--- a/modules/crm-mobile-messaging/src/Models/MessagingContact.php
+++ b/modules/crm-mobile-messaging/src/Models/MessagingContact.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\MobileMessaging\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property string $address @property string $channel @property string $consent */
 final class MessagingContact extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_mobile_messaging_contacts';
 
     protected $guarded = [];

--- a/modules/crm-mobile-messaging/src/Models/MessagingMessage.php
+++ b/modules/crm-mobile-messaging/src/Models/MessagingMessage.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\MobileMessaging\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property string $direction @property string $status @property int $team_id */
 final class MessagingMessage extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_mobile_messaging_messages';
 
     protected $guarded = [];

--- a/modules/crm-omnichannel-service/src/Models/Conversation.php
+++ b/modules/crm-omnichannel-service/src/Models/Conversation.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\OmnichannelService\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /** @property int $team_id @property string $channel @property string $status @property string $priority @property int|null $assigned_to */
 final class Conversation extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_omnichannel_conversations';
 
     protected $guarded = [];

--- a/modules/crm-omnichannel-service/src/Models/Interaction.php
+++ b/modules/crm-omnichannel-service/src/Models/Interaction.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\OmnichannelService\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property string $direction @property string $body @property int $team_id */
 final class Interaction extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_omnichannel_interactions';
 
     protected $guarded = [];

--- a/modules/crm-orders-and-payments-workspace/src/Models/PaymentTransaction.php
+++ b/modules/crm-orders-and-payments-workspace/src/Models/PaymentTransaction.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\OrdersAndPaymentsWorkspace\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /** @property int $team_id @property string $kind @property string $status @property float $amount @property float $paid_amount @property float $refunded_amount */
 final class PaymentTransaction extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_orders_payments';
 
     protected $guarded = [];

--- a/modules/crm-personalization/src/Models/PersonalizationRule.php
+++ b/modules/crm-personalization/src/Models/PersonalizationRule.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Personalization\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -13,6 +14,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class PersonalizationRule extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_personalization_rules';
 
     protected $guarded = [];

--- a/modules/crm-playbooks-and-enablement/src/Models/Playbook.php
+++ b/modules/crm-playbooks-and-enablement/src/Models/Playbook.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\PlaybooksAndEnablement\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -11,6 +12,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class Playbook extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_playbooks';
 
     protected $guarded = [];

--- a/modules/crm-predictive-models/src/Models/Prediction.php
+++ b/modules/crm-predictive-models/src/Models/Prediction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\PredictiveModels\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -11,6 +12,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class Prediction extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_predictive_predictions';
 
     protected $guarded = [];

--- a/modules/crm-product-workspace/src/Models/ProductBundle.php
+++ b/modules/crm-product-workspace/src/Models/ProductBundle.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\ProductWorkspace\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property array $product_ids */
 final class ProductBundle extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_product_workspace_bundles';
 
     protected $guarded = [];

--- a/modules/crm-product-workspace/src/Models/ProductEntitlement.php
+++ b/modules/crm-product-workspace/src/Models/ProductEntitlement.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\ProductWorkspace\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $customer_id @property string $status */
 final class ProductEntitlement extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_product_workspace_entitlements';
 
     protected $guarded = [];

--- a/modules/crm-product-workspace/src/Models/ProductSync.php
+++ b/modules/crm-product-workspace/src/Models/ProductSync.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\ProductWorkspace\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property string $status */
 final class ProductSync extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_product_workspace_syncs';
 
     protected $guarded = [];

--- a/modules/crm-product-workspace/src/Models/WorkspaceProduct.php
+++ b/modules/crm-product-workspace/src/Models/WorkspaceProduct.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\ProductWorkspace\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property string $sku @property bool $eligible */
 final class WorkspaceProduct extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_product_workspace_products';
 
     protected $guarded = [];

--- a/modules/crm-projects/src/Models/Project.php
+++ b/modules/crm-projects/src/Models/Project.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Projects\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -11,6 +12,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class Project extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_projects';
 
     protected $guarded = [];

--- a/modules/crm-proposals-and-quotes/src/Models/Proposal.php
+++ b/modules/crm-proposals-and-quotes/src/Models/Proposal.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\ProposalsAndQuotes\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -11,6 +12,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class Proposal extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_proposals';
 
     protected $guarded = [];

--- a/modules/crm-prospecting-agent/src/Models/AgentRun.php
+++ b/modules/crm-prospecting-agent/src/Models/AgentRun.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\ProspectingAgent\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -11,6 +12,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class AgentRun extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_prospecting_agent_runs';
 
     protected $guarded = [];

--- a/modules/crm-prospecting/src/Models/Prospect.php
+++ b/modules/crm-prospecting/src/Models/Prospect.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Prospecting\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -11,6 +12,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class Prospect extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_prospects';
 
     protected $guarded = [];

--- a/modules/crm-prospecting/src/Models/ProspectCredit.php
+++ b/modules/crm-prospecting/src/Models/ProspectCredit.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Prospecting\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id */
 final class ProspectCredit extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_prospect_credits';
 
     protected $guarded = [];

--- a/modules/crm-quotas-and-incentives/src/Models/CommissionCredit.php
+++ b/modules/crm-quotas-and-incentives/src/Models/CommissionCredit.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\QuotasAndIncentives\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id */
 final class CommissionCredit extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_commission_credits';
 
     protected $guarded = [];

--- a/modules/crm-quotas-and-incentives/src/Models/Quota.php
+++ b/modules/crm-quotas-and-incentives/src/Models/Quota.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\QuotasAndIncentives\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -11,6 +12,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class Quota extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_quotas';
 
     protected $guarded = [];

--- a/modules/crm-referrals/src/Models/Referral.php
+++ b/modules/crm-referrals/src/Models/Referral.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Referrals\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
 
@@ -14,6 +15,8 @@ use Illuminate\Support\Carbon;
  */
 final class Referral extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_referrals';
 
     protected $guarded = [];

--- a/modules/crm-referrals/src/Models/ReferralReward.php
+++ b/modules/crm-referrals/src/Models/ReferralReward.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Referrals\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id */
 final class ReferralReward extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_referral_rewards';
 
     protected $guarded = [];

--- a/modules/crm-reputation-management/src/Models/ReputationReview.php
+++ b/modules/crm-reputation-management/src/Models/ReputationReview.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\ReputationManagement\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -11,6 +12,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class ReputationReview extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_reputation_reviews';
 
     protected $guarded = [];

--- a/modules/crm-resource-planning/src/Models/ResourceBooking.php
+++ b/modules/crm-resource-planning/src/Models/ResourceBooking.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\ResourcePlanning\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
 
@@ -14,6 +15,8 @@ use Illuminate\Support\Carbon;
  */
 final class ResourceBooking extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_resource_bookings';
 
     protected $guarded = [];

--- a/modules/crm-revenue-intelligence/src/Models/RevenueInsight.php
+++ b/modules/crm-revenue-intelligence/src/Models/RevenueInsight.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\RevenueIntelligence\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -11,6 +12,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class RevenueInsight extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_revenue_insights';
 
     protected $guarded = [];

--- a/modules/crm-revenue-lifecycle/src/Models/RevenueAsset.php
+++ b/modules/crm-revenue-lifecycle/src/Models/RevenueAsset.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\RevenueLifecycle\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model; /** @property string $status @property string|null $lifecycle_action @property \Illuminate\Support\Carbon|null $renewal_date */
 
 /**
@@ -11,6 +12,8 @@ use Illuminate\Database\Eloquent\Model; /** @property string $status @property s
  */
 final class RevenueAsset extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_revenue_assets';
 
     protected $guarded = [];

--- a/modules/crm-routing/src/Models/RoutingAssignment.php
+++ b/modules/crm-routing/src/Models/RoutingAssignment.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\Routing\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Carbon;
@@ -15,6 +16,8 @@ use Illuminate\Support\Carbon;
  */
 final class RoutingAssignment extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_routing_assignments';
 
     protected $guarded = [];

--- a/modules/crm-saas-packaging/src/Models/SaasSubscription.php
+++ b/modules/crm-saas-packaging/src/Models/SaasSubscription.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\SaasPackaging\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Carbon;
@@ -16,6 +17,8 @@ use Illuminate\Support\Carbon;
  */
 final class SaasSubscription extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_saas_subscriptions';
 
     protected $guarded = [];

--- a/modules/crm-sales-engagement/src/Models/EngagementSequence.php
+++ b/modules/crm-sales-engagement/src/Models/EngagementSequence.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\SalesEngagement\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -11,6 +12,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class EngagementSequence extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_engagement_sequences';
 
     protected $guarded = [];

--- a/modules/crm-search/src/Models/SearchDocument.php
+++ b/modules/crm-search/src/Models/SearchDocument.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\CrmSearch\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property string $record_type @property string $record_key */
 final class SearchDocument extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_search_documents';
 
     protected $guarded = [];

--- a/modules/crm-search/src/Models/SearchRecent.php
+++ b/modules/crm-search/src/Models/SearchRecent.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\CrmSearch\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $user_id */
 final class SearchRecent extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_search_recents';
 
     protected $guarded = [];

--- a/modules/crm-search/src/Models/SearchView.php
+++ b/modules/crm-search/src/Models/SearchView.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\CrmSearch\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $user_id @property bool $shared */
 final class SearchView extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_search_views';
 
     protected $guarded = [];

--- a/modules/crm-templates-and-snapshots/src/Models/SnapshotAudit.php
+++ b/modules/crm-templates-and-snapshots/src/Models/SnapshotAudit.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\TemplatesAndSnapshots\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 final class SnapshotAudit extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_snapshot_audits';
 
     protected $fillable = ['team_id', 'actor_id', 'event', 'details'];

--- a/modules/crm-templates-and-snapshots/src/Models/SnapshotBundle.php
+++ b/modules/crm-templates-and-snapshots/src/Models/SnapshotBundle.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\TemplatesAndSnapshots\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 final class SnapshotBundle extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_snapshot_bundles';
 
     protected $fillable = ['team_id', 'name', 'version', 'status', 'payload', 'checksum', 'share_token_hash', 'shared_at', 'created_by'];

--- a/modules/crm-templates-and-snapshots/src/Models/SnapshotInstall.php
+++ b/modules/crm-templates-and-snapshots/src/Models/SnapshotInstall.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\TemplatesAndSnapshots\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 final class SnapshotInstall extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_snapshot_installs';
 
     protected $fillable = ['team_id', 'bundle_id', 'version', 'status', 'installed_by'];

--- a/modules/crm-territories-and-ownership/src/Models/OwnershipHistory.php
+++ b/modules/crm-territories-and-ownership/src/Models/OwnershipHistory.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\TerritoriesAndOwnership\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 final class OwnershipHistory extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_ownership_history';
 
     protected $fillable = ['team_id', 'subject_type', 'subject_id', 'previous_owner_id', 'owner_id', 'reason', 'actor_id'];

--- a/modules/crm-territories-and-ownership/src/Models/TerritoryCoverage.php
+++ b/modules/crm-territories-and-ownership/src/Models/TerritoryCoverage.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\TerritoriesAndOwnership\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 final class TerritoryCoverage extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_territory_coverage';
 
     protected $fillable = ['team_id', 'rule_id', 'covered_user_id', 'substitute_user_id', 'starts_at', 'ends_at'];

--- a/modules/crm-territories-and-ownership/src/Models/TerritoryRule.php
+++ b/modules/crm-territories-and-ownership/src/Models/TerritoryRule.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\TerritoriesAndOwnership\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 final class TerritoryRule extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_territory_rules';
 
     protected $fillable = ['team_id', 'name', 'book_of_business', 'criteria', 'members', 'capacity', 'round_robin_cursor', 'active'];

--- a/modules/crm-unified-conversations/src/Models/Conversation.php
+++ b/modules/crm-unified-conversations/src/Models/Conversation.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\UnifiedConversations\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 final class Conversation extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_conversations';
 
     protected $fillable = ['team_id', 'channel', 'external_id', 'subject', 'status', 'priority', 'assigned_to', 'last_message_at', 'metadata'];

--- a/modules/crm-unified-conversations/src/Models/ConversationAudit.php
+++ b/modules/crm-unified-conversations/src/Models/ConversationAudit.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\UnifiedConversations\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 final class ConversationAudit extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_conversation_audits';
 
     protected $fillable = ['team_id', 'actor_id', 'event', 'details'];

--- a/modules/crm-unified-conversations/src/Models/ConversationMessage.php
+++ b/modules/crm-unified-conversations/src/Models/ConversationMessage.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\UnifiedConversations\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 final class ConversationMessage extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_conversation_messages';
 
     protected $fillable = ['team_id', 'conversation_id', 'external_id', 'sender_id', 'body', 'direction', 'metadata', 'internal', 'delivery_status', 'read_at', 'idempotency_key'];

--- a/modules/crm-unified-conversations/src/Models/ConversationParticipant.php
+++ b/modules/crm-unified-conversations/src/Models/ConversationParticipant.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\UnifiedConversations\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 final class ConversationParticipant extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_conversation_participants';
 
     protected $fillable = ['team_id', 'conversation_id', 'identity', 'name', 'role'];

--- a/modules/crm-usage-wallet-and-rebilling/src/Models/UsageAudit.php
+++ b/modules/crm-usage-wallet-and-rebilling/src/Models/UsageAudit.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\UsageWalletAndRebilling\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 final class UsageAudit extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_usage_audits';
 
     protected $fillable = ['team_id', 'actor_id', 'event', 'details', 'request_id'];

--- a/modules/crm-usage-wallet-and-rebilling/src/Models/UsageCharge.php
+++ b/modules/crm-usage-wallet-and-rebilling/src/Models/UsageCharge.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\UsageWalletAndRebilling\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 final class UsageCharge extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_usage_charges';
 
     protected $fillable = ['team_id', 'usage_import_id', 'wallet_id', 'client_reference', 'cost', 'charge', 'currency', 'status'];

--- a/modules/crm-usage-wallet-and-rebilling/src/Models/UsageImport.php
+++ b/modules/crm-usage-wallet-and-rebilling/src/Models/UsageImport.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\UsageWalletAndRebilling\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 final class UsageImport extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_usage_imports';
 
     protected $fillable = ['team_id', 'provider', 'external_id', 'amount', 'currency', 'status', 'failure_reason', 'payload'];

--- a/modules/crm-usage-wallet-and-rebilling/src/Models/UsageWallet.php
+++ b/modules/crm-usage-wallet-and-rebilling/src/Models/UsageWallet.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\UsageWalletAndRebilling\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property string $currency @property string $balance @property string $threshold @property string $reload_amount @property string $status @property int $version */
 final class UsageWallet extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_usage_wallets';
 
     protected $fillable = ['team_id', 'currency', 'balance', 'threshold', 'reload_amount', 'status', 'version'];

--- a/modules/crm-web-intent/src/Models/WebIntentAlert.php
+++ b/modules/crm-web-intent/src/Models/WebIntentAlert.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\WebIntent\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id */
 final class WebIntentAlert extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_web_intent_alerts';
 
     protected $fillable = ['team_id', 'visitor_key', 'visit_id', 'severity', 'title', 'details', 'status', 'triggered_at', 'resolved_at', 'resolved_by'];

--- a/modules/crm-web-intent/src/Models/WebIntentConsent.php
+++ b/modules/crm-web-intent/src/Models/WebIntentConsent.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\WebIntent\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 final class WebIntentConsent extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_web_intent_consents';
 
     protected $fillable = ['team_id', 'visitor_key', 'purpose', 'status', 'policy_version', 'granted_at', 'revoked_at'];

--- a/modules/crm-web-intent/src/Models/WebIntentConversion.php
+++ b/modules/crm-web-intent/src/Models/WebIntentConversion.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\WebIntent\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 final class WebIntentConversion extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_web_intent_conversions';
 
     protected $fillable = ['team_id', 'visitor_key', 'visit_id', 'target_type', 'target_id', 'actor_id', 'status', 'metadata'];

--- a/modules/crm-web-intent/src/Models/WebIntentEngagement.php
+++ b/modules/crm-web-intent/src/Models/WebIntentEngagement.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\WebIntent\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 final class WebIntentEngagement extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_web_intent_engagements';
 
     protected $fillable = ['team_id', 'visit_id', 'visitor_key', 'event_type', 'page_url', 'content_type', 'content_id', 'points', 'duration_seconds', 'dedupe_key', 'metadata', 'occurred_at'];

--- a/modules/crm-web-intent/src/Models/WebIntentIdentification.php
+++ b/modules/crm-web-intent/src/Models/WebIntentIdentification.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\WebIntent\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 final class WebIntentIdentification extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_web_intent_identifications';
 
     protected $fillable = ['team_id', 'visitor_key', 'adapter', 'account_name', 'account_domain', 'confidence', 'status', 'metadata'];

--- a/modules/crm-web-intent/src/Models/WebIntentSignal.php
+++ b/modules/crm-web-intent/src/Models/WebIntentSignal.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\WebIntent\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 final class WebIntentSignal extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_web_intent_signals';
 
     protected $fillable = ['team_id', 'visit_id', 'visitor_key', 'signal', 'points', 'metadata', 'occurred_at'];

--- a/modules/crm-web-intent/src/Models/WebIntentVisit.php
+++ b/modules/crm-web-intent/src/Models/WebIntentVisit.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\WebIntent\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
@@ -16,6 +17,8 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  */
 final class WebIntentVisit extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_web_intent_visits';
 
     protected $fillable = ['team_id', 'visitor_key', 'session_key', 'ip_hash', 'user_agent_hash', 'landing_url', 'referrer', 'consent_status', 'score', 'intent_level', 'status', 'started_at', 'ended_at', 'metadata'];

--- a/modules/crm-white-label/src/Models/WhiteLabelAudit.php
+++ b/modules/crm-white-label/src/Models/WhiteLabelAudit.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\WhiteLabel\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 final class WhiteLabelAudit extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_white_label_audits';
 
     protected $fillable = ['team_id', 'actor_id', 'event', 'changes', 'request_id'];

--- a/modules/crm-white-label/src/Models/WhiteLabelSettings.php
+++ b/modules/crm-white-label/src/Models/WhiteLabelSettings.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\WhiteLabel\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -20,6 +21,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class WhiteLabelSettings extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_white_label_settings';
 
     protected $fillable = ['team_id', 'brand_name', 'custom_domain', 'theme', 'email_settings', 'application_settings', 'client_experience', 'provider', 'show_platform_attribution', 'version'];

--- a/modules/crm-work-management/src/Models/Approval.php
+++ b/modules/crm-work-management/src/Models/Approval.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\WorkManagement\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -13,6 +14,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 final class Approval extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_work_approvals';
 
     protected $fillable = ['work_item_id', 'team_id', 'requested_by', 'reviewed_by', 'status', 'comment', 'reviewed_at'];

--- a/modules/crm-work-management/src/Models/ChecklistItem.php
+++ b/modules/crm-work-management/src/Models/ChecklistItem.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\WorkManagement\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property bool $completed */
 final class ChecklistItem extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_work_checklist_items';
 
     protected $fillable = ['work_item_id', 'team_id', 'actor_id', 'title', 'completed', 'position'];

--- a/modules/crm-work-management/src/Models/Dependency.php
+++ b/modules/crm-work-management/src/Models/Dependency.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\WorkManagement\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 
 /** @property int $team_id @property int $work_item_id @property int $depends_on_id */
 final class Dependency extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_work_dependencies';
 
     protected $fillable = ['work_item_id', 'depends_on_id', 'team_id'];

--- a/modules/crm-work-management/src/Models/WorkItem.php
+++ b/modules/crm-work-management/src/Models/WorkItem.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\WorkManagement\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Carbon;
@@ -18,6 +19,8 @@ use Illuminate\Support\Carbon;
  */
 final class WorkItem extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_work_items';
 
     protected $fillable = ['team_id', 'actor_id', 'assigned_to', 'queue_id', 'title', 'description', 'status', 'priority', 'subject_type', 'subject_id', 'due_at', 'recurrence', 'next_run_at', 'version', 'metadata'];

--- a/modules/crm-work-management/src/Models/WorkQueue.php
+++ b/modules/crm-work-management/src/Models/WorkQueue.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liberu\CRM\WorkManagement\Models;
 
+use App\Traits\IsTenantModel;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
@@ -13,6 +14,8 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  */
 final class WorkQueue extends Model
 {
+    use IsTenantModel;
+
     protected $table = 'crm_work_queues';
 
     protected $fillable = ['team_id', 'actor_id', 'name', 'description', 'status', 'rules'];


### PR DESCRIPTION
## Changes\n- Add tenant team relationships and scoping to all 206 modern CRM models carrying team_id.\n- Categorize app-panel resources into Sales, Marketing, Communication, Support, Operations, Data & intelligence, and CRM groups.\n- Keep navigation groups collapsed by default.\n- Fix stricter Larastan findings in AppPanelProvider.\n\n## Verification\n- php artisan module:validate\n- 16 targeted Filament/module tests\n- Pint\n- PHPStan/Larastan level 5